### PR TITLE
Documentation: Add sites-config

### DIFF
--- a/sites-config/ci.json
+++ b/sites-config/ci.json
@@ -1,0 +1,32 @@
+{
+  "artifactStructure": {
+    "assets": [
+      {
+        "root": "packages/yext-sites-scripts/docs/.vitepress/dist",
+        "pattern": "**/*.html"
+      },
+      {
+        "root": "packages/yext-sites-scripts/docs/.vitepress/dist",
+        "pattern": "**/*.js"
+      },
+      {
+        "root": "packages/yext-sites-scripts/docs/.vitepress/dist",
+        "pattern": "**/*.css"
+      }
+    ]
+  },
+  "dependencies": {
+    "installDepsCmd": "(cd packages/yext-sites-scripts && npm install)",
+    "requiredFiles": [
+      "packages/yext-sites-scripts/package.json",
+      "packages/yext-sites-scripts/package-lock.json"
+    ]
+  },
+  "buildArtifacts": {
+    "buildCmd": "(cd packages/yext-sites-scripts && npm run docs:build)"
+  },
+  "livePreview": {
+    "serveSetupCmd": "(cd packages/yext-sites-scripts && npm run docs:build)",
+    "serveCmd": "(cd packages/yext-sites-scripts && npm run docs:serve)"
+  }
+}


### PR DESCRIPTION
This ci.json file should enable serving our documentation site
via Yext Sites. After shipping I'll setup the site and give
it a whirl.

J=SUMO-4391
TEST=none

Made ci.json file in accordance to this documentation [1], will
test once merged and I can setup a site with it.

1: https://www.yext.com/docmd/docs/gocode/src/yext/publish/configuration/config.html#sites-config-ci-json