### PR TITLE
Update init

### DIFF
--- a/packages/yext-sites-scripts/src/init/generate/generate.ts
+++ b/packages/yext-sites-scripts/src/init/generate/generate.ts
@@ -22,7 +22,9 @@ export async function generate(info: GenerationInfo) {
   // Remove files the user shouldn't need
   info.startStep("Cleaning up");
   const cmdExitCode = await info.runCommand(
-    `rm -rf ${filesToFilter.join(" ")} && sed '/"license": "BSD-3-Clause",/d' package.json`
+    `rm -rf ${filesToFilter.join(
+      " "
+    )} && sed '/"license": "BSD-3-Clause",/d' package.json`
   );
   if (cmdExitCode) {
     throw new Error("error cleaning up files " + cmdExitCode);

--- a/packages/yext-sites-scripts/src/init/generate/interface.tsx
+++ b/packages/yext-sites-scripts/src/init/generate/interface.tsx
@@ -159,16 +159,22 @@ const Generator: FC = () => {
       {done && (
         <Text color="white">
           {"\n"}
-          <Text color="greenBright">Done!</Text> Try the following commands to start:{"\n"}
-          
-          <Text bold>yext init</Text>{"\t"}
-          <Text color="white"># Initialize with your yext account</Text>{"\n"}
-          
-          <Text bold>yext sites generate-test-data</Text>{"\t"}
-          <Text color="white"># Pull down local data from the Knowledge Graph</Text>{"\n"}
-
-          <Text bold>npm run dev</Text>{"\t"}
-          <Text color="white"># Start a development server</Text>{"\n"}
+          <Text color="greenBright">Done!</Text> Try the following commands to
+          start:{"\n"}
+          <Text bold>yext init</Text>
+          {"\t"}
+          <Text color="white"># Initialize with your yext account</Text>
+          {"\n"}
+          <Text bold>yext sites generate-test-data</Text>
+          {"\t"}
+          <Text color="white">
+            # Pull down local data from the Knowledge Graph
+          </Text>
+          {"\n"}
+          <Text bold>npm run dev</Text>
+          {"\t"}
+          <Text color="white"># Start a development server</Text>
+          {"\n"}
         </Text>
       )}
     </>


### PR DESCRIPTION
This updates the init command to point to the newer yext starter repo. A future update will be necessary once it's publicly released.

I couldn't figure out how to get it working correctly with the spinner as it always removed the stdout text which happens when you don't have access to the repo, so I changed it to just a static unicode icon.

The reason for updating this in general is that once we add the license actions to the starter, the way to clone it will be via this command since it removes files that users won't need.

J=none
TEST=manual

