### PR TITLE
fix: features command when using top-level await

### DIFF
--- a/packages/pages/src/bin/pages.sh
+++ b/packages/pages/src/bin/pages.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-/usr/bin/env node --experimental-specifier-resolution=node node_modules/@yext/pages/dist/bin/pages.js "$@"
+/usr/bin/env node --experimental-specifier-resolution=node --experimental-vm-modules node_modules/@yext/pages/dist/bin/pages.js "$@"


### PR DESCRIPTION
When using a top-level await to dynamically import a module in a template, `npm run features` was failing with cjs errors. This was due to [module-from-string](https://www.npmjs.com/package/module-from-string) requiring `--experimental-vm-modules` in order to work properly.