### PR TITLE
feat(components): add getDirections function

### DIFF
--- a/packages/pages/src/components/address/index.ts
+++ b/packages/pages/src/components/address/index.ts
@@ -1,2 +1,3 @@
 export { Address } from "./address";
+export { getDirections} from './methods';
 export * from "./types";

--- a/packages/pages/src/components/address/index.ts
+++ b/packages/pages/src/components/address/index.ts
@@ -1,3 +1,3 @@
 export { Address } from "./address";
-export { getDirections} from './methods';
+export { getDirections } from "./methods";
 export * from "./types";

--- a/packages/pages/src/components/address/methods.test.ts
+++ b/packages/pages/src/components/address/methods.test.ts
@@ -64,9 +64,7 @@ describe("getDirections()", () => {
   });
 
   it("returns URL to Google Maps address query", () => {
-    expect(
-      getDirections(sampleAddress)
-    ).toEqual(
+    expect(getDirections(sampleAddress)).toEqual(
       "https://maps.google.com/maps/search/?api=1&query=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US"
     );
   });
@@ -82,21 +80,23 @@ describe("getDirections()", () => {
   });
 
   it("returns URL to Google Maps GMB listing", () => {
-    expect(
-      getDirections(undefined, sampleListings)
-    ).toEqual("https://maps.google.com/maps?cid=3287244376840534043");
+    expect(getDirections(undefined, sampleListings)).toEqual(
+      "https://maps.google.com/maps?cid=3287244376840534043"
+    );
   });
 
   it("returns URL to Google Maps Place ID with route", () => {
     expect(
-      getDirections(undefined, undefined, 'someID', { route: true })
-    ).toEqual("https://maps.google.com/maps/dir/?api=1&destination_place_id=someID&destination=direct");
+      getDirections(undefined, undefined, "someID", { route: true })
+    ).toEqual(
+      "https://maps.google.com/maps/dir/?api=1&destination_place_id=someID&destination=direct"
+    );
   });
 
   it("returns URL to Google Maps Place ID, by forcing route", () => {
-    expect(
-      getDirections(undefined, undefined, 'someID')
-    ).toEqual("https://maps.google.com/maps/dir/?api=1&destination_place_id=someID&destination=direct");
+    expect(getDirections(undefined, undefined, "someID")).toEqual(
+      "https://maps.google.com/maps/dir/?api=1&destination_place_id=someID&destination=direct"
+    );
   });
 });
 

--- a/packages/pages/src/components/address/methods.test.ts
+++ b/packages/pages/src/components/address/methods.test.ts
@@ -1,5 +1,10 @@
 import { getDirections, getUnabbreviated } from "./methods";
-import { AddressType, ListingPublisher, ListingType, MapProvider } from "./types";
+import {
+  AddressType,
+  ListingPublisher,
+  ListingType,
+  MapProvider,
+} from "./types";
 
 const sampleAddress: AddressType = {
   city: "New York",
@@ -21,49 +26,85 @@ const sampleAddress2: AddressType = {
 
 const sampleListings: ListingType[] = [
   {
-    listingUrl: 'https://maps.google.com/maps?cid=3287244376840534043',
+    listingUrl: "https://maps.google.com/maps?cid=3287244376840534043",
     publisher: ListingPublisher.googlemybusiness,
   },
 ];
 
 describe("getDirections()", () => {
-  it('returns URL to Apple Maps address query', () => {
-    expect(getDirections({
-      ref_listings: sampleListings,
-      address: sampleAddress,
-    }, MapProvider.Apple)).toEqual('https://maps.apple.com/?address=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US');
+  it("returns URL to Apple Maps address query", () => {
+    expect(
+      getDirections(
+        {
+          ref_listings: sampleListings,
+          address: sampleAddress,
+        },
+        MapProvider.Apple
+      )
+    ).toEqual(
+      "https://maps.apple.com/?address=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US"
+    );
   });
-  
-  it('returns URL to Bing Maps address query', () => {
-    expect(getDirections({
-      ref_listings: sampleListings,
-      address: sampleAddress,
-    }, MapProvider.Bing)).toEqual('https://bing.com/maps/default.aspx?where1=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010');
+
+  it("returns URL to Bing Maps address query", () => {
+    expect(
+      getDirections(
+        {
+          ref_listings: sampleListings,
+          address: sampleAddress,
+        },
+        MapProvider.Bing
+      )
+    ).toEqual(
+      "https://bing.com/maps/default.aspx?where1=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010"
+    );
   });
-  
-  it('returns URL to Bing Maps address query with route from current location', () => {
-    expect(getDirections({
-      ref_listings: sampleListings,
-      address: sampleAddress,
-    }, MapProvider.Bing, true)).toEqual('https://bing.com/maps/default.aspx?rtp=adr.60%20W%2023rd%20St,%20New%20York,%20NY,%2010010');
+
+  it("returns URL to Bing Maps address query with route from current location", () => {
+    expect(
+      getDirections(
+        {
+          ref_listings: sampleListings,
+          address: sampleAddress,
+        },
+        MapProvider.Bing,
+        true
+      )
+    ).toEqual(
+      "https://bing.com/maps/default.aspx?rtp=adr.60%20W%2023rd%20St,%20New%20York,%20NY,%2010010"
+    );
   });
-  
-  it('returns URL to Google Maps address query', () => {
-    expect(getDirections({
-      address: sampleAddress,
-    })).toEqual('https://maps.google.com/maps/search/?api=1&query=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US');
+
+  it("returns URL to Google Maps address query", () => {
+    expect(
+      getDirections({
+        address: sampleAddress,
+      })
+    ).toEqual(
+      "https://maps.google.com/maps/search/?api=1&query=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US"
+    );
   });
-  
-  it('returns URL to Google Maps address query with route from current location', () => {
-    expect(getDirections({
-      address: sampleAddress,
-    }, undefined, true)).toEqual('https://maps.google.com/maps/dir/?api=1&destination=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US');
+
+  it("returns URL to Google Maps address query with route from current location", () => {
+    expect(
+      getDirections(
+        {
+          address: sampleAddress,
+        },
+        undefined,
+        true
+      )
+    ).toEqual(
+      "https://maps.google.com/maps/dir/?api=1&destination=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US"
+    );
   });
-  
-  it('returns URL to Google Maps GMB listing', () => {
-    expect(getDirections({
-      ref_listings: sampleListings,
-    })).toEqual('https://maps.google.com/maps?cid=3287244376840534043');
+
+  it("returns URL to Google Maps GMB listing", () => {
+    expect(
+      getDirections({
+        ref_listings: sampleListings,
+      })
+    ).toEqual("https://maps.google.com/maps?cid=3287244376840534043");
   });
 });
 

--- a/packages/pages/src/components/address/methods.test.ts
+++ b/packages/pages/src/components/address/methods.test.ts
@@ -1,9 +1,9 @@
 import { getDirections, getUnabbreviated } from "./methods";
 import {
   AddressType,
-  ListingPublisher,
+  ListingPublisherOption,
   ListingType,
-  MapProvider,
+  MapProviderOption,
 } from "./types";
 
 const sampleAddress: AddressType = {
@@ -27,20 +27,16 @@ const sampleAddress2: AddressType = {
 const sampleListings: ListingType[] = [
   {
     listingUrl: "https://maps.google.com/maps?cid=3287244376840534043",
-    publisher: ListingPublisher.googlemybusiness,
+    publisher: ListingPublisherOption.GOOGLEMYBUSINESS,
   },
 ];
 
 describe("getDirections()", () => {
   it("returns URL to Apple Maps address query", () => {
     expect(
-      getDirections(
-        {
-          ref_listings: sampleListings,
-          address: sampleAddress,
-        },
-        MapProvider.Apple
-      )
+      getDirections(sampleAddress, sampleListings, undefined, {
+        provider: MapProviderOption.APPLE,
+      })
     ).toEqual(
       "https://maps.apple.com/?address=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US"
     );
@@ -48,13 +44,9 @@ describe("getDirections()", () => {
 
   it("returns URL to Bing Maps address query", () => {
     expect(
-      getDirections(
-        {
-          ref_listings: sampleListings,
-          address: sampleAddress,
-        },
-        MapProvider.Bing
-      )
+      getDirections(sampleAddress, sampleListings, undefined, {
+        provider: MapProviderOption.BING,
+      })
     ).toEqual(
       "https://bing.com/maps/default.aspx?where1=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010"
     );
@@ -62,14 +54,10 @@ describe("getDirections()", () => {
 
   it("returns URL to Bing Maps address query with route from current location", () => {
     expect(
-      getDirections(
-        {
-          ref_listings: sampleListings,
-          address: sampleAddress,
-        },
-        MapProvider.Bing,
-        true
-      )
+      getDirections(sampleAddress, sampleListings, undefined, {
+        provider: MapProviderOption.BING,
+        route: true,
+      })
     ).toEqual(
       "https://bing.com/maps/default.aspx?rtp=adr.60%20W%2023rd%20St,%20New%20York,%20NY,%2010010"
     );
@@ -77,9 +65,7 @@ describe("getDirections()", () => {
 
   it("returns URL to Google Maps address query", () => {
     expect(
-      getDirections({
-        address: sampleAddress,
-      })
+      getDirections(sampleAddress)
     ).toEqual(
       "https://maps.google.com/maps/search/?api=1&query=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US"
     );
@@ -87,13 +73,9 @@ describe("getDirections()", () => {
 
   it("returns URL to Google Maps address query with route from current location", () => {
     expect(
-      getDirections(
-        {
-          address: sampleAddress,
-        },
-        undefined,
-        true
-      )
+      getDirections(sampleAddress, undefined, undefined, {
+        route: true,
+      })
     ).toEqual(
       "https://maps.google.com/maps/dir/?api=1&destination=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US"
     );
@@ -101,10 +83,20 @@ describe("getDirections()", () => {
 
   it("returns URL to Google Maps GMB listing", () => {
     expect(
-      getDirections({
-        ref_listings: sampleListings,
-      })
+      getDirections(undefined, sampleListings)
     ).toEqual("https://maps.google.com/maps?cid=3287244376840534043");
+  });
+
+  it("returns URL to Google Maps Place ID with route", () => {
+    expect(
+      getDirections(undefined, undefined, 'someID', { route: true })
+    ).toEqual("https://maps.google.com/maps/dir/?api=1&destination_place_id=someID&destination=direct");
+  });
+
+  it("returns URL to Google Maps Place ID, by forcing route", () => {
+    expect(
+      getDirections(undefined, undefined, 'someID')
+    ).toEqual("https://maps.google.com/maps/dir/?api=1&destination_place_id=someID&destination=direct");
   });
 });
 

--- a/packages/pages/src/components/address/methods.test.ts
+++ b/packages/pages/src/components/address/methods.test.ts
@@ -1,7 +1,15 @@
-import { getUnabbreviated } from "./methods";
-import { AddressType } from "./types";
+import { getDirections, getUnabbreviated } from "./methods";
+import { AddressType, ListingPublisher, ListingType, MapProvider } from "./types";
 
-const address: AddressType = {
+const sampleAddress: AddressType = {
+  city: "New York",
+  countryCode: "US",
+  line1: "60 W 23rd St",
+  postalCode: "10010",
+  region: "NY",
+};
+
+const sampleAddress2: AddressType = {
   city: "Birmingham",
   countryCode: "US",
   line1: "1716 University Boulevard",
@@ -11,12 +19,60 @@ const address: AddressType = {
   region: "AL",
 };
 
+const sampleListings: ListingType[] = [
+  {
+    listingUrl: 'https://maps.google.com/maps?cid=3287244376840534043',
+    publisher: ListingPublisher.googlemybusiness,
+  },
+];
+
+describe("getDirections()", () => {
+  it('returns URL to Apple Maps address query', () => {
+    expect(getDirections({
+      ref_listings: sampleListings,
+      address: sampleAddress,
+    }, MapProvider.Apple)).toEqual('https://maps.apple.com/?address=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US');
+  });
+  
+  it('returns URL to Bing Maps address query', () => {
+    expect(getDirections({
+      ref_listings: sampleListings,
+      address: sampleAddress,
+    }, MapProvider.Bing)).toEqual('https://bing.com/maps/default.aspx?where1=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010');
+  });
+  
+  it('returns URL to Bing Maps address query with route from current location', () => {
+    expect(getDirections({
+      ref_listings: sampleListings,
+      address: sampleAddress,
+    }, MapProvider.Bing, true)).toEqual('https://bing.com/maps/default.aspx?rtp=adr.60%20W%2023rd%20St,%20New%20York,%20NY,%2010010');
+  });
+  
+  it('returns URL to Google Maps address query', () => {
+    expect(getDirections({
+      address: sampleAddress,
+    })).toEqual('https://maps.google.com/maps/search/?api=1&query=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US');
+  });
+  
+  it('returns URL to Google Maps address query with route from current location', () => {
+    expect(getDirections({
+      address: sampleAddress,
+    }, undefined, true)).toEqual('https://maps.google.com/maps/dir/?api=1&destination=60%20W%2023rd%20St,%20New%20York,%20NY,%2010010,%20US');
+  });
+  
+  it('returns URL to Google Maps GMB listing', () => {
+    expect(getDirections({
+      ref_listings: sampleListings,
+    })).toEqual('https://maps.google.com/maps?cid=3287244376840534043');
+  });
+});
+
 describe("getUnabbreviated()", () => {
-  it("properly return the unabbreviated value of a field if it exists", () => {
-    expect(getUnabbreviated("region", address)).toBe("Alabama");
+  it("properly returns the unabbreviated value of a field if it exists", () => {
+    expect(getUnabbreviated("region", sampleAddress2)).toBe("Alabama");
   });
 
-  it("return undefined if an unabbreviated value does not exist", () => {
-    expect(getUnabbreviated("postalCode", address)).toBe(undefined);
+  it("returns undefined if an unabbreviated value does not exist", () => {
+    expect(getUnabbreviated("postalCode", sampleAddress2)).toBe(undefined);
   });
 });

--- a/packages/pages/src/components/address/methods.ts
+++ b/packages/pages/src/components/address/methods.ts
@@ -43,7 +43,7 @@ export const getUnabbreviated = (
  */
 export const getDirections = (
   address?: AddressType,
-  listings?: ListingType[],
+  listings: ListingType[] = [],
   googlePlaceId?: string,
   config: GetDirectionsConfig = {
     route: false,
@@ -84,12 +84,10 @@ export const getDirections = (
       return getDirectionsBing(query, config.route);
 
     default:
-      const gmb = getListingByProvider(
-        listings,
-        ListingPublisherOption.GOOGLEMYBUSINESS
-      );
-      if (gmb) {
-        return gmb.listingUrl;
+      const listingsMap: { [key in ListingPublisher]?: string } | undefined =
+        listings?.reduce((obj, listing) => ({...obj, [listing.publisher]: listing.listingUrl}), {});
+      if (listingsMap[ListingPublisherOption.GOOGLEMYBUSINESS]) {
+        return listingsMap[ListingPublisherOption.GOOGLEMYBUSINESS];
       }
 
       if (googlePlaceId) {
@@ -170,22 +168,6 @@ const getDirectionsGoogle = (query: string, route?: boolean): string => {
   return route
     ? `https://maps.google.com/maps/dir/?api=1&destination=${query}`
     : `https://maps.google.com/maps/search/?api=1&query=${query}`;
-};
-
-/**
- * Get a maps url from listings
- *
- * @param {ListingType[]} listings - Yext listings
- * @param {ListingPublisher} publisher - provider to get listing for
- * @returns {string} - url
- */
-const getListingByProvider = (
-  listings: ListingType[] = [],
-  publisher: ListingPublisher
-): ListingType | undefined => {
-  // TODO: Extract cid from URL to use in directions search
-  const gmb = listings.find((l) => l.publisher === publisher);
-  return gmb;
 };
 
 /**

--- a/packages/pages/src/components/address/methods.ts
+++ b/packages/pages/src/components/address/methods.ts
@@ -47,18 +47,19 @@ export const getDirections = (
   googlePlaceId?: string,
   config: GetDirectionsConfig = {
     route: false,
-  },
+  }
 ): string | undefined => {
-
   // Default query for all providers
-  let query = address && encodeArray([
-    address.line1,
-    address.line2,
-    address.city,
-    address.region,
-    address.postalCode,
-    address.countryCode,
-  ]);
+  let query =
+    address &&
+    encodeArray([
+      address.line1,
+      address.line2,
+      address.city,
+      address.region,
+      address.postalCode,
+      address.countryCode,
+    ]);
 
   switch (config.provider) {
     case MapProviderOption.APPLE:
@@ -68,12 +69,14 @@ export const getDirections = (
       return getDirectionsApple(query, config.route);
 
     case MapProviderOption.BING:
-      query = address && encodeArray([
-        address.line1,
-        address.city,
-        address.region,
-        address.postalCode,
-      ]);
+      query =
+        address &&
+        encodeArray([
+          address.line1,
+          address.city,
+          address.region,
+          address.postalCode,
+        ]);
 
       // Bing Maps requires a query
       if (!query) break;
@@ -81,17 +84,16 @@ export const getDirections = (
       return getDirectionsBing(query, config.route);
 
     default:
-      const gmb = getListingByProvider(listings, ListingPublisherOption.GOOGLEMYBUSINESS);
+      const gmb = getListingByProvider(
+        listings,
+        ListingPublisherOption.GOOGLEMYBUSINESS
+      );
       if (gmb) {
         return gmb.listingUrl;
       }
 
       if (googlePlaceId) {
-        return getDirectionsGooglePlaceID(
-          googlePlaceId,
-          query,
-          config.route
-        );
+        return getDirectionsGooglePlaceID(googlePlaceId, query, config.route);
       }
 
       // Google Maps without Listings data requires a query
@@ -146,9 +148,9 @@ const getDirectionsGooglePlaceID = (
 ): string => {
   const queryParam = query ? `&query=${query}` : ``;
   if (route) {
-    return `https://maps.google.com/maps/dir/?api=1${queryParam}&destination_place_id=${placeId}&destination=direct`
+    return `https://maps.google.com/maps/dir/?api=1${queryParam}&destination_place_id=${placeId}&destination=direct`;
   }
-  
+
   if (queryParam) {
     `https://maps.google.com/maps/search/?api=1${queryParam}&query_place_id=${placeId}`;
   }

--- a/packages/pages/src/components/address/methods.ts
+++ b/packages/pages/src/components/address/methods.ts
@@ -4,7 +4,6 @@ import {
   ListingPublisher,
   ListingPublisherOption,
   ListingType,
-  MapProvider,
   MapProviderOption,
 } from "./types";
 
@@ -49,6 +48,7 @@ export const getDirections = (
     route: false,
   }
 ): string | undefined => {
+  const NO_QUERY_WARNING = 'Failed to construct query for maps service.';
   // Default query for all providers
   let query =
     address &&
@@ -64,7 +64,10 @@ export const getDirections = (
   switch (config.provider) {
     case MapProviderOption.APPLE:
       // Apple Maps requires a query string
-      if (!query) break;
+      if (!query) {
+        console.warn(`${NO_QUERY_WARNING} Check that you've provided a valid Yext Address.`);
+        break;
+      }
 
       return getDirectionsApple(query, config.route);
 
@@ -79,7 +82,10 @@ export const getDirections = (
         ]);
 
       // Bing Maps requires a query
-      if (!query) break;
+      if (!query) {
+        console.warn(`${NO_QUERY_WARNING} Check that you've provided a valid Yext Address.`);
+        break;
+      }
 
       return getDirectionsBing(query, config.route);
 
@@ -101,7 +107,10 @@ export const getDirections = (
       }
 
       // Google Maps without Listings data requires a query
-      if (!query) break;
+      if (!query) {
+        console.warn(`${NO_QUERY_WARNING} Check that you've provided a valid Yext Address, Yext ListingType, or Google Place ID.`);
+        break;
+      }
 
       return getDirectionsGoogle(query, config.route);
   }

--- a/packages/pages/src/components/address/methods.ts
+++ b/packages/pages/src/components/address/methods.ts
@@ -1,4 +1,9 @@
-import { AddressType, ListingPublisher, ListingType, MapProvider } from "./types";
+import {
+  AddressType,
+  ListingPublisher,
+  ListingType,
+  MapProvider,
+} from "./types";
 
 /**
  * Get the unabbreviated version of a field if available
@@ -25,69 +30,92 @@ export const getUnabbreviated = (
 
 /**
  * Get a third-party maps url for a Yext location
- * 
+ *
  * @param {any} profile - Partial of Yext Location entity profile
  * @param {Provider} provider - Google, Apple, Bing
  * @param {boolean} directions - Enable driving directions
- * 
+ *
  * @returns {string} - Maps service url
  */
-export const getDirections = (profile: any, provider?: MapProvider, directions?: boolean): string | undefined => {
+export const getDirections = (
+  profile: any,
+  provider?: MapProvider,
+  directions?: boolean
+): string | undefined => {
   // TODO: replace profile type any with partial type declaration for profile
   if (!profile.ref_listings && !profile.address) return undefined;
   const { address } = profile;
 
-  let query = encodeArray([address?.line1, address?.line2, address?.city, address?.region, address?.postalCode, address?.countryCode]);
+  let query = encodeArray([
+    address?.line1,
+    address?.line2,
+    address?.city,
+    address?.region,
+    address?.postalCode,
+    address?.countryCode,
+  ]);
 
   switch (provider) {
-    case 'APPLE':
+    case "APPLE":
       return getDirectionsApple(query, directions);
       break;
-    case 'BING':
-      query = encodeArray([address?.line1, address?.city, address?.region, address?.postalCode]);
+    case "BING":
+      query = encodeArray([
+        address?.line1,
+        address?.city,
+        address?.region,
+        address?.postalCode,
+      ]);
       return getDirectionsBing(query, directions);
       break;
     default:
-      const gmbURL = getlistingUrl(profile.ref_listings, ListingPublisher.googlemybusiness);
+      const gmbURL = getlistingUrl(
+        profile.ref_listings,
+        ListingPublisher.googlemybusiness
+      );
       if (gmbURL) {
         return gmbURL;
       }
 
       if (profile.googlePlaceId) {
-        return getDirectionsGooglePlaceID(profile.googlePlaceId, query, directions);
+        return getDirectionsGooglePlaceID(
+          profile.googlePlaceId,
+          query,
+          directions
+        );
       }
 
       return getDirectionsGoogle(query, directions);
   }
-}
+};
 
 /**
  * Get Apple Maps location query
- * 
+ *
  * @param {string} query - Stringified address query
  * @param {boolean} directions
- * 
+ *
  * @returns {string} - Apple maps url
  */
 const getDirectionsApple = (query: string, directions?: boolean): string => {
   return directions
     ? `https://maps.apple.com/?daddr=${query}`
     : `https://maps.apple.com/?address=${query}`;
-}
+};
 
 /**
  * Get Bing Maps location query
  *
  * @param {string} query - Stringified address query
  * @param {string} directions
- * 
+ *
  * @returns {string} - Bing maps url
  */
 const getDirectionsBing = (query: string, directions?: boolean): string => {
   return directions
     ? `https://bing.com/maps/default.aspx?rtp=adr.${query}`
-    : `https://bing.com/maps/default.aspx?where1=${query}`
-}
+    : `https://bing.com/maps/default.aspx?where1=${query}`;
+};
 
 /**
  * Get a Google Maps Place ID page
@@ -97,11 +125,15 @@ const getDirectionsBing = (query: string, directions?: boolean): string => {
  * @param {boolean} directions - Enable driving directions
  * @returns {string} - Google maps url
  */
-const getDirectionsGooglePlaceID = (placeId: string, query: string, directions?: boolean): string => {
+const getDirectionsGooglePlaceID = (
+  placeId: string,
+  query: string,
+  directions?: boolean
+): string => {
   return directions
     ? `https://maps.google.com/maps/dir/?api=1&destination_place_id=${placeId}&destination=direct`
     : `https://maps.google.com/maps/search/?api=1&query=${query}&query_place_id=${placeId}`;
-}
+};
 
 /**
  * Get a Google Maps search query
@@ -114,7 +146,7 @@ const getDirectionsGoogle = (query: string, directions?: boolean): string => {
   return directions
     ? `https://maps.google.com/maps/dir/?api=1&destination=${query}`
     : `https://maps.google.com/maps/search/?api=1&query=${query}`;
-}
+};
 
 /**
  * Get a maps url from listings
@@ -123,11 +155,14 @@ const getDirectionsGoogle = (query: string, directions?: boolean): string => {
  * @param {ListingPublisher} publisher - provider to get listing for
  * @returns {string} - url
  */
-const getlistingUrl = (listings: ListingType[] = [], publisher: ListingPublisher): string | undefined => {
-   // TODO: Extract cid from URL to use in directions search
-  const gmb = listings.find(l => l.publisher === publisher);
+const getlistingUrl = (
+  listings: ListingType[] = [],
+  publisher: ListingPublisher
+): string | undefined => {
+  // TODO: Extract cid from URL to use in directions search
+  const gmb = listings.find((l) => l.publisher === publisher);
   return gmb?.listingUrl;
-}
+};
 
 /**
  * Convert an array of values like address parts to a url readable string
@@ -136,8 +171,8 @@ const getlistingUrl = (listings: ListingType[] = [], publisher: ListingPublisher
  * @returns {string} - url friendly string
  */
 const encodeArray = (substrings: string[] = []): string => {
-  if (!substrings.length) return '';
+  if (!substrings.length) return "";
 
-  const str = substrings.filter(Boolean).join(', ');
+  const str = substrings.filter(Boolean).join(", ");
   return encodeURI(str);
-}
+};

--- a/packages/pages/src/components/address/methods.ts
+++ b/packages/pages/src/components/address/methods.ts
@@ -1,4 +1,4 @@
-import { AddressType } from "./types";
+import { AddressType, ListingPublisher, ListingType, MapProvider } from "./types";
 
 /**
  * Get the unabbreviated version of a field if available
@@ -22,3 +22,122 @@ export const getUnabbreviated = (
 
   return unabbreviatedField && address[unabbreviatedField];
 };
+
+/**
+ * Get a third-party maps url for a Yext location
+ * 
+ * @param {any} profile - Partial of Yext Location entity profile
+ * @param {Provider} provider - Google, Apple, Bing
+ * @param {boolean} directions - Enable driving directions
+ * 
+ * @returns {string} - Maps service url
+ */
+export const getDirections = (profile: any, provider?: MapProvider, directions?: boolean): string | undefined => {
+  // TODO: replace profile type any with partial type declaration for profile
+  if (!profile.ref_listings && !profile.address) return undefined;
+  const { address } = profile;
+
+  let query = encodeArray([address?.line1, address?.line2, address?.city, address?.region, address?.postalCode, address?.countryCode]);
+
+  switch (provider) {
+    case 'APPLE':
+      return getDirectionsApple(query, directions);
+      break;
+    case 'BING':
+      query = encodeArray([address?.line1, address?.city, address?.region, address?.postalCode]);
+      return getDirectionsBing(query, directions);
+      break;
+    default:
+      const gmbURL = getlistingUrl(profile.ref_listings, ListingPublisher.googlemybusiness);
+      if (gmbURL) {
+        return gmbURL;
+      }
+
+      if (profile.googlePlaceId) {
+        return getDirectionsGooglePlaceID(profile.googlePlaceId, query, directions);
+      }
+
+      return getDirectionsGoogle(query, directions);
+  }
+}
+
+/**
+ * Get Apple Maps location query
+ * 
+ * @param {string} query - Stringified address query
+ * @param {boolean} directions
+ * 
+ * @returns {string} - Apple maps url
+ */
+const getDirectionsApple = (query: string, directions?: boolean): string => {
+  return directions
+    ? `https://maps.apple.com/?daddr=${query}`
+    : `https://maps.apple.com/?address=${query}`;
+}
+
+/**
+ * Get Bing Maps location query
+ *
+ * @param {string} query - Stringified address query
+ * @param {string} directions
+ * 
+ * @returns {string} - Bing maps url
+ */
+const getDirectionsBing = (query: string, directions?: boolean): string => {
+  return directions
+    ? `https://bing.com/maps/default.aspx?rtp=adr.${query}`
+    : `https://bing.com/maps/default.aspx?where1=${query}`
+}
+
+/**
+ * Get a Google Maps Place ID page
+ *
+ * @param {string} placeId - Stringified address query
+ * @param {string} query - Stringified address query
+ * @param {boolean} directions - Enable driving directions
+ * @returns {string} - Google maps url
+ */
+const getDirectionsGooglePlaceID = (placeId: string, query: string, directions?: boolean): string => {
+  return directions
+    ? `https://maps.google.com/maps/dir/?api=1&destination_place_id=${placeId}&destination=direct`
+    : `https://maps.google.com/maps/search/?api=1&query=${query}&query_place_id=${placeId}`;
+}
+
+/**
+ * Get a Google Maps search query
+ *
+ * @param {string} query - Stringified address query
+ * @param {boolean} directions - Enable driving directions
+ * @returns {string} - Google maps url
+ */
+const getDirectionsGoogle = (query: string, directions?: boolean): string => {
+  return directions
+    ? `https://maps.google.com/maps/dir/?api=1&destination=${query}`
+    : `https://maps.google.com/maps/search/?api=1&query=${query}`;
+}
+
+/**
+ * Get a maps url from listings
+ *
+ * @param {Yext.ListingType[]} listings - Yext listings
+ * @param {ListingPublisher} publisher - provider to get listing for
+ * @returns {string} - url
+ */
+const getlistingUrl = (listings: ListingType[] = [], publisher: ListingPublisher): string | undefined => {
+   // TODO: Extract cid from URL to use in directions search
+  const gmb = listings.find(l => l.publisher === publisher);
+  return gmb?.listingUrl;
+}
+
+/**
+ * Convert an array of values like address parts to a url readable string
+ *
+ * @param {string} substrings - ordered list to encode as csv
+ * @returns {string} - url friendly string
+ */
+const encodeArray = (substrings: string[] = []): string => {
+  if (!substrings.length) return '';
+
+  const str = substrings.filter(Boolean).join(', ');
+  return encodeURI(str);
+}

--- a/packages/pages/src/components/address/methods.ts
+++ b/packages/pages/src/components/address/methods.ts
@@ -85,7 +85,13 @@ export const getDirections = (
 
     default:
       const listingsMap: { [key in ListingPublisher]?: string } | undefined =
-        listings?.reduce((obj, listing) => ({...obj, [listing.publisher]: listing.listingUrl}), {});
+        listings?.reduce(
+          (obj, listing) => ({
+            ...obj,
+            [listing.publisher]: listing.listingUrl,
+          }),
+          {}
+        );
       if (listingsMap[ListingPublisherOption.GOOGLEMYBUSINESS]) {
         return listingsMap[ListingPublisherOption.GOOGLEMYBUSINESS];
       }

--- a/packages/pages/src/components/address/types.ts
+++ b/packages/pages/src/components/address/types.ts
@@ -43,21 +43,54 @@ export type AddressLineProps = {
 
 /**
  * The available listing publishers
+ * 
+ * @public
  */
-export enum ListingPublisher {
-  googlemybusiness = "googlemybusiness",
-}
+export const ListingPublisherOption = {
+  GOOGLEMYBUSINESS: "googlemybusiness",
+} as const;
+
+/**
+ * The type definition for the listing publisher
+ * 
+ * @public
+ */
+export type ListingPublisher =
+  typeof ListingPublisherOption[keyof typeof ListingPublisherOption];
 
 /**
  * The type definition for a Listing
+ * 
+ * @public
  */
 export interface ListingType {
   listingUrl: string;
   publisher: ListingPublisher;
 }
 
-export enum MapProvider {
-  Google = "GOOGLE",
-  Apple = "APPLE",
-  Bing = "BING",
+/**
+ * The available map providers
+ * 
+ * @public
+ */
+export const MapProviderOption = {
+  GOOGLE: "google",
+  APPLE: "apple",
+  BING: "bing",
+} as const;
+
+/**
+ * The type definition for the map provider
+ * 
+ * @public
+ */
+ export type MapProvider =
+ typeof MapProviderOption[keyof typeof MapProviderOption];
+
+/**
+ * The Yext profile fields used to create a getDirections URL
+ */
+export interface GetDirectionsConfig {
+  provider?: MapProvider;
+  route?: boolean;
 }

--- a/packages/pages/src/components/address/types.ts
+++ b/packages/pages/src/components/address/types.ts
@@ -43,7 +43,7 @@ export type AddressLineProps = {
 
 /**
  * The available listing publishers
- * 
+ *
  * @public
  */
 export const ListingPublisherOption = {
@@ -52,7 +52,7 @@ export const ListingPublisherOption = {
 
 /**
  * The type definition for the listing publisher
- * 
+ *
  * @public
  */
 export type ListingPublisher =
@@ -60,7 +60,7 @@ export type ListingPublisher =
 
 /**
  * The type definition for a Listing
- * 
+ *
  * @public
  */
 export interface ListingType {
@@ -70,7 +70,7 @@ export interface ListingType {
 
 /**
  * The available map providers
- * 
+ *
  * @public
  */
 export const MapProviderOption = {
@@ -81,11 +81,11 @@ export const MapProviderOption = {
 
 /**
  * The type definition for the map provider
- * 
+ *
  * @public
  */
- export type MapProvider =
- typeof MapProviderOption[keyof typeof MapProviderOption];
+export type MapProvider =
+  typeof MapProviderOption[keyof typeof MapProviderOption];
 
 /**
  * The Yext profile fields used to create a getDirections URL

--- a/packages/pages/src/components/address/types.ts
+++ b/packages/pages/src/components/address/types.ts
@@ -40,3 +40,24 @@ export type AddressLineProps = {
   line: AddressLine;
   separator?: string;
 };
+
+/**
+ * The available listing publishers
+ */
+export enum ListingPublisher {
+  googlemybusiness = 'googlemybusiness',
+}
+
+/**
+ * The type definition for a Listing
+ */
+export interface ListingType {
+  listingUrl: string;
+  publisher: ListingPublisher;
+}
+
+export enum MapProvider {
+  Google = 'GOOGLE',
+  Apple = 'APPLE',
+  Bing = 'BING',
+}

--- a/packages/pages/src/components/address/types.ts
+++ b/packages/pages/src/components/address/types.ts
@@ -45,7 +45,7 @@ export type AddressLineProps = {
  * The available listing publishers
  */
 export enum ListingPublisher {
-  googlemybusiness = 'googlemybusiness',
+  googlemybusiness = "googlemybusiness",
 }
 
 /**
@@ -57,7 +57,7 @@ export interface ListingType {
 }
 
 export enum MapProvider {
-  Google = 'GOOGLE',
-  Apple = 'APPLE',
-  Bing = 'BING',
+  Google = "GOOGLE",
+  Apple = "APPLE",
+  Bing = "BING",
 }

--- a/packages/pages/src/components/hours/sampleData.ts
+++ b/packages/pages/src/components/hours/sampleData.ts
@@ -65,7 +65,7 @@ export const HOURS_WITH_HOLIDAY: HoursType = {
   },
   holidayHours: [
     {
-      date: offsetDate(3),
+      date: "2022-08-11",
       openIntervals: [{ start: "9:00", end: "12:00" }],
     },
   ],
@@ -103,7 +103,7 @@ export const HOURS_WITH_REOPEN_DATE = {
   reopenDate: offsetDate(3),
 };
 
-function offsetDate(daysForward: number) {
+export function offsetDate(daysForward: number) {
   const d = new Date();
 
   d.setDate(d.getDate() + daysForward);

--- a/packages/pages/src/components/hours/sampleData.ts
+++ b/packages/pages/src/components/hours/sampleData.ts
@@ -65,7 +65,7 @@ export const HOURS_WITH_HOLIDAY: HoursType = {
   },
   holidayHours: [
     {
-      date: "2022-08-11",
+      date: offsetDate(3),
       openIntervals: [{ start: "9:00", end: "12:00" }],
     },
   ],
@@ -100,5 +100,24 @@ export const HOURS_WITH_REOPEN_DATE = {
     isClosed: false,
     openIntervals: [{ start: "9:07", end: "18:07" }],
   },
-  reopenDate: "2022-08-11",
+  reopenDate: offsetDate(3),
 };
+
+function offsetDate(daysForward: number) {
+  const d = new Date();
+
+  d.setDate(d.getDate() + daysForward);
+
+  let yyyy = '' + d.getFullYear(),
+      mm = '' + (d.getMonth() + 1),
+      dd = '' + (d.getDate());
+  
+  if (mm.length < 2) {
+    mm = '0' + mm;
+  }
+  if (dd.length < 2) {
+    dd = '0' + dd;
+  }
+
+  return [yyyy, mm, dd].join('-');
+}


### PR DESCRIPTION
power 'Get Directions' CTAs. This function follows a hierarchy of methods to derive an entities map url, starting with using the GMB id managed by Listings. There are two TODOs which would align us completely with classic pages behviour once we know more about how a GMB/streams data structure, this shouldn't be considered blocking.

J=CR-2816