### PR TITLE
chore: add dev/plugin as title option

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -28,3 +28,4 @@ jobs:
             plugin
             components
             util
+            dev/plugin


### PR DESCRIPTION
Some changes affect both the plugin and dev mode. This adds this as a valid scope.