### PR TITLE
fix(components): fix un-gated window access in analytics component

### DIFF
--- a/packages/pages/src/components/analytics/hooks.ts
+++ b/packages/pages/src/components/analytics/hooks.ts
@@ -1,5 +1,6 @@
 import { ConversionDetails, Visitor } from "@yext/analytics";
 import { useContext } from "react";
+import { getRuntime } from "../../util";
 import { AnalyticsContext } from "./context";
 import { concatScopes } from "./helpers";
 import { AnalyticsMethods } from "./interfaces";
@@ -28,7 +29,7 @@ export function useAnalytics(): AnalyticsMethods {
   }
 
   // TODO: is this the right way / place to expose a callback for use by a Cookie Management banner?
-  if (!window.setAnalyticsOptIn) {
+  if (getRuntime().name === "browser" && !window.setAnalyticsOptIn) {
     window.setAnalyticsOptIn = async () => {
       await ctx.optIn();
     };


### PR DESCRIPTION
The setAnalyticsOptIn function was being added to the window by
the AnalyticsProvider regardless of the runtime, causing 500 errors.

The window object can only be reliably accessed when gated by a
getRuntime().name === "browser" check.

We need further research on how to test all components for respecting
run time dependent functionality.

After some additional research, it does not appear that there is a good
solution for asserting that a component should not fail to render server
side.  

Some threads:
https://github.com/testing-library/react-testing-library/issues/561
https://github.com/testing-library/react-testing-library/issues/1080


J=none
TEST=none