### PR TITLE
fix(dev): honor feature name casing in local dev url (fixes #121)

### DIFF
--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -48,7 +48,7 @@ export const indexPage =
               `<div class="list-title"> <span class="list-title-templateName">${templateName}</span> Pages (1):</div>
             <ul>
               <li>
-                <a href="http://localhost:${viteDevServerPort}/${templateName}/">
+                <a href="http://localhost:${viteDevServerPort}/${encodeURIComponent(templateName)}/">
                   ${templateName}
                 </a>
               </li>
@@ -79,7 +79,7 @@ export const indexPage =
                 (entityAccumulator, entityId) =>
                   entityAccumulator +
                   `<li>
-                    <a href="http://localhost:${viteDevServerPort}/${templateName}/${entityId}">
+                    <a href="http://localhost:${viteDevServerPort}/${encodeURIComponent(templateName)}/${entityId}">
                       ${entityId}
                     </a>
                   </li>`,

--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -48,7 +48,9 @@ export const indexPage =
               `<div class="list-title"> <span class="list-title-templateName">${templateName}</span> Pages (1):</div>
             <ul>
               <li>
-                <a href="http://localhost:${viteDevServerPort}/${encodeURIComponent(templateName)}/">
+                <a href="http://localhost:${viteDevServerPort}/${encodeURIComponent(
+                templateName
+              )}/">
                   ${templateName}
                 </a>
               </li>
@@ -79,7 +81,9 @@ export const indexPage =
                 (entityAccumulator, entityId) =>
                   entityAccumulator +
                   `<li>
-                    <a href="http://localhost:${viteDevServerPort}/${encodeURIComponent(templateName)}/${entityId}">
+                    <a href="http://localhost:${viteDevServerPort}/${encodeURIComponent(
+                    templateName
+                  )}/${entityId}">
                       ${entityId}
                     </a>
                   </li>`,

--- a/packages/pages/src/dev/server/ssr/featureNameToTemplateModuleInternal.ts
+++ b/packages/pages/src/dev/server/ssr/featureNameToTemplateModuleInternal.ts
@@ -27,10 +27,8 @@ export const featureNameToTemplateModuleInternal = async (
         templateModule,
         false
       );
-      
-    if (
-      featureName === templateModuleInternal.config.name
-    ) {
+
+    if (featureName === templateModuleInternal.config.name) {
       return templateModuleInternal;
     }
   }

--- a/packages/pages/src/dev/server/ssr/featureNameToTemplateModuleInternal.ts
+++ b/packages/pages/src/dev/server/ssr/featureNameToTemplateModuleInternal.ts
@@ -27,17 +27,13 @@ export const featureNameToTemplateModuleInternal = async (
         templateModule,
         false
       );
-
+      
     if (
-      featureName === normalizeTemplateName(templateModuleInternal.config.name)
+      featureName === templateModuleInternal.config.name
     ) {
       return templateModuleInternal;
     }
   }
 
   return null;
-};
-
-const normalizeTemplateName = (name: string) => {
-  return name.replace(/\s/g, "").toLowerCase();
 };


### PR DESCRIPTION
Note that feature names with spaces currently doesn't work until https://github.com/vitejs/vite/issues/9446 is fixed.