### PR TITLE
Revert "fix bundler (#103)"

### DIFF
--- a/packages/sites-scripts/src/bundler.js
+++ b/packages/sites-scripts/src/bundler.js
@@ -43,7 +43,6 @@ const commonBuildOpts = {
   loader: {
     ".ts": "ts",
     ".html": "text",
-    ".md": "text",
   },
   tsconfig: "tsconfig.json",
   logLevel: "error",


### PR DESCRIPTION
This reverts commit 62128591308037448664687f7df6d1db4b190805. It was an erroneous error added due to a stray node_modules folder on my local branch 👎 .