### PR TITLE
YSS: Start dev server in dynamic mode by default

### DIFF
--- a/packages/yext-sites-scripts/src/dev/server/ssr/generateTestData.ts
+++ b/packages/yext-sites-scripts/src/dev/server/ssr/generateTestData.ts
@@ -38,7 +38,7 @@ export const generateTestDataForEntity = async (
     "generate-test-data",
     "--featureName",
     `'${featuresConfig.features[0]?.name}'`,
-    "--entityIds",
+    "--entityId",
     entityId,
     "--featuresConfig",
     `'${JSON.stringify(featuresConfig)}'`,


### PR DESCRIPTION
This is currently broken with static pages, but Duval has a fix
coming in his PR so I'll just wait to merge until that's merged.

Also had to update the generateTestData command to work with the
new CLI.

J=SUMO-4620
TEST=manual

Started dev mode, made sure it was in dynamic. Also, made sure
the -- local flag worked as expected.