### PR TITLE
fix(dev): remove final slash from static page urls on index

### DIFF
--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -50,7 +50,7 @@ export const indexPage =
               <li>
                 <a href="http://localhost:${viteDevServerPort}/${encodeURIComponent(
                 templateName
-              )}/">
+              )}">
                   ${templateName}
                 </a>
               </li>


### PR DESCRIPTION
This was causing unnecessary 301s after clicking the link to a static page.