### PR TITLE
feat(dev): support alternate languages via `locale` query param

### DIFF
--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -23,9 +23,9 @@ export const serverRenderRoute =
   ({ vite, dynamicGenerateData, projectStructure }: Props): RequestHandler =>
   async (req, res, next) => {
     try {
-      const url = req.baseUrl;
+      const url = new URL("http://" + req.headers.host + req.originalUrl);
 
-      const { feature, entityId } = urlToFeature(url);
+      const { feature, entityId, locale } = urlToFeature(url);
 
       const templateModuleInternal = await featureNameToTemplateModuleInternal(
         vite,
@@ -49,10 +49,11 @@ export const serverRenderRoute =
 
       const { template, Component, props }: PageLoaderResult = await pageLoader(
         {
-          url,
+          url: url.pathname,
           vite,
           templateFilename: templateModuleInternal.filename,
           entityId,
+          locale,
           featuresConfig,
           dynamicGenerateData,
           projectStructure,

--- a/packages/pages/src/dev/server/ssr/generateTestData.test.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.test.ts
@@ -65,6 +65,7 @@ const getGenerateTestDataForPageRunner = () =>
     mockParentProcessStdout,
     FEATURE_CONFIG,
     "loc3",
+    "en",
     projectStructure
   );
 

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -40,6 +40,7 @@ export const generateTestDataForPage = async (
   stdout: NodeJS.WriteStream,
   featuresConfig: FeaturesConfig,
   entityId: string,
+  locale: string,
   projectStructure: ProjectStructure
 ): Promise<any> => {
   const siteStreamPath = path.resolve(
@@ -56,7 +57,7 @@ export const generateTestDataForPage = async (
     "--featuresConfig",
     `'${JSON.stringify(featuresConfig)}'`,
     "--locale",
-    "en",
+    locale,
     "--printDocuments",
   ];
 

--- a/packages/pages/src/dev/server/ssr/getLocalData.ts
+++ b/packages/pages/src/dev/server/ssr/getLocalData.ts
@@ -62,7 +62,10 @@ export const getLocalDataManifest = async (): Promise<LocalDataManifest> => {
   return localDataManifest;
 };
 
-export const getLocalDataForEntity = async (entityId: string) => {
+export const getLocalDataForEntity = async (
+  entityId: string,
+  locale: string
+) => {
   try {
     const dir = await readdir(LOCAL_DATA_PATH);
 
@@ -75,7 +78,7 @@ export const getLocalDataForEntity = async (entityId: string) => {
           .toString()
       );
 
-      if (data.id?.toString() === entityId) {
+      if (data.id?.toString() === entityId && data.locale === locale) {
         return data;
       }
     }
@@ -87,5 +90,7 @@ export const getLocalDataForEntity = async (entityId: string) => {
     }
   }
 
-  throw `No localData files match entityId ${entityId}`;
+  throw new Error(
+    `No localData files match entityId and locale: ${entityId} ${locale}`
+  );
 };

--- a/packages/pages/src/dev/server/ssr/pageLoader.ts
+++ b/packages/pages/src/dev/server/ssr/pageLoader.ts
@@ -19,6 +19,7 @@ type PageLoaderValues = {
   vite: ViteDevServer;
   templateFilename: string;
   entityId: string;
+  locale: string;
   featuresConfig: FeaturesConfig;
   dynamicGenerateData: boolean;
   projectStructure: ProjectStructure;
@@ -41,6 +42,7 @@ export const pageLoader = async ({
   vite,
   templateFilename,
   entityId,
+  locale,
   featuresConfig,
   dynamicGenerateData,
   projectStructure,
@@ -79,15 +81,18 @@ export const pageLoader = async ({
       process.stdout,
       featuresConfig,
       entityId,
+      locale,
       projectStructure
     );
   } else {
     // Get the document from localData
-    document = await getLocalDataForEntity(entityId);
+    document = await getLocalDataForEntity(entityId, locale);
   }
 
   if (entityId && !document) {
-    throw new Error(`Could not find document data for entityId: ${entityId}`);
+    throw new Error(
+      `Could not find document data for entityId and locale: ${entityId} ${locale}`
+    );
   }
 
   let templateProps: TemplateProps = {

--- a/packages/pages/src/dev/server/ssr/urlToFeature.ts
+++ b/packages/pages/src/dev/server/ssr/urlToFeature.ts
@@ -1,22 +1,16 @@
-import chalk from "chalk";
-
 export const urlToFeature = (
-  url: string
-): { feature: string; entityId: string } => {
+  url: URL
+): { feature: string; entityId: string; locale: string } => {
   // URI decode and remove leading slash: /foo/123
-  const uriSegments = decodeURI(url).substring(1).split("/");
-
-  if (uriSegments.length !== 2) {
-    process.stderr.write(
-      `Url must be of the form ${chalk.bold("/{featureName}/{entityId}")}\n`
-    );
-  }
-
+  const uriSegments = decodeURI(url.pathname).substring(1).split("/");
   const feature = uriSegments[0];
   const entityId = uriSegments[1];
+
+  const locale = url.searchParams.get("locale") || "en";
 
   return {
     feature,
     entityId,
+    locale,
   };
 };


### PR DESCRIPTION
For now "en" is used as the default locale until a future enhancement is added to allow users to specify the default locale they want to use.