### PR TITLE
fix(components): remove `process?` optional chaining

### DIFF
--- a/packages/pages/src/components/analytics/provider.tsx
+++ b/packages/pages/src/components/analytics/provider.tsx
@@ -36,8 +36,10 @@ export function AnalyticsProvider(
     analytics.enableTrackingCookie();
   }
 
-  const enableDebuggingDefault =
-    debuggingParamDetected() || process?.env?.NODE_ENV === "development";
+  let enableDebuggingDefault = debuggingParamDetected();
+  if (typeof process !== "undefined") {
+    enableDebuggingDefault = enableDebuggingDefault || process.env?.NODE_ENV === "development";
+  }
   analytics.setDebugEnabled(enableDebugging ?? enableDebuggingDefault);
 
   return (


### PR DESCRIPTION
Trying to perform optional chaining on the `process` object was causing an error during generation.

TEST=none