### PR TITLE
feat(components): add `LocationMap` component

### DIFF
--- a/packages/pages/src/components/README.md
+++ b/packages/pages/src/components/README.md
@@ -11,3 +11,15 @@ Render an image from a Knowledge Graph field.
 ## Link
 
 Render an anchor tag with an `href` or from a `CTA` type Knowledge Graph field.
+
+## Map
+
+Render a map using either the `Mapbox` or `Google` provider.
+
+## Marker
+
+Render a marker in a Map component at a given coorindate.
+
+## LocationMap
+
+Render a Map component with a single marker that links to a `href`.

--- a/packages/pages/src/components/README.md
+++ b/packages/pages/src/components/README.md
@@ -22,4 +22,4 @@ Render a marker in a Map component at a given coorindate.
 
 ## LocationMap
 
-Render a Map component with a single marker that links to a `href`.
+Render a Map component with a single marker that links to an `href`.

--- a/packages/pages/src/components/index.ts
+++ b/packages/pages/src/components/index.ts
@@ -3,3 +3,4 @@ export * from "./analytics/index.js";
 export * from "./image/index.js";
 export * from "./link/index.js";
 export * from "./map/index.js";
+export * from "./locationmap/index.js";

--- a/packages/pages/src/components/locationmap/index.ts
+++ b/packages/pages/src/components/locationmap/index.ts
@@ -1,0 +1,2 @@
+export { LocationMap } from "./locationmap.js";
+export * from "./types.js";

--- a/packages/pages/src/components/locationmap/locationmap.stories.tsx
+++ b/packages/pages/src/components/locationmap/locationmap.stories.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from "react";
+import { ComponentMeta } from "@storybook/react";
+import { LocationMap } from ".";
+import { getDirections } from "../address/methods.js";
+import { MapProviderOption } from "../address/types.js";
+
+export default {
+  title: "components/LocationMap",
+  component: LocationMap,
+} as ComponentMeta<typeof LocationMap>;
+
+const sampleAddress = {
+  city: "New York",
+  countryCode: "US",
+  line1: "60 W 23rd St",
+  postalCode: "10010",
+  region: "NY",
+};
+
+// LocationMap that uses the default Marker icon
+
+export const Map_With_Default_Icon = () => {
+  return (
+    <LocationMap
+      clientKey="gme-yextinc"
+      coordinate={{ latitude: 38.8974, longitude: -77.0638 }}
+    />
+  );
+};
+
+// LocationMap with Custom SVG
+
+export const Map_With_No_Link = () => {
+  return (
+    <LocationMap
+      clientKey="gme-yextinc"
+      coordinate={{ latitude: 38.8974, longitude: -77.0638 }}
+    >
+      <svg width="30" height="38" fill="#F46036" viewBox="0 0 30 38">
+        <path
+          x="50%"
+          y="40%"
+          d="M30 15.0882C30 23.4212 23.3333 30.7353 15 38C7.22222 31.2941 0 23.4212 0 15.0882C0 6.75523 6.71573 0 15 0C23.2843 0 30 6.75523 30 15.0882Z"
+        />
+      </svg>
+    </LocationMap>
+  );
+};
+
+export const Map_With_Link = () => {
+  return (
+    <LocationMap
+      clientKey="gme-yextinc"
+      coordinate={{ latitude: 38.8974, longitude: -77.0638 }}
+      pinUrl="https://yext.com"
+    >
+      <svg width="30" height="38" fill="#F46036" viewBox="0 0 30 38">
+        <path
+          x="50%"
+          y="40%"
+          d="M30 15.0882C30 23.4212 23.3333 30.7353 15 38C7.22222 31.2941 0 23.4212 0 15.0882C0 6.75523 6.71573 0 15 0C23.2843 0 30 6.75523 30 15.0882Z"
+        />
+      </svg>
+    </LocationMap>
+  );
+};
+
+// LocationMap with a different icon on hover
+
+export const Map_With_Hover_State = () => {
+  const [hovered, setHovered] = useState(false);
+  const handleHover = (hovered: boolean, id: string) => {
+    setHovered(hovered);
+  };
+
+  return (
+    <LocationMap
+      clientKey={"gme-yextinc"}
+      coordinate={{ latitude: 40.74237, longitude: -73.99211 }}
+      onHover={handleHover}
+    >
+      {hovered ? (
+        <svg
+          width="48px"
+          height="48px"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M24,1.32c-9.92,0-18,7.8-18,17.38A16.83,16.83,0,0,0,9.57,29.09l12.84,16.8a2,2,0,0,0,3.18,0l12.84-16.8A16.84,16.84,0,0,0,42,18.7C42,9.12,33.92,1.32,24,1.32Z"
+            fill="#ec5044"
+          />
+          <path
+            d="M25.37,12.13a7,7,0,1,0,5.5,5.5A7,7,0,0,0,25.37,12.13Z"
+            fill="#a1362e"
+          />
+        </svg>
+      ) : (
+        <svg
+          width={30}
+          height={38}
+          fill="#F46036"
+          viewBox="0 0 30 38"
+          style={{ cursor: "pointer" }}
+        >
+          <path
+            x="50%"
+            y="40%"
+            d="M30 15.0882C30 23.4212 23.3333 30.7353 15 38C7.22222 31.2941 0 23.4212 0 15.0882C0 6.75523 6.71573 0 15 0C23.2843 0 30 6.75523 30 15.0882Z"
+          />
+        </svg>
+      )}
+    </LocationMap>
+  );
+};
+
+// LocationMap using getDirections()
+
+export const Map_With_Directions_Link = () => {
+  return (
+    <LocationMap
+      clientKey="gme-yextinc"
+      coordinate={{ latitude: 40.74237, longitude: -73.99211 }}
+      pinUrl={getDirections(sampleAddress, [], undefined, {
+        provider: MapProviderOption.GOOGLE,
+      })}
+    >
+      <svg width="30" height="38" fill="#F46036" viewBox="0 0 30 38">
+        <path
+          x="50%"
+          y="40%"
+          d="M30 15.0882C30 23.4212 23.3333 30.7353 15 38C7.22222 31.2941 0 23.4212 0 15.0882C0 6.75523 6.71573 0 15 0C23.2843 0 30 6.75523 30 15.0882Z"
+        />
+      </svg>
+    </LocationMap>
+  );
+};

--- a/packages/pages/src/components/locationmap/locationmap.test.tsx
+++ b/packages/pages/src/components/locationmap/locationmap.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from "react";
+import { render, waitFor, screen } from "@testing-library/react";
+import { LocationMap } from ".";
+import { MapboxMaps } from "@yext/components-tsx-maps";
+
+describe("LocationMap", () => {
+  it("renders with Google Maps", async () => {
+    render(
+      <LocationMap
+        clientKey="gme-yextinc"
+        coordinate={{ latitude: 38.8974, longitude: -97.0638 }}
+      />
+    );
+
+    const title = "Open this area in Google Maps (opens a new window)";
+    await waitFor(() => {
+      expect(screen.findByTitle(title)).toBeTruthy();
+    });
+  });
+
+  it("renders with Mapbox", async () => {
+    render(
+      <LocationMap
+        provider={MapboxMaps}
+        apiKey={process.env.MAPBOX_APIKEY}
+        coordinate={{ latitude: 38.8974, longitude: -97.0638 }}
+      />
+    );
+
+    const role = "region";
+    await waitFor(() => {
+      expect(screen.findByRole(role)).toBeTruthy();
+    });
+  });
+
+  it("renders with Link", () => {
+    render(
+      <LocationMap
+        provider={MapboxMaps}
+        apiKey={process.env.MAPBOX_APIKEY}
+        coordinate={{ latitude: 38.8974, longitude: -97.0638 }}
+        pinUrl="https://yext.com"
+      />
+    );
+  });
+
+  it("renders with child", () => {
+    render(
+      <LocationMap
+        provider={MapboxMaps}
+        apiKey={process.env.MAPBOX_APIKEY}
+        coordinate={{ latitude: 38.8974, longitude: -97.0638 }}
+        pinUrl="https://yext.com"
+      >
+        <svg
+          width="48px"
+          height="48px"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M24,1.32c-9.92,0-18,7.8-18,17.38A16.83,16.83,0,0,0,9.57,29.09l12.84,16.8a2,2,0,0,0,3.18,0l12.84-16.8A16.84,16.84,0,0,0,42,18.7C42,9.12,33.92,1.32,24,1.32Z"
+            fill="#ec5044"
+          />
+          <path
+            d="M25.37,12.13a7,7,0,1,0,5.5,5.5A7,7,0,0,0,25.37,12.13Z"
+            fill="#a1362e"
+          />
+        </svg>
+      </LocationMap>
+    );
+  });
+});

--- a/packages/pages/src/components/locationmap/locationmap.tsx
+++ b/packages/pages/src/components/locationmap/locationmap.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { LocationMapProps } from "./types.js";
+import { GoogleMaps } from "@yext/components-tsx-maps";
+import { Map } from "../map/map.js";
+import { Marker } from "../map/marker.js";
+import { Link } from "../link/link.js";
+
+export const LocationMap = ({
+  children,
+  coordinate,
+  linkSameTab,
+  pinUrl,
+  onClick = () => null,
+  onHover = () => null,
+  onFocus = () => null,
+  ...mapProps
+}: LocationMapProps) => {
+  return (
+    <Map bounds={[coordinate]} {...mapProps}>
+      <Marker
+        coordinate={coordinate}
+        id={"location-map-marker"}
+        onClick={onClick}
+        onHover={onHover}
+        onFocus={onFocus}
+      >
+        {pinUrl ? (
+          <Link href={pinUrl} target={linkSameTab ? "_self" : "_blank"}>
+            {children}
+          </Link>
+        ) : children ? (
+          children
+        ) : undefined}
+      </Marker>
+    </Map>
+  );
+};
+
+LocationMap.defaultProps = {
+  controls: true,
+  panHandler: () => null,
+  provider: GoogleMaps,
+  singleZoom: 16,
+};

--- a/packages/pages/src/components/locationmap/types.ts
+++ b/packages/pages/src/components/locationmap/types.ts
@@ -1,0 +1,11 @@
+import type { MapProps, Coordinate } from "../map/types.js";
+
+export interface LocationMapProps extends MapProps {
+  children?: React.ReactChild;
+  coordinate: Coordinate;
+  linkSameTab?: boolean;
+  pinUrl?: string;
+  onClick?: (id: string) => void;
+  onHover?: (hovered: boolean, id: string) => void;
+  onFocus?: (focused: boolean, id: string) => void;
+}


### PR DESCRIPTION
This PR adds the `LocationMap` component, which allows uses to easily add a single marker to the map and have it link to another page on marker click. The common use case for this is adding it to a location page and having the pin click link out to the directions.