### PR TITLE
breaking change -- update props object passed into devmode

### DIFF
--- a/packages/yext-sites-scripts/src/dev/server/ssr/pageLoader.ts
+++ b/packages/yext-sites-scripts/src/dev/server/ssr/pageLoader.ts
@@ -65,12 +65,10 @@ export const pageLoader = async ({
     }
   }
 
-  let data = { document: { streamOutput: streamOutput } };
+  let props = { document: { streamOutput }, __meta: { mode: "development" } };
   if (getStaticProps) {
-    data = await getStaticProps(data);
+    props = await getStaticProps(props);
   }
-
-  const props = { data: data, __meta: { mode: "development" } };
 
   return { template, Component, props };
 };


### PR DESCRIPTION
Note this is a breaking change and all templates past this version will need to change.

This update makes the props object in prod/dev mode the same. Before this change, devmode was wrapping the document in an additional "data" field that always only contained a document field.

Before:
```
{
  data: { document: {}},
  __meta: {},
} 
```

After:
```
{
  document: {},
  __meta: {},
} 
```