### PR TITLE
fix(plugin): fix slug connector pagination

### DIFF
--- a/packages/plugins/slugManager/manager.ts
+++ b/packages/plugins/slugManager/manager.ts
@@ -36,8 +36,8 @@ export function createManager(config: InternalSlugManagerConfig) {
     const params = new URLSearchParams({
       fields: "meta",
     });
-    if (pageToken != null) {
-      params.set("pagination_token", pageToken);
+    if (pageToken) {
+      params.set("pageToken", pageToken);
     }
     if (searchIds.length) {
       params.set("searchIds", searchIds.join(","));


### PR DESCRIPTION
pagination incorrectly used a 'pagination_token' query param rather than 'pageToken'

TEST=manual