### PR TITLE
fix(dev): prevent crashing on empty id

### DIFF
--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -50,7 +50,7 @@ export const generateTestDataForPage = async (
 
   const command = "yext";
   const args = [
-    "sites",
+    "pages",
     "generate-test-data",
     "--featureName",
     `'${featuresConfig.features[0]?.name}'`,
@@ -127,17 +127,27 @@ export const generateTestDataForPage = async (
     });
 
     childProcess.on("close", () => {
+      let parsedData: any;
       if (testData) {
-        testData = JSON.parse(testData.trim());
+        try {
+          parsedData = JSON.parse(testData.trim());
+        } catch (e) {
+          stdout.write(
+            `\nUnable to parse test data from command: \`${command}${args.join(
+              " "
+            )}\``
+          );
+          resolve(null);
+        }
       } else {
         stdout.write(
-          `Unable to generate test data from command: \`${command}${args.join(
+          `\nUnable to generate test data from command: \`${command}${args.join(
             " "
           )}\``
         );
       }
 
-      resolve(testData);
+      resolve(parsedData);
     });
   });
 };

--- a/packages/pages/src/dev/server/ssr/pageLoader.ts
+++ b/packages/pages/src/dev/server/ssr/pageLoader.ts
@@ -84,10 +84,6 @@ export const pageLoader = async ({
       locale,
       projectStructure
     );
-    if (document === null) {
-      // Fall back to localData
-      document = await getLocalDataForEntity(entityId, locale);
-    }
   } else {
     // Get the document from localData
     document = await getLocalDataForEntity(entityId, locale);

--- a/packages/pages/src/dev/server/ssr/pageLoader.ts
+++ b/packages/pages/src/dev/server/ssr/pageLoader.ts
@@ -84,6 +84,10 @@ export const pageLoader = async ({
       locale,
       projectStructure
     );
+    if (document === null) {
+      // Fall back to localData
+      document = await getLocalDataForEntity(entityId, locale);
+    }
   } else {
     // Get the document from localData
     document = await getLocalDataForEntity(entityId, locale);


### PR DESCRIPTION
Fixes #168 by catching the json parse error and returning null, which prompts the server to return an error.

It will still 500, when a 404 would _probably_ be preferable, but at least the server will not crash now.