### PR TITLE
Allow streamOutput for static pages

### DIFF
--- a/packages/yext-sites-scripts/src/dev/server/ssr/pageLoader.ts
+++ b/packages/yext-sites-scripts/src/dev/server/ssr/pageLoader.ts
@@ -65,7 +65,6 @@ export const pageLoader = async ({
   const { default: Component, getStaticProps } = module as SsrLoadedModule;
 
   let streamOutput;
-  // Don't try to pull stream data if one isn't defined. This is primarily for static pages.
   if (dynamicGenerateData) {
     streamOutput = await generateTestData(
       process.stdout,


### PR DESCRIPTION
Spruce sets streamOutput even for static features. This will allow users to access site-stream data in their static templates.

J=SUMO-4614
TEST=auto,manual

Verified the data comes through now.