### PR TITLE
Fix ts compiler error

### DIFF
--- a/packages/common/src/project/structure.ts
+++ b/packages/common/src/project/structure.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as pathLib from "path";
 import * as _ from "lodash";
 
 /**
@@ -144,10 +144,10 @@ export class Path {
   }
 
   getRelativePath = (to: string): string => {
-    return `./${path.relative(this.path, to)}`;
+    return `./${pathLib.relative(this.path, to)}`;
   };
 
   getAbsolutePath = (): string => {
-    return path.resolve(this.path);
+    return pathLib.resolve(this.path);
   };
 }


### PR DESCRIPTION
When trying to use ProjectStructure in a test, npm run test was
producing a ts error that was due to us overloading the name
"path" in the getRelativePath and getAbsolutePath functions.

TEST=auto

declared a ProjectStructure in generateTestData.test.ts and
made sure that this let the tests run without throwing the
ts error.