### PR TITLE
Fix plugin: use relative path

### DIFF
--- a/packages/vite-plugin-yext-sites-ssg/package.json
+++ b/packages/vite-plugin-yext-sites-ssg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yext/vite-plugin-yext-sites-ssg",
   "author": "Yext",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "description": "A vite plugin which provides automatic bundling of JS templates and an accompanying deno function used for static site generation in Yext Sites.",
   "main": "dist/esm/src/plugin.js",

--- a/packages/vite-plugin-yext-sites-ssg/src/paths.ts
+++ b/packages/vite-plugin-yext-sites-ssg/src/paths.ts
@@ -13,7 +13,7 @@ const templatePath = "./src/templates";
 const distPath = "./dist";
 const hydrationOut = `${resolvePath(distPath)}/hydration_templates`;
 let featureJson = "./sites-config/features.json";
-const serverBundleOut = `${resolvePath(distPath)}/assets/server`;
+const serverBundleOut = `${distPath}/assets/server`;
 
 /**
  * Creates a filepath relative to the generated manifest.json, which lives under .yext


### PR DESCRIPTION
This needs to be a relative path

TEST=manual

Locally yext sites built and served and the generated
pages with the starter worked. Need to cut a release
to test in prod.