### PR TITLE
feat: add alternateLanguageFields to the template config

### DIFF
--- a/packages/pages/src/common/src/feature/features.ts
+++ b/packages/pages/src/common/src/feature/features.ts
@@ -30,6 +30,7 @@ interface FeatureConfigBase {
   name: string;
   streamId?: string;
   templateType: "JS";
+  alternateLanguageFields?: string[];
 }
 
 interface EntityPageSetConfig extends FeatureConfigBase {
@@ -64,6 +65,7 @@ export const convertTemplateConfigToFeatureConfig = (
       ? config.streamId
       : undefined,
     templateType: "JS",
+    alternateLanguageFields: config.alternateLanguageFields,
   };
 
   let featureConfig: FeatureConfig;

--- a/packages/pages/src/common/src/template/internal/types.ts
+++ b/packages/pages/src/common/src/template/internal/types.ts
@@ -56,6 +56,8 @@ export interface TemplateConfigInternal {
   streamId?: string;
   /** The stream configuration used by the template */
   stream?: Stream;
+  /** The specific fields to add additional language options to based on the stream's localization */
+  alternateLanguageFields?: string[];
 }
 
 /**

--- a/packages/pages/src/common/src/template/types.ts
+++ b/packages/pages/src/common/src/template/types.ts
@@ -91,6 +91,8 @@ export interface TemplateConfig {
   streamId?: string;
   /** The stream configuration used by the template */
   stream?: Stream;
+  /** The specific fields to add additional language options to based on the stream's localization */
+  alternateLanguageFields?: string[];
 }
 
 /**


### PR DESCRIPTION
This works as a passthrough to `generate-test-data` and verified it works in the starter.