### PR TITLE
feat(components): support pageDomain param

### DIFF
--- a/packages/pages/THIRD-PARTY-NOTICES
+++ b/packages/pages/THIRD-PARTY-NOTICES
@@ -1,6 +1,6 @@
 The following NPM package may be included in this product:
 
- - @yext/analytics@0.2.2
+ - @yext/analytics@0.3.0
 
 This package contains the following license and notice below:
 

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -57,7 +57,7 @@
     "THIRD-PARTY-NOTICES"
   ],
   "dependencies": {
-    "@yext/analytics": "^0.2.2",
+    "@yext/analytics": "^0.3.0",
     "@yext/components-tsx-geo": "^1.0.3",
     "@yext/components-tsx-maps": "^1.0.9",
     "ansi-to-html": "^0.7.2",

--- a/packages/pages/src/components/analytics/Analytics.ts
+++ b/packages/pages/src/components/analytics/Analytics.ts
@@ -43,7 +43,8 @@ export class Analytics implements AnalyticsMethods {
    */
   constructor(
     private templateData: TemplateProps,
-    requireOptIn?: boolean | undefined
+    requireOptIn?: boolean | undefined,
+    private pageDomain?: string
   ) {
     this._optedIn = !requireOptIn;
     this.makeReporter();
@@ -93,6 +94,7 @@ export class Analytics implements AnalyticsMethods {
       production: inProduction,
       referrer: document.referrer,
       siteId: this.templateData.document.siteId as number,
+      pageDomain: this.pageDomain,
     });
 
     this.setDebugEnabled(this._enableDebugging);

--- a/packages/pages/src/components/analytics/interfaces.ts
+++ b/packages/pages/src/components/analytics/interfaces.ts
@@ -90,6 +90,13 @@ export interface AnalyticsProviderProps {
    * in the developer console.
    */
   enableDebugging?: boolean | undefined;
+
+  /**
+   * The domain of the page to send with API requests. If none is specified,
+   * the hostname for the site ID is used. The domain string must include the
+   * scheme (e.g. https://foo.com).
+   */
+  pageDomain?: string;
 }
 
 /**

--- a/packages/pages/src/components/analytics/provider.tsx
+++ b/packages/pages/src/components/analytics/provider.tsx
@@ -22,12 +22,17 @@ export function AnalyticsProvider(
     enableTrackingCookie,
     enableDebugging,
     templateData,
+    pageDomain,
   } = props;
 
   const analyticsRef = useRef<AnalyticsMethods | null>(null);
 
   if (analyticsRef.current === null) {
-    analyticsRef.current = new Analytics(templateData, requireOptIn);
+    analyticsRef.current = new Analytics(
+      templateData,
+      requireOptIn,
+      pageDomain
+    );
   }
 
   const analytics = analyticsRef.current;
@@ -38,7 +43,8 @@ export function AnalyticsProvider(
 
   let enableDebuggingDefault = debuggingParamDetected();
   if (typeof process !== "undefined") {
-    enableDebuggingDefault = enableDebuggingDefault || process.env?.NODE_ENV === "development";
+    enableDebuggingDefault =
+      enableDebuggingDefault || process.env?.NODE_ENV === "development";
   }
   analytics.setDebugEnabled(enableDebugging ?? enableDebuggingDefault);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,7 @@ importers:
       '@types/react-dom': ^17.0.17
       '@types/shelljs': ^0.8.11
       '@types/ws': ^8.5.3
-      '@yext/analytics': ^0.2.2
+      '@yext/analytics': ^0.3.0
       '@yext/components-tsx-geo': ^1.0.3
       '@yext/components-tsx-maps': ^1.0.9
       ansi-to-html: ^0.7.2
@@ -123,7 +123,7 @@ importers:
       typescript: ^4.8.2
       vite: ^3.1.0
     dependencies:
-      '@yext/analytics': 0.2.2
+      '@yext/analytics': 0.3.0
       '@yext/components-tsx-geo': 1.0.3
       '@yext/components-tsx-maps': 1.0.9
       ansi-to-html: 0.7.2
@@ -4588,8 +4588,8 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
     dev: true
 
-  /@yext/analytics/0.2.2:
-    resolution: {integrity: sha512-XWo03wn1hjxAKe0gxoVC94LLFy/c+IF+4XlvDvf7qLC5NtFXzTFKQMxZo7PItYMqRiUFgBHhlXWlAEXE5YBJKg==}
+  /@yext/analytics/0.3.0:
+    resolution: {integrity: sha512-b2sXkoEmCdQyO2nbuYATOOQ1gs501bOUd1GxE8u7dQmhcYCyzzbUKQ07hzWRJoP6I3/Rf1o0fEfXsnlb5vmcnA==}
     dependencies:
       cross-fetch: 3.1.5
     transitivePeerDependencies:


### PR DESCRIPTION
Resolves #229. Bumps the version of `@yext/analytics` and adds support for passing in the `pageDomain` as a prop to the `AnalyticsProvider`, which is passed to `providePagesAnalytics`.

J=SLAP-2402
TEST=manual

Tested locally to make sure the `pageDomain` could be set from the `AnalyticsProvider` props and was only sent as a query param when formatted correctly (included the scheme). Otherwise, a console warning was logged and it was not sent in the analytics API requests.