### PR TITLE
feat(dev): redirect if url ends in final slash (closes #143)

### DIFF
--- a/packages/pages/src/dev/server/middleware/finalSlashRedirect.test.ts
+++ b/packages/pages/src/dev/server/middleware/finalSlashRedirect.test.ts
@@ -1,0 +1,58 @@
+import { finalSlashRedirect } from "./finalSlashRedirect";
+
+describe("finalSlashRedirect", () => {
+  it("redirects when request path ends in slash", async () => {
+    const canonicalUrl = "test.com/foo";
+
+    const req = {
+      url: canonicalUrl + "/",
+      path: canonicalUrl + "/",
+    };
+    const res = {
+      redirect: jest.fn(),
+    };
+    const next = jest.fn();
+
+    finalSlashRedirect(req, res, next);
+
+    expect(res.redirect).toBeCalledWith(301, canonicalUrl);
+    expect(next).not.toBeCalled();
+  });
+
+  it("redirects with query when request path ends in slash", async () => {
+    const query = "?bar=baz";
+    const canonicalUrl = "test.com/foo";
+
+    const req = {
+      url: canonicalUrl + "/" + query,
+      path: canonicalUrl + "/",
+    };
+    const res = {
+      redirect: jest.fn(),
+    };
+    const next = jest.fn();
+
+    finalSlashRedirect(req, res, next);
+
+    expect(res.redirect).toBeCalledWith(301, canonicalUrl + query);
+    expect(next).not.toBeCalled();
+  });
+
+  it("does not redirect when request path does not end in slash", async () => {
+    const canonicalUrl = "test.com/foo";
+
+    const req = {
+      url: canonicalUrl,
+      path: canonicalUrl,
+    };
+    const res = {
+      redirect: jest.fn(),
+    };
+    const next = jest.fn();
+
+    finalSlashRedirect(req, res, next);
+
+    expect(res.redirect).not.toBeCalled();
+    expect(next).toBeCalled();
+  });
+});

--- a/packages/pages/src/dev/server/middleware/finalSlashRedirect.ts
+++ b/packages/pages/src/dev/server/middleware/finalSlashRedirect.ts
@@ -2,11 +2,11 @@
  * Redirect urls with a final slash to their canonical url without the slash.
  */
 export const finalSlashRedirect = (req: any, res: any, next: any): void => {
-    if (req.path.endsWith('/') && req.path.length > 1) {
-        const query = req.url.slice(req.path.length);
-        const safepath = req.path.slice(0, -1).replace(/\/+/g, '/');
-        res.redirect(301, safepath + query);
-      } else {
-        next()
-      }
-}
+  if (req.path.endsWith("/") && req.path.length > 1) {
+    const query = req.url.slice(req.path.length);
+    const safepath = req.path.slice(0, -1).replace(/\/+/g, "/");
+    res.redirect(301, safepath + query);
+  } else {
+    next();
+  }
+};

--- a/packages/pages/src/dev/server/middleware/finalSlashRedirect.ts
+++ b/packages/pages/src/dev/server/middleware/finalSlashRedirect.ts
@@ -1,0 +1,12 @@
+/**
+ * Redirect urls with a final slash to their canonical url without the slash.
+ */
+export const finalSlashRedirect = (req: any, res: any, next: any): void => {
+    if (req.path.endsWith('/') && req.path.length > 1) {
+        const query = req.url.slice(req.path.length);
+        const safepath = req.path.slice(0, -1).replace(/\/+/g, '/');
+        res.redirect(301, safepath + query);
+      } else {
+        next()
+      }
+}

--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -7,6 +7,7 @@ import { viteDevServerPort } from "./middleware/constants.js";
 import { indexPage } from "./middleware/indexPage.js";
 import { generateTestData } from "./ssr/generateTestData.js";
 import { ProjectStructure } from "../../common/src/project/structure.js";
+import { finalSlashRedirect } from "./middleware/finalSlashRedirect.js";
 
 export const createServer = async (dynamicGenerateData: boolean) => {
   // creates a standard express app
@@ -37,6 +38,9 @@ export const createServer = async (dynamicGenerateData: boolean) => {
     displayGenerateTestDataWarning = !(await generateTestData());
   }
 
+  // Redirect urls with a final slash to their canonical url without the slash
+  // app.use(finalSlashRedirect);
+  
   // When a page is requested that is anything except the root, call our
   // serverRenderRoute middleware.
   app.use(

--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -32,15 +32,15 @@ export const createServer = async (dynamicGenerateData: boolean) => {
   // Ignore favicon requests if it doesn't exist
   app.use(ignoreFavicon);
 
+  // Redirect urls with a final slash to their canonical url without the slash
+  app.use(finalSlashRedirect);
+
   let displayGenerateTestDataWarning = false;
   if (dynamicGenerateData) {
     // display the warning if the call to generateTestData fails.
     displayGenerateTestDataWarning = !(await generateTestData());
   }
 
-  // Redirect urls with a final slash to their canonical url without the slash
-  // app.use(finalSlashRedirect);
-  
   // When a page is requested that is anything except the root, call our
   // serverRenderRoute middleware.
   app.use(


### PR DESCRIPTION
If the local dev url ends in a slash, 301 redirects to the canonical url without the slash. This will prevent future issues when people use relative links.