### PR TITLE
discard query params before parsing url

### DIFF
--- a/packages/yext-sites-scripts/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/yext-sites-scripts/src/dev/server/middleware/serverRenderRoute.ts
@@ -18,7 +18,7 @@ export const serverRenderRoute =
   ({ vite, dynamicGenerateData }: Props): RequestHandler =>
   async (req, res, next) => {
     try {
-      const url = req.originalUrl;
+      const url = req.baseUrl;
 
       const { feature, entityId } = urlToFeature(url);
 


### PR DESCRIPTION
Currently a url like index/loc6?param=value will error because it uses the full url to try and match against the feature/entityId.
