### PR TITLE
Fix bundler

### DIFF
--- a/packages/sites-scripts/src/bundler.js
+++ b/packages/sites-scripts/src/bundler.js
@@ -43,6 +43,7 @@ const commonBuildOpts = {
   loader: {
     ".ts": "ts",
     ".html": "text",
+    ".md": "text",
   },
   tsconfig: "tsconfig.json",
   logLevel: "error",


### PR DESCRIPTION
A recent change updated which files the bundler encountered but the bundler was never updated so it couldn't build `sites-scripts` anymore. This fixes it.