### PR TITLE
feat(util): add isServerSide to getRuntime

### DIFF
--- a/packages/pages/CHANGELOG.md
+++ b/packages/pages/CHANGELOG.md
@@ -1,41 +1,37 @@
 # 1.0.0-beta.5 (2022-08-30)
 
-
 ### Bug Fixes
 
-* **components:** add environment compatibility to mktgcdn urls ([#167](https://github.com/yext/sites-scripts/issues/167)) ([5565bc7](https://github.com/yext/sites-scripts/commit/5565bc73e9cd153317da9a7dff47b49d28b99733))
-* **components:** fix un-gated window access in analytics component ([#186](https://github.com/yext/sites-scripts/issues/186)) ([47c7589](https://github.com/yext/sites-scripts/commit/47c75894b5a21a5fa8526eca7bdfad2b49c5e169))
-* **components:** image url now correctly handles envs ([#192](https://github.com/yext/sites-scripts/issues/192)) ([b5d3db0](https://github.com/yext/sites-scripts/commit/b5d3db073ea36086036de1f99ffc106fcd8e5c24))
-* **dev/plugin:** address incompatibilities with windows ([#173](https://github.com/yext/sites-scripts/issues/173)) ([de67065](https://github.com/yext/sites-scripts/commit/de670656d584482f55b18079104dda8d39a53941))
-* **dev:** add newline to error messages ([#175](https://github.com/yext/sites-scripts/issues/175)) ([2f88862](https://github.com/yext/sites-scripts/commit/2f888629a77e72a179d73bb057125a6c33df94a1))
-* **dev:** fix template path import for windows ([#177](https://github.com/yext/sites-scripts/issues/177)) ([9a8b7f3](https://github.com/yext/sites-scripts/commit/9a8b7f3e885bf61f0bc549cf360e028c6ada6060)), closes [#170](https://github.com/yext/sites-scripts/issues/170) [#173](https://github.com/yext/sites-scripts/issues/173)
-* **dev:** honor feature name casing in local dev url (fixes [#121](https://github.com/yext/sites-scripts/issues/121)) ([#146](https://github.com/yext/sites-scripts/issues/146)) ([e6fb9f2](https://github.com/yext/sites-scripts/commit/e6fb9f2f759d9e93101512e2270053a0157beba8))
-* **dev:** prevent crashing on empty id ([#169](https://github.com/yext/sites-scripts/issues/169)) ([ffca6de](https://github.com/yext/sites-scripts/commit/ffca6de0d01ffde2cdab1c7bce347cba689fb4f3)), closes [#168](https://github.com/yext/sites-scripts/issues/168)
-* improve errors related to undefined getPath (fixes [#130](https://github.com/yext/sites-scripts/issues/130)) ([#138](https://github.com/yext/sites-scripts/issues/138)) ([37b33d0](https://github.com/yext/sites-scripts/commit/37b33d00f75b8acb7e232d2935c173f98347cb21))
-* index page incorrectly saying there is no localData (fix [#135](https://github.com/yext/sites-scripts/issues/135)) ([#136](https://github.com/yext/sites-scripts/issues/136)) ([dd272d2](https://github.com/yext/sites-scripts/commit/dd272d2977ac76bf416965382b44fcc199c2c869))
-* **plugin:** add features.json generation back to build plugin ([#187](https://github.com/yext/sites-scripts/issues/187)) ([4650f55](https://github.com/yext/sites-scripts/commit/4650f5574fedcc1acbf2b75e18201cda962c98ac))
-* update bundler plugin copying ([#111](https://github.com/yext/sites-scripts/issues/111)) ([c602104](https://github.com/yext/sites-scripts/commit/c602104d8f921b47842c2a245fa4c89b571caf80)), closes [#109](https://github.com/yext/sites-scripts/issues/109) [#109](https://github.com/yext/sites-scripts/issues/109)
-* update getRuntime to work with the plugins system ([#161](https://github.com/yext/sites-scripts/issues/161)) ([02aee27](https://github.com/yext/sites-scripts/commit/02aee279a95f7a82905e463a346aaa5ff7301164))
-* **util:** guard window check when getting deno version ([#188](https://github.com/yext/sites-scripts/issues/188)) ([e9e4cd1](https://github.com/yext/sites-scripts/commit/e9e4cd1a1cbbb80ed1bc6bf3e6932132a9cdde8d))
-
+- **components:** add environment compatibility to mktgcdn urls ([#167](https://github.com/yext/sites-scripts/issues/167)) ([5565bc7](https://github.com/yext/sites-scripts/commit/5565bc73e9cd153317da9a7dff47b49d28b99733))
+- **components:** fix un-gated window access in analytics component ([#186](https://github.com/yext/sites-scripts/issues/186)) ([47c7589](https://github.com/yext/sites-scripts/commit/47c75894b5a21a5fa8526eca7bdfad2b49c5e169))
+- **components:** image url now correctly handles envs ([#192](https://github.com/yext/sites-scripts/issues/192)) ([b5d3db0](https://github.com/yext/sites-scripts/commit/b5d3db073ea36086036de1f99ffc106fcd8e5c24))
+- **dev/plugin:** address incompatibilities with windows ([#173](https://github.com/yext/sites-scripts/issues/173)) ([de67065](https://github.com/yext/sites-scripts/commit/de670656d584482f55b18079104dda8d39a53941))
+- **dev:** add newline to error messages ([#175](https://github.com/yext/sites-scripts/issues/175)) ([2f88862](https://github.com/yext/sites-scripts/commit/2f888629a77e72a179d73bb057125a6c33df94a1))
+- **dev:** fix template path import for windows ([#177](https://github.com/yext/sites-scripts/issues/177)) ([9a8b7f3](https://github.com/yext/sites-scripts/commit/9a8b7f3e885bf61f0bc549cf360e028c6ada6060)), closes [#170](https://github.com/yext/sites-scripts/issues/170) [#173](https://github.com/yext/sites-scripts/issues/173)
+- **dev:** honor feature name casing in local dev url (fixes [#121](https://github.com/yext/sites-scripts/issues/121)) ([#146](https://github.com/yext/sites-scripts/issues/146)) ([e6fb9f2](https://github.com/yext/sites-scripts/commit/e6fb9f2f759d9e93101512e2270053a0157beba8))
+- **dev:** prevent crashing on empty id ([#169](https://github.com/yext/sites-scripts/issues/169)) ([ffca6de](https://github.com/yext/sites-scripts/commit/ffca6de0d01ffde2cdab1c7bce347cba689fb4f3)), closes [#168](https://github.com/yext/sites-scripts/issues/168)
+- improve errors related to undefined getPath (fixes [#130](https://github.com/yext/sites-scripts/issues/130)) ([#138](https://github.com/yext/sites-scripts/issues/138)) ([37b33d0](https://github.com/yext/sites-scripts/commit/37b33d00f75b8acb7e232d2935c173f98347cb21))
+- index page incorrectly saying there is no localData (fix [#135](https://github.com/yext/sites-scripts/issues/135)) ([#136](https://github.com/yext/sites-scripts/issues/136)) ([dd272d2](https://github.com/yext/sites-scripts/commit/dd272d2977ac76bf416965382b44fcc199c2c869))
+- **plugin:** add features.json generation back to build plugin ([#187](https://github.com/yext/sites-scripts/issues/187)) ([4650f55](https://github.com/yext/sites-scripts/commit/4650f5574fedcc1acbf2b75e18201cda962c98ac))
+- update bundler plugin copying ([#111](https://github.com/yext/sites-scripts/issues/111)) ([c602104](https://github.com/yext/sites-scripts/commit/c602104d8f921b47842c2a245fa4c89b571caf80)), closes [#109](https://github.com/yext/sites-scripts/issues/109) [#109](https://github.com/yext/sites-scripts/issues/109)
+- update getRuntime to work with the plugins system ([#161](https://github.com/yext/sites-scripts/issues/161)) ([02aee27](https://github.com/yext/sites-scripts/commit/02aee279a95f7a82905e463a346aaa5ff7301164))
+- **util:** guard window check when getting deno version ([#188](https://github.com/yext/sites-scripts/issues/188)) ([e9e4cd1](https://github.com/yext/sites-scripts/commit/e9e4cd1a1cbbb80ed1bc6bf3e6932132a9cdde8d))
 
 ### Features
 
-* add alternateLanguageFields to the template config ([#112](https://github.com/yext/sites-scripts/issues/112)) ([c53b08d](https://github.com/yext/sites-scripts/commit/c53b08d671ffbd086d5ea19d48855ef297462634))
-* **components:** add `Image` component ([#144](https://github.com/yext/sites-scripts/issues/144)) ([f6bad2c](https://github.com/yext/sites-scripts/commit/f6bad2c733a1aff69372babad48b4cc08c17d525))
-* **components:** add Address component ([#159](https://github.com/yext/sites-scripts/issues/159)) ([c93b960](https://github.com/yext/sites-scripts/commit/c93b96039163b10123976943d5dd7e89258bc54d))
-* **components:** add AnalyticsProvider ([#151](https://github.com/yext/sites-scripts/issues/151)) ([be32c2c](https://github.com/yext/sites-scripts/commit/be32c2cb0577ec904e96be72185eb554cd5d22ab))
-* **components:** add Hours component ([#163](https://github.com/yext/sites-scripts/issues/163)) ([b9efd30](https://github.com/yext/sites-scripts/commit/b9efd30e925ad62ca1d37ece7cfae3e6ab70504b))
-* **components:** add Link component ([#158](https://github.com/yext/sites-scripts/issues/158)) ([436464d](https://github.com/yext/sites-scripts/commit/436464dcf80cf3cab61ffb0b81d1efbb6e878c89))
-* **components:** add support for simple image fields ([#180](https://github.com/yext/sites-scripts/issues/180)) ([15cb86b](https://github.com/yext/sites-scripts/commit/15cb86b02800d521d2a23daa09b932c0b4c6dc99)), closes [#156](https://github.com/yext/sites-scripts/issues/156) [#155](https://github.com/yext/sites-scripts/issues/155)
-* **dev:** redirect if url ends in final slash (closes [#143](https://github.com/yext/sites-scripts/issues/143)) ([#148](https://github.com/yext/sites-scripts/issues/148)) ([61d38e9](https://github.com/yext/sites-scripts/commit/61d38e943915d55004e55d1ba4cd556ec7fc9947))
-* **dev:** support alternate languages via `locale` query param ([#141](https://github.com/yext/sites-scripts/issues/141)) ([3aa60c8](https://github.com/yext/sites-scripts/commit/3aa60c8d96b279eea5674af6ff0e43f852f00657))
-* extract features.json generation into its own command ([#170](https://github.com/yext/sites-scripts/issues/170)) ([6a7f2a4](https://github.com/yext/sites-scripts/commit/6a7f2a43d7429790fd08c4b6935b9f254e8eb4d2))
-* **plugin:** validate file sizes (closes [#145](https://github.com/yext/sites-scripts/issues/145)) ([#147](https://github.com/yext/sites-scripts/issues/147)) ([6a16d2a](https://github.com/yext/sites-scripts/commit/6a16d2a7efe3a4f91f096e2b88bcbbddbc53b324))
-* **util:** add fetch and runtime functions ([#118](https://github.com/yext/sites-scripts/issues/118)) ([207fc63](https://github.com/yext/sites-scripts/commit/207fc63a2aa69e0d04dc72e32ded98a2a9231bee)), closes [#117](https://github.com/yext/sites-scripts/issues/117) [#119](https://github.com/yext/sites-scripts/issues/119) [#120](https://github.com/yext/sites-scripts/issues/120) [#124](https://github.com/yext/sites-scripts/issues/124) [#125](https://github.com/yext/sites-scripts/issues/125) [#126](https://github.com/yext/sites-scripts/issues/126)
-* **util:** add isProduction function ([#150](https://github.com/yext/sites-scripts/issues/150)) ([f89f45d](https://github.com/yext/sites-scripts/commit/f89f45da584ec196f519e30c95124fcf2e4ae11c))
-
-
+- add alternateLanguageFields to the template config ([#112](https://github.com/yext/sites-scripts/issues/112)) ([c53b08d](https://github.com/yext/sites-scripts/commit/c53b08d671ffbd086d5ea19d48855ef297462634))
+- **components:** add `Image` component ([#144](https://github.com/yext/sites-scripts/issues/144)) ([f6bad2c](https://github.com/yext/sites-scripts/commit/f6bad2c733a1aff69372babad48b4cc08c17d525))
+- **components:** add Address component ([#159](https://github.com/yext/sites-scripts/issues/159)) ([c93b960](https://github.com/yext/sites-scripts/commit/c93b96039163b10123976943d5dd7e89258bc54d))
+- **components:** add AnalyticsProvider ([#151](https://github.com/yext/sites-scripts/issues/151)) ([be32c2c](https://github.com/yext/sites-scripts/commit/be32c2cb0577ec904e96be72185eb554cd5d22ab))
+- **components:** add Hours component ([#163](https://github.com/yext/sites-scripts/issues/163)) ([b9efd30](https://github.com/yext/sites-scripts/commit/b9efd30e925ad62ca1d37ece7cfae3e6ab70504b))
+- **components:** add Link component ([#158](https://github.com/yext/sites-scripts/issues/158)) ([436464d](https://github.com/yext/sites-scripts/commit/436464dcf80cf3cab61ffb0b81d1efbb6e878c89))
+- **components:** add support for simple image fields ([#180](https://github.com/yext/sites-scripts/issues/180)) ([15cb86b](https://github.com/yext/sites-scripts/commit/15cb86b02800d521d2a23daa09b932c0b4c6dc99)), closes [#156](https://github.com/yext/sites-scripts/issues/156) [#155](https://github.com/yext/sites-scripts/issues/155)
+- **dev:** redirect if url ends in final slash (closes [#143](https://github.com/yext/sites-scripts/issues/143)) ([#148](https://github.com/yext/sites-scripts/issues/148)) ([61d38e9](https://github.com/yext/sites-scripts/commit/61d38e943915d55004e55d1ba4cd556ec7fc9947))
+- **dev:** support alternate languages via `locale` query param ([#141](https://github.com/yext/sites-scripts/issues/141)) ([3aa60c8](https://github.com/yext/sites-scripts/commit/3aa60c8d96b279eea5674af6ff0e43f852f00657))
+- extract features.json generation into its own command ([#170](https://github.com/yext/sites-scripts/issues/170)) ([6a7f2a4](https://github.com/yext/sites-scripts/commit/6a7f2a43d7429790fd08c4b6935b9f254e8eb4d2))
+- **plugin:** validate file sizes (closes [#145](https://github.com/yext/sites-scripts/issues/145)) ([#147](https://github.com/yext/sites-scripts/issues/147)) ([6a16d2a](https://github.com/yext/sites-scripts/commit/6a16d2a7efe3a4f91f096e2b88bcbbddbc53b324))
+- **util:** add fetch and runtime functions ([#118](https://github.com/yext/sites-scripts/issues/118)) ([207fc63](https://github.com/yext/sites-scripts/commit/207fc63a2aa69e0d04dc72e32ded98a2a9231bee)), closes [#117](https://github.com/yext/sites-scripts/issues/117) [#119](https://github.com/yext/sites-scripts/issues/119) [#120](https://github.com/yext/sites-scripts/issues/120) [#124](https://github.com/yext/sites-scripts/issues/124) [#125](https://github.com/yext/sites-scripts/issues/125) [#126](https://github.com/yext/sites-scripts/issues/126)
+- **util:** add isProduction function ([#150](https://github.com/yext/sites-scripts/issues/150)) ([f89f45d](https://github.com/yext/sites-scripts/commit/f89f45da584ec196f519e30c95124fcf2e4ae11c))
 
 # 1.0.0-beta.4 (2022-08-26)
 

--- a/packages/pages/src/util/runtime.test.ts
+++ b/packages/pages/src/util/runtime.test.ts
@@ -28,6 +28,27 @@ describe("runtime", () => {
     global.process = originalProcess;
   });
 
+  it("returns true for isServerSide when the runtime is node.", async () => {
+    const originalProcess = process;
+    global.process = {
+      ...originalProcess,
+      versions: {
+        http_parser: "foo",
+        node: "16.16.0",
+        v8: "foo",
+        ares: "foo",
+        uv: "foo",
+        zlib: "foo",
+        modules: "foo",
+        openssl: "foo",
+      },
+    };
+    const runtime = getRuntime();
+
+    expect(runtime.isServerSide).toBe(true);
+    global.process = originalProcess;
+  });
+
   it("correctly identifies deno via Deno object", async () => {
     const originalProcess = process;
     // @ts-ignore
@@ -72,6 +93,30 @@ describe("runtime", () => {
     windowSpy.mockRestore();
   });
 
+  it("returns true for isServerSide when runtime is deno", async () => {
+    const originalProcess = process;
+    // @ts-ignore
+    global.process = undefined;
+
+    const originalWindow = { ...window };
+    const windowSpy = jest.spyOn(global, "window", "get");
+    // @ts-ignore
+    windowSpy.mockImplementation(() => ({
+      ...originalWindow,
+      Deno: {
+        version: {
+          deno: "1.24.0",
+        },
+      },
+    }));
+
+    const runtime = getRuntime();
+    expect(runtime.isServerSide).toBe(true);
+
+    global.process = originalProcess;
+    windowSpy.mockRestore();
+  });
+
   it("getNodeMajorVersion() throws when not node", async () => {
     const originalProcess = process;
     // @ts-ignore
@@ -105,6 +150,18 @@ describe("runtime", () => {
     const runtime = getRuntime();
 
     expect(runtime.name).toEqual("browser");
+
+    global.process = originalProcess;
+  });
+
+  it("returns false for isServerSide when runtime is browser", async () => {
+    const originalProcess = process;
+    // @ts-ignore
+    global.process = undefined;
+
+    const runtime = getRuntime();
+
+    expect(runtime.isServerSide).toBe(false);
 
     global.process = originalProcess;
   });

--- a/packages/pages/src/util/runtime.ts
+++ b/packages/pages/src/util/runtime.ts
@@ -1,14 +1,22 @@
 class Runtime {
   name: "node" | "deno" | "browser";
+  /**
+   * Whether or not the current runtime is being executed server-side or client-side. If the runtime
+   * is node or deno then isServerSide will be true. When the runtime is browser isServerSide is
+   * false.
+   */
+  isServerSide: boolean;
   version: string;
 
   constructor() {
     if (typeof process !== "undefined") {
       this.name = "node";
       this.version = process.versions.node;
+      this.isServerSide = true;
     } else if (typeof window !== "undefined" && !("Deno" in window)) {
       this.name = "browser";
       this.version = navigator.userAgent;
+      this.isServerSide = false;
     } else {
       this.name = "deno";
       this.version = "";
@@ -16,6 +24,7 @@ class Runtime {
         // @ts-ignore
         this.version = window?.Deno?.version.deno || "";
       }
+      this.isServerSide = true;
     }
   }
 


### PR DESCRIPTION
Adds a new field to `Runtime` which indicates whether the runtime is server-side or not. This improves upon the current way of checking this which would be to do `getRuntime().name === "node" || getRuntime().name === "deno"`.

J=none
TEST=auto