### PR TITLE
feat(components): add Link component

### DIFF
--- a/packages/pages/src/components/README.md
+++ b/packages/pages/src/components/README.md
@@ -3,3 +3,7 @@
 ## Image
 
 Render an image from a Knowledge Graph field.
+
+## Link
+
+Render an anchor tag with an `href` or from a `CTA` type Knowledge Graph field.

--- a/packages/pages/src/components/analytics/Analytics.ts
+++ b/packages/pages/src/components/analytics/Analytics.ts
@@ -1,3 +1,4 @@
+import { MouseEvent } from "react";
 import { TemplateProps } from "../../common/src/template/types";
 import { getRuntime, isProduction } from "../../util";
 import { AnalyticsMethods } from "./interfaces";
@@ -179,7 +180,7 @@ export class Analytics implements AnalyticsMethods {
   trackClick(
     eventName: string,
     conversionData?: ConversionDetails
-  ): (e: MouseEvent) => Promise<void> {
+  ): (e: MouseEvent<HTMLAnchorElement>) => Promise<void> {
     return (e: MouseEvent) => {
       if (!this.canTrack()) {
         return Promise.resolve();
@@ -220,7 +221,7 @@ export class Analytics implements AnalyticsMethods {
       e.preventDefault();
 
       const navigate = () => {
-        window.location.href = linkUrl.toString();
+        window.location.assign(linkUrl);
       };
 
       const awaitTimeout = new Promise<void>((resolve) => {

--- a/packages/pages/src/components/analytics/analytics.test.tsx
+++ b/packages/pages/src/components/analytics/analytics.test.tsx
@@ -10,7 +10,6 @@ import { AnalyticsProvider } from "./provider";
 import { useAnalytics } from "./hooks";
 import { AnalyticsScopeProvider } from "./scope";
 
-
 // The following section of mocks just exists to supress an error that occurs
 // because jest does not implement a window.location.navigate.  See:
 // https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/
@@ -31,7 +30,7 @@ beforeAll(() => {
       assign: {
         configurable: true,
         value: jest.fn(),
-      }
+      },
     }
   );
 
@@ -105,7 +104,9 @@ describe("Analytics", () => {
   it("should track a click", () => {
     render(
       <AnalyticsProvider templateData={baseProps} requireOptIn={false}>
-        <Link href="https://yext.com" onClick={e => e.preventDefault()} >Click Me</Link>
+        <Link href="https://yext.com" onClick={(e) => e.preventDefault()}>
+          Click Me
+        </Link>
       </AnalyticsProvider>
     );
 
@@ -113,7 +114,7 @@ describe("Analytics", () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const callstack = global.fetch.mock.calls;
-    const generatedUrlStr = callstack[callstack.length-1][0];
+    const generatedUrlStr = callstack[callstack.length - 1][0];
     const generatedUrl = new URL(generatedUrlStr);
     expect(generatedUrl.searchParams.get("eventType")).toBe("link");
   });
@@ -130,7 +131,9 @@ describe("Analytics", () => {
               <Link cta={{ link: "https://yext.com" }}>two</Link>
             </AnalyticsScopeProvider>
           </AnalyticsScopeProvider>
-          <Link href="https://yext.com" eventName={"fooclick"}>three</Link>
+          <Link href="https://yext.com" eventName={"fooclick"}>
+            three
+          </Link>
         </AnalyticsProvider>
       );
     };
@@ -177,11 +180,13 @@ describe("Analytics", () => {
     const expectedConversionData = { cid: "123456", cv: "10" };
 
     const MyButton = () => {
-      const analytics = useAnalytics()
+      const analytics = useAnalytics();
       analytics?.enableTrackingCookie();
       return (
         <button
-          onClick={async () => await analytics?.track("foo click", expectedConversionData)}
+          onClick={async () =>
+            await analytics?.track("foo click", expectedConversionData)
+          }
         />
       );
     };

--- a/packages/pages/src/components/analytics/hooks.ts
+++ b/packages/pages/src/components/analytics/hooks.ts
@@ -19,7 +19,7 @@ declare global {
  *
  * @public
  */
-export function useAnalytics(): AnalyticsMethods|null {
+export function useAnalytics(): AnalyticsMethods | null {
   const ctx = useContext(AnalyticsContext);
 
   if (!ctx) {

--- a/packages/pages/src/components/analytics/hooks.ts
+++ b/packages/pages/src/components/analytics/hooks.ts
@@ -1,5 +1,5 @@
 import { ConversionDetails, Visitor } from "@yext/analytics";
-import { useContext } from "react";
+import { MouseEvent, useContext } from "react";
 import { AnalyticsContext } from "./context";
 import { concatScopes } from "./helpers";
 import { AnalyticsMethods } from "./interfaces";
@@ -19,12 +19,11 @@ declare global {
  *
  * @public
  */
-export function useAnalytics(): AnalyticsMethods {
+export function useAnalytics(): AnalyticsMethods|null {
   const ctx = useContext(AnalyticsContext);
+
   if (!ctx) {
-    throw new Error(
-      "Attempted to call useAnalytics outside of an AnalyticsProvider"
-    );
+    return ctx;
   }
 
   // TODO: is this the right way / place to expose a callback for use by a Cookie Management banner?
@@ -41,7 +40,7 @@ export function useAnalytics(): AnalyticsMethods {
     trackClick(
       eventName: string,
       conversionData?: ConversionDetails
-    ): (e: MouseEvent) => Promise<void> {
+    ): (e: MouseEvent<HTMLAnchorElement>) => Promise<void> {
       return ctx.trackClick(concatScopes(scope, eventName), conversionData);
     },
     setDebugEnabled(enabled: boolean): void {
@@ -74,7 +73,7 @@ export function useAnalytics(): AnalyticsMethods {
  * @public
  */
 export const useTrack = () => {
-  return useAnalytics().track;
+  return useAnalytics()?.track;
 };
 
 /**
@@ -83,7 +82,7 @@ export const useTrack = () => {
  * @public
  */
 export const usePageView = () => {
-  return useAnalytics().pageView;
+  return useAnalytics()?.pageView;
 };
 
 /**
@@ -92,5 +91,5 @@ export const usePageView = () => {
  * @public
  */
 export const useIdentify = () => {
-  return useAnalytics().identify;
+  return useAnalytics()?.identify;
 };

--- a/packages/pages/src/components/analytics/interfaces.ts
+++ b/packages/pages/src/components/analytics/interfaces.ts
@@ -1,3 +1,4 @@
+import { MouseEvent } from "react";
 import { ConversionDetails, Visitor } from "@yext/analytics";
 import { TemplateProps } from "../../common/src/template/types";
 
@@ -35,7 +36,7 @@ export interface AnalyticsMethods {
   trackClick(
     eventName: string,
     conversionData?: ConversionDetails
-  ): (e: MouseEvent) => Promise<void>;
+  ): (e: MouseEvent<HTMLAnchorElement>) => Promise<void>;
 
   /**
    * The optIn method should be called when a user opts into analytics tracking,

--- a/packages/pages/src/components/index.ts
+++ b/packages/pages/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./address";
 export * from "./image";
 export * from "./analytics";
+export * from "./link";

--- a/packages/pages/src/components/link/index.ts
+++ b/packages/pages/src/components/link/index.ts
@@ -1,0 +1,2 @@
+export { Link } from "./link";
+export * from "./types";

--- a/packages/pages/src/components/link/link.test.tsx
+++ b/packages/pages/src/components/link/link.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+import { Link } from "./link";
+
+describe("Link", () => {
+  it("renders component when given href + children", () => {
+    render(<Link href="https://yext.com">Click Me</Link>);
+  });
+
+  it("renders component when given partial cta and children", () => {
+    render(<Link cta={{ link: "https://yext.com" }}>Click Me</Link>);
+  });
+
+  it("renders component when given full cta prop and no children", () => {
+    render(
+      <Link
+        cta={{ link: "https://yext.com", label: "Click Me", linkType: "URL" }}
+      />
+    );
+  });
+
+  it("renders component when given full cta prop and no children", () => {
+    render(<Link cta={{ link: "https://yext.com" }} />);
+  });
+});
+
+// TODO: Add tests
+// Check target="_blank" present on newTab
+// Check obfuscated label
+// Check obfuscated href
+// Check children is label if present
+// Check fallback to link for label

--- a/packages/pages/src/components/link/link.tsx
+++ b/packages/pages/src/components/link/link.tsx
@@ -1,0 +1,136 @@
+import { ConversionDetails } from "@yext/analytics";
+import React, { useState } from "react";
+import classNames from "classnames";
+import { AnalyticsContext, useAnalytics } from "../analytics";
+import { AnalyticsMethods } from "../analytics/interfaces";
+import { getHref, isEmail, reverse } from "./methods";
+import type { CTA } from "./types";
+
+/**
+ * Configuration options available for any usages of the Link component.
+ *
+ * @public
+ */
+interface LinkConfig
+  extends React.DetailedHTMLProps<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    HTMLAnchorElement
+  > {
+  obfuscate?: boolean;
+  eventName?: string;
+  conversionDetails?: ConversionDetails|undefined;
+}
+
+/**
+ * The shape of the data passed to {@link Link} when directly passing an HREF to the Link component.
+ */
+interface HREFLinkProps extends LinkConfig {
+  href: string;
+  cta?: never;
+}
+
+/**
+ * The shape of the data passed to {@link Link} when using a CTA field, and not overriding children.
+ */
+interface CTAWithChildrenLinkProps extends LinkConfig {
+  href?: never;
+  cta: CTA;
+  children?: never;
+}
+
+/**
+ * The shape of the data passed to {@link Link} when using a CTA field, and overriding children.
+ *
+ * @public
+ */
+interface CTAWithoutChildrenLinkProps extends LinkConfig {
+  href?: never;
+  cta: Omit<CTA, "label">;
+  children: React.ReactNode;
+}
+
+/**
+ * The shape of the data passed to {@link Link} when using a CTA field.
+ *
+ * @public
+ */
+type CTALinkProps = CTAWithChildrenLinkProps | CTAWithoutChildrenLinkProps;
+
+/**
+ * The shape of the data passed to {@link Link}.
+ *
+ * @public
+ */
+export type LinkProps = CTALinkProps | HREFLinkProps;
+
+/**
+ * Type predicate for distinguishing between data cases.
+ */
+function isHREFProps(props: LinkProps): props is HREFLinkProps {
+  return "href" in props;
+}
+
+/**
+ * Renders an anchor tag using either a directly provided HREF or from a field in the Yext Knowledge Graph.
+ *
+ * Example of using the component to render
+ * a link with and without sourcing from a knowledge graph field:
+ *
+ * @example
+ * ```
+ * import { Link } from "@yext/pages/components";
+ *
+ * <Link href="/search">Locator</Link>
+ * <Link cta={document.c_exampleCTA} />
+ * <Link cta={{link: "https://www.yext.com", label: "Click Here", linkType: "URL"}} />
+ *
+ * @public
+ */
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    const { children, onClick, className, eventName, ...rest } = props;
+    const link: CTA = isHREFProps(props) ? { link: props.href } : props.cta;
+
+    const trackEvent = eventName ? eventName : (props.cta ? "cta" : "link");
+    const analytics = useAnalytics();
+
+    const obfuscate =
+      props.obfuscate || (props.obfuscate !== false && isEmail(link.link));
+    const [humanInteraction, setHumanInteraction] = useState<boolean>(false);
+
+    const handleClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+      setHumanInteraction(true);
+      if (analytics !== null) {
+        await analytics.trackClick(trackEvent, props.conversionDetails)(e);
+      }
+
+      if (onClick) {
+        onClick(e);
+      }
+    };
+
+    const useLinkAsLabel = !children && !link.label;
+    const isObfuscate = !humanInteraction && obfuscate;
+    const obfuscatedStyle: React.CSSProperties = {
+      ...props.style,
+      unicodeBidi: "bidi-override",
+      direction: useLinkAsLabel && isObfuscate ? "rtl" : "ltr",
+    };
+
+    const renderedLink = isObfuscate ? reverse(link.link) : link.link;
+
+    return (
+      <a
+        className={classNames("Link", className)}
+        href={humanInteraction || !obfuscate ? getHref(link) : "obfuscate"}
+        onClick={handleClick}
+        rel={props.target && !props.rel ? "noopener" : undefined}
+        ref={ref}
+        style={obfuscatedStyle}
+        {...rest}
+      >
+        {children || link.label || renderedLink}
+      </a>
+    );
+  }
+);

--- a/packages/pages/src/components/link/link.tsx
+++ b/packages/pages/src/components/link/link.tsx
@@ -18,7 +18,7 @@ interface LinkConfig
   > {
   obfuscate?: boolean;
   eventName?: string;
-  conversionDetails?: ConversionDetails|undefined;
+  conversionDetails?: ConversionDetails | undefined;
 }
 
 /**
@@ -91,7 +91,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     const { children, onClick, className, eventName, ...rest } = props;
     const link: CTA = isHREFProps(props) ? { link: props.href } : props.cta;
 
-    const trackEvent = eventName ? eventName : (props.cta ? "cta" : "link");
+    const trackEvent = eventName ? eventName : props.cta ? "cta" : "link";
     const analytics = useAnalytics();
 
     const obfuscate =

--- a/packages/pages/src/components/link/methods.test.ts
+++ b/packages/pages/src/components/link/methods.test.ts
@@ -1,13 +1,7 @@
 import { getHref, isEmail, reverse } from "./methods";
-
-enum LinkType {
-  URL = "URL",
-  Email = "Email",
-  Phone = "Phone",
-}
+import { LinkType } from "./types";
 
 // getHref
-
 test("getHref: Url type", () => {
   expect(
     getHref({

--- a/packages/pages/src/components/link/methods.test.ts
+++ b/packages/pages/src/components/link/methods.test.ts
@@ -1,0 +1,97 @@
+import { getHref, isEmail, reverse } from "./methods";
+
+enum LinkType {
+  URL = "URL",
+  Email = "Email",
+  Phone = "Phone",
+}
+
+// getHref
+
+test("getHref: Url type", () => {
+  expect(
+    getHref({
+      label: "",
+      link: "https://yext.com",
+      linkType: LinkType.URL,
+    })
+  ).toEqual("https://yext.com");
+});
+
+test("getHref: Email type", () => {
+  expect(
+    getHref({
+      label: "",
+      link: "email@test.com",
+      linkType: LinkType.Email,
+    })
+  ).toEqual("mailto:email@test.com");
+});
+
+test("getHref: Telephone type", () => {
+  expect(
+    getHref({
+      label: "",
+      link: "+11234567890",
+      linkType: LinkType.Phone,
+    })
+  ).toEqual("tel:+11234567890");
+});
+
+// isEmail
+
+// Source test cases from chromium
+// https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/fast/forms/resources/ValidityState-typeMismatch-email.js?q=ValidityState-typeMismatch-email.js&ss=chromium
+
+const expectValid = true;
+const expectInvalid = false;
+
+test.each<[string, boolean]>([
+  ["something@something.com", expectValid],
+  ["someone@localhost.localdomain", expectValid],
+  ["someone@127.0.0.1", expectValid],
+  ["a@b.b", expectValid],
+  ["a/b@domain.com", expectValid],
+  ["{}@domain.com", expectValid],
+  ["m*'!%@something.sa", expectValid],
+  ["tu!!7n7.ad##0!!!@company.ca", expectValid],
+  ["%@com.com", expectValid],
+  ["!#$%&'*+/=?^_`{|}~.-@com.com", expectValid],
+  [".wooly@example.com", expectValid],
+  ["wo..oly@example.com", expectValid],
+  ["someone@do-ma-in.com", expectValid],
+  ["somebody@example", expectValid],
+  ["invalid:email@example.com", expectInvalid],
+  ["@somewhere.com", expectInvalid],
+  ["example.com", expectInvalid],
+  ["@@example.com", expectInvalid],
+  ["a space@example.com", expectInvalid],
+  ["something@ex..ample.com", expectInvalid],
+  ["a\b@c", expectInvalid],
+  ["someone@somewhere.com.", expectInvalid],
+  ['""test\blah""@example.com', expectInvalid],
+  ['"testblah"@example.com', expectInvalid],
+  ["someone@somewhere.com@", expectInvalid],
+  ["someone@somewhere_com", expectInvalid],
+  ["someone@some:where.com", expectInvalid],
+  [".", expectInvalid],
+  ["F/s/f/a@feo+re.com", expectInvalid],
+  [
+    'some+long+email+address@some+host-weird-/looking.com", "some+long+email+address@some+host-weird-/looking.com',
+    expectInvalid,
+  ],
+  ["a @p.com", expectInvalid],
+  ["ddjk-s-jk@asl-.com", expectInvalid],
+])(`isEmail: %s`, (emailAddress, validity) => {
+  expect(isEmail(emailAddress)).toEqual(validity);
+});
+
+// reverse
+
+test.each<[string, string]>([
+  ["https://yext.com", "moc.txey//:sptth"],
+  ["0123456789", "9876543210"],
+  ["the quick fox", "xof kciuq eht"],
+])(`reverse: %s`, (forwards, backwards) => {
+  expect(reverse(forwards)).toEqual(backwards);
+});

--- a/packages/pages/src/components/link/methods.ts
+++ b/packages/pages/src/components/link/methods.ts
@@ -1,0 +1,70 @@
+import { ReactNode } from "react";
+import { LinkType } from "./types";
+import type { CTA } from "./types";
+
+/**
+ * Get the link from a CTA
+ *
+ * @param {CTA} cta
+ *
+ * @returns {string}
+ */
+const getHref = (cta: CTA): string => {
+  if (cta.linkType === "Email" || (!cta.linkType && isEmail(cta.link))) {
+    return `mailto:${cta.link}`;
+  }
+
+  if (cta.linkType === "Phone") {
+    return `tel:${cta.link}`;
+  }
+
+  return cta.link;
+};
+
+/**
+ * CTA constructor
+ *
+ * @param {string} link
+ * @param {LinkType} linkType
+ * @param {string} label
+ *
+ * @returns {boolean}
+ */
+export function cta(
+  link: string,
+  linkType: LinkType = LinkType.URL,
+  label?: ReactNode
+): CTA {
+  return {
+    link,
+    linkType: linkType,
+    label: typeof label === "string" ? label : "",
+  };
+}
+
+/**
+ * Checks if is a valid email address
+ *
+ * Regex defined in HTML Spec for <input type="email"> validation.
+ * https://html.spec.whatwg.org/#email-state-(type=email)
+ */
+const isEmail = (string: string): boolean => {
+  const re =
+    /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  return re.test(string);
+};
+
+/**
+ * Reverse a string, used for obfuscation
+ *
+ * https://eddmann.com/posts/ten-ways-to-reverse-a-string-in-javascript/
+ */
+const reverse = (string: string): string => {
+  let o = "";
+  for (let i = string.length - 1; i >= 0; o += string[i--]) {
+    // intentionally empty, logic happens in the for loop iteration
+  }
+  return o;
+};
+
+export { getHref, isEmail, reverse };

--- a/packages/pages/src/components/link/types.ts
+++ b/packages/pages/src/components/link/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Constants for available link types.
+ */
+export const LinkType = {
+  URL: "URL",
+  Email: "Email",
+  Phone: "Phone",
+} as const;
+
+/**
+ * Type of link types that might be received from the platform.
+ */
+export type LinkType = typeof LinkType[keyof typeof LinkType];
+
+/**
+ * Type for CTA field
+ * Note that when coming from the platform the label will always be a string
+ * but ReactNode allows for more general usage.
+ */
+export interface CTA {
+  link: string;
+  label?: React.ReactNode;
+  linkType?: LinkType;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5424,7 +5424,6 @@ packages:
 
   /bindings/1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -7795,7 +7794,6 @@ packages:
 
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-    requiresBuild: true
     dev: true
     optional: true
 
@@ -10690,7 +10688,6 @@ packages:
 
   /nan/2.16.0:
     resolution: {integrity: sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==}
-    requiresBuild: true
     dev: true
     optional: true
 


### PR DESCRIPTION
Summary of changes from the existing Consulting version of this component, mainly for @tatimblin: 
* I converted the LinkType to a const rather than an enum so that users can either import the value, or pass a raw string. Follows the pattern used by the `layout` prop on the Image, which came out of a slack discussion.
* The component defines its own CTA type, in the type I made `label` optional and changed its type from string to ReactNode so that it's easier to use things like icons. 
* I removed the global props for now, since I think that's probably worth a separate PR to make sure we feel good about how it works in a public repo
* I removed the phone number library. It was only used for trying to autodetect phone numbers, and I'm not sure it's worth the cost of the dependency size
* I changed the linkType so that it's only inferred if it isn't explicitly specified
* I removed the `parseLinkType` function. I thin kif we type the linkType, we don't need to worry about handling arbitrary strings.
* I removed `linkType` from the base LinkConfig. I got confused by it compared to the cta.linkType, and wasn't sure if there was a specific use case we had in mind for it.