### PR TITLE
fix(plugin): add features.json generation back to build plugin

### DIFF
--- a/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
@@ -9,6 +9,7 @@ import {
   loadTemplateModules,
   TemplateModuleCollection,
 } from "../../../common/src/template/internal/loader.js";
+import { createFeaturesJson } from "../../../generate/features.js";
 
 export default (projectStructure: ProjectStructure) => {
   return async () => {
@@ -30,6 +31,16 @@ export default (projectStructure: ProjectStructure) => {
       return;
     }
 
+    finisher = logger.timedLog({ startLog: "Writing features.json" });
+    try {
+      createFeaturesJson(templateModules, path.join("./sites-config/features.json"));
+      finisher.succeed("Successfully wrote features.json");
+    } catch (e: any) {
+      finisher.fail("Failed to write features.json");
+      console.error(colors.red(e.message));
+      return;
+    }
+
     finisher = logger.timedLog({ startLog: "Writing manifest.json" });
     try {
       await generateManifestFile(templateModules, projectStructure);
@@ -37,6 +48,7 @@ export default (projectStructure: ProjectStructure) => {
     } catch (e: any) {
       finisher.fail("Failed to write manifest.json");
       console.error(colors.red(e.message));
+      return;
     }
   };
 };

--- a/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
@@ -33,7 +33,10 @@ export default (projectStructure: ProjectStructure) => {
 
     finisher = logger.timedLog({ startLog: "Writing features.json" });
     try {
-      createFeaturesJson(templateModules, path.join("./sites-config/features.json"));
+      createFeaturesJson(
+        templateModules,
+        path.join("./sites-config/features.json")
+      );
       finisher.succeed("Successfully wrote features.json");
     } catch (e: any) {
       finisher.fail("Failed to write features.json");


### PR DESCRIPTION
Prior work was done to extract features.json generation from the build plugin. Unfortunately this is causing problems to run as a separate `pages` command in the YextCI system due to the experimental node flag required (which is actually only needed for the dev command). In order to avoid the issue in the meantime so we can unblock people and cut new releases, add the features generation back to the build as it was beforehand. Users can still generate features.json themselves though.