### PR TITLE
feat(util): add isProduction function

### DIFF
--- a/packages/pages/src/util/env.test.ts
+++ b/packages/pages/src/util/env.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isProduction } from "./env";
+import * as runTime from "./runtime";
+
+describe("isProduction", () => {
+  it("returns true when browser and prod domain", async () => {
+    const runtimeSpy = jest.spyOn(runTime, "getRuntime") as jest.MockInstance<
+      any,
+      any
+    >;
+    runtimeSpy.mockImplementation(() => ({
+      name: "browser",
+    }));
+
+    const domain = "prod.com";
+
+    const windowSpy = jest.spyOn(window, "window", "get") as jest.MockInstance<
+      any,
+      any
+    >;
+    windowSpy.mockImplementation(() => ({
+      location: {
+        hostname: "prod.com",
+      },
+    }));
+
+    expect(isProduction(domain)).toBeTruthy();
+
+    windowSpy.mockRestore();
+    runtimeSpy.mockRestore();
+  });
+
+  it("returns false when not browser and prod domain", async () => {
+    const runtimeSpy = jest.spyOn(runTime, "getRuntime") as jest.MockInstance<
+      any,
+      any
+    >;
+    runtimeSpy.mockImplementation(() => ({
+      name: "node",
+    }));
+
+    const domain = "prod.com";
+
+    const windowSpy = jest.spyOn(window, "window", "get") as jest.MockInstance<
+      any,
+      any
+    >;
+    windowSpy.mockImplementation(() => ({
+      location: {
+        hostname: "prod.com",
+      },
+    }));
+
+    expect(isProduction(domain)).toBeFalsy();
+
+    windowSpy.mockRestore();
+    runtimeSpy.mockRestore();
+  });
+
+  it("returns false when browser and staging domain", async () => {
+    const runtimeSpy = jest.spyOn(runTime, "getRuntime") as jest.MockInstance<
+      any,
+      any
+    >;
+    runtimeSpy.mockImplementation(() => ({
+      name: "browser",
+    }));
+
+    const domain = "prod.com";
+
+    const windowSpy = jest.spyOn(window, "window", "get") as jest.MockInstance<
+      any,
+      any
+    >;
+    windowSpy.mockImplementation(() => ({
+      location: {
+        hostname: "prod.com",
+      },
+    }));
+
+    expect(isProduction("staging.com")).toBeFalsy();
+
+    windowSpy.mockRestore();
+    runtimeSpy.mockRestore();
+  });
+});

--- a/packages/pages/src/util/env.ts
+++ b/packages/pages/src/util/env.ts
@@ -13,5 +13,5 @@ import { getRuntime } from "./runtime";
 export const isProduction = (domain: string): boolean => {
   const runtime = getRuntime();
 
-  return runtime.name === "browser" && domain === window.location.hostname;
+  return runtime.name === "browser" && domain === window?.location?.hostname;
 };

--- a/packages/pages/src/util/env.ts
+++ b/packages/pages/src/util/env.ts
@@ -1,0 +1,17 @@
+import { getRuntime } from "./runtime";
+
+/**
+ * Determines if the code is being executed on the production site on
+ * the client. This is useful for things like firing analytics only
+ * in production (opposed to dev or staging) and not during server side
+ * rendering.
+ *
+ * @param domain The production domain of the site
+ *
+ * @public
+ */
+export const isProduction = (domain: string): boolean => {
+  const runtime = getRuntime();
+
+  return runtime.name === "browser" && domain === window.location.hostname;
+};

--- a/packages/pages/src/util/index.ts
+++ b/packages/pages/src/util/index.ts
@@ -1,2 +1,3 @@
 export { fetch } from "./fetch";
 export { getRuntime } from "./runtime";
+export { isProduction } from "./env";


### PR DESCRIPTION
Checks if a user is on a production domain client-side. Useful for firing analytics only in a real production environment.