### PR TITLE
fix(components): make fixed Image width and height optional

### DIFF
--- a/packages/pages/THIRD-PARTY-NOTICES
+++ b/packages/pages/THIRD-PARTY-NOTICES
@@ -494,6 +494,38 @@ terms above.
 
 The following NPM package may be included in this product:
 
+ - mime-types@2.1.35
+
+This package contains the following license and notice below:
+
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----------
+
+The following NPM package may be included in this product:
+
  - module-from-string@3.3.0
 
 This package contains the following license and notice below:

--- a/packages/pages/src/components/image/image.test.tsx
+++ b/packages/pages/src/components/image/image.test.tsx
@@ -416,7 +416,7 @@ describe("validateRequiredProps", () => {
 
     expect(logMock.mock.calls.length).toBe(1);
     expect(logMock.mock.calls[0][0]).toBe(
-      "Using fixed layout but width and height are not passed as props."
+      "Using fixed layout but neither width nor height is passed as props."
     );
     jest.clearAllMocks();
   });

--- a/packages/pages/src/components/image/image.tsx
+++ b/packages/pages/src/components/image/image.tsx
@@ -136,7 +136,7 @@ export const validateRequiredProps = (
   if (layout == ImageLayoutOption.FIXED) {
     if (!width && !height) {
       console.warn(
-        "Using fixed layout but width and height are not passed as props."
+        "Using fixed layout but neither width nor height is passed as props."
       );
 
       return;

--- a/packages/pages/src/components/image/types.ts
+++ b/packages/pages/src/components/image/types.ts
@@ -105,15 +105,16 @@ interface OtherImageProps extends BaseImageProps {
 
 /**
  * The shape of the data passed to {@link Image} when layout is {@link ImageLayoutOption.FIXED}.
- * Extends the {@link BaseImageProps} interface and has the additions of required width and height.
+ * Extends the {@link BaseImageProps} interface and has the additions of a width and height,
+ * at least one of which must be specified.
  */
 interface FixedImageProps extends BaseImageProps {
   /** Specifies how the image is rendered. */
   layout: "fixed";
   /** The absolute width of the image. Only impacts if layout is set to "fixed". */
-  width: number;
+  width?: number;
   /** The absolute height of the image. Only impacts if layout is set to "fixed". */
-  height: number;
+  height?: number;
 }
 
 /**


### PR DESCRIPTION
Fixes #195.

J=SLAP-2400
TEST=auto, manual

See that the updated Jest test passes and tested locally to make sure a `width` could be specified without a `height` and vice versa when the image had a fixed layout. Specifying neither `width` nor `height` or invalid values for either still logged an error, as did specifying either a `width` or `height` (or both) when the image layout was not fixed.