### PR TITLE
fix(components): set sizes attribute for images

### DIFF
--- a/packages/pages/src/components/image/image.test.tsx
+++ b/packages/pages/src/components/image/image.test.tsx
@@ -165,6 +165,35 @@ describe("Image", () => {
 
     expect(img.getAttribute("srcset")).toContain("dynl.mktgcdn.com/p-sandbox/");
   });
+
+  it("properly renders the sizes for a fixed width", () => {
+    render(
+      <Image
+        image={image}
+        layout={ImageLayoutOption.FIXED}
+        width={width}
+        height={height}
+      />
+    );
+
+    const img = screen.getByRole("img", {
+      name: /alt text/i,
+    });
+
+    expect(img.getAttribute("sizes")).toEqual(`${width}px`);
+  });
+
+  it("properly renders the sizes for the default widths", () => {
+    render(<Image image={image} />);
+
+    const img = screen.getByRole("img", {
+      name: /alt text/i,
+    });
+
+    expect(img.getAttribute("sizes")).toEqual(
+      "(max-width: 640px) 100px, (max-width: 768px) 320px, (max-width: 1024px) 640px, (max-width: 1280px) 960px, (max-width: 1536px) 1280px, 1920px"
+    );
+  });
 });
 
 describe("getImageUUID", () => {

--- a/packages/pages/src/components/image/image.tsx
+++ b/packages/pages/src/components/image/image.tsx
@@ -86,6 +86,16 @@ export const Image = ({
     )
     .join(", ");
 
+  // Generate Image Sizes
+  const maxWidthBreakpoints = [640, 768, 1024, 1280, 1536];
+  const sizes: string = widths
+    .map((w, i) =>
+      i === widths.length - 1
+        ? `${w}px`
+        : `(max-width: ${maxWidthBreakpoints[i]}px) ${w}px`
+    )
+    .join(", ");
+
   return (
     <>
       {!isImageLoaded && placeholder != null && placeholder}
@@ -97,6 +107,7 @@ export const Image = ({
         width={absWidth}
         height={absHeight}
         srcSet={srcSet}
+        sizes={sizes}
         loading={"lazy"}
         alt={imageData.alternateText || ""}
         {...imgOverrides}


### PR DESCRIPTION
Fixes #209. 

J=SLAP-2384
TEST=auto, manual

Added unit tests to check that the `sizes` string is generated correctly. Also, tested locally to make sure `sizes` and `srcset` work together as expected to only make network requests to the image URL corresponding with the screen width.