### PR TITLE
fix(dev): parse multiple stream documents

### DIFF
--- a/packages/pages/src/dev/server/ssr/constants.ts
+++ b/packages/pages/src/dev/server/ssr/constants.ts
@@ -1,6 +1,8 @@
 export const TEMPLATE_PATH = "src/templates";
 export const STREAM_DATA_CHUNK_BEGIN = "{";
 export const STREAM_DATA_CHUNK_END = "}";
+export const STREAM_DATA_CHUNK_BEGIN_MULTIPLE = "[";
+export const STREAM_DATA_CHUNK_END_MULTIPLE = "]";
 export const CLI_BOILERPLATE_BETA_MESSAGE =
   "This is a beta version of the Yext Command Line Interface";
 export const UPGRADE_MESSAGE_LINE_BEGIN = "Please upgrade the Yext CLI";

--- a/packages/pages/src/dev/server/ssr/generateTestData.test.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.test.ts
@@ -108,11 +108,7 @@ describe("generateTestDataForPage", () => {
 
     mockChildProcess.stdout.emit(
       "data",
-      `${
-        JSON.stringify(CLI_STREAM_DATA_MULTIPLE_DOCS[0], null, "  ") +
-        "\n" +
-        JSON.stringify(CLI_STREAM_DATA_MULTIPLE_DOCS[1], null, "  ")
-      }`
+      `${JSON.stringify(CLI_STREAM_DATA_MULTIPLE_DOCS, null, "  ")}`
     );
     mockChildProcess.emit("close");
 

--- a/packages/pages/src/dev/server/ssr/generateTestData.test.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.test.ts
@@ -80,7 +80,7 @@ const getGenerateTestDataForPageWithAlternateLanguageFieldsRunner = () =>
     mockParentProcessStdout,
     FEATURE_CONFIG_ALTERNATE_LANGUAGE_FIELDS,
     "4092",
-    "en",
+    "es-US",
     projectStructure
   );
 
@@ -118,7 +118,7 @@ describe("generateTestDataForPage", () => {
 
     const datadoc = await testRunnerPromise;
 
-    expect(datadoc).toEqual(CLI_STREAM_DATA_MULTIPLE_DOCS[0]);
+    expect(datadoc).toEqual(CLI_STREAM_DATA_MULTIPLE_DOCS[1]);
     // There is no output from the CLI other than the stream data, so nothing should be
     // written back to the parent process.
     expect(mockParentProcessStdout.write).toBeCalledTimes(0);

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -128,11 +128,11 @@ export const generateTestDataForPage = async (
       let parsedData: any;
       if (testData) {
         try {
-          const documents = splitUnsafeDocuments(testData.trim());
+          const documents = parseConcatenatedDocuments(testData.trim());
           if (documents.length === 1) {
             parsedData = documents[0];
           } else {
-            parsedData = getDocumentByLocale(parsedData, locale);
+            parsedData = getDocumentByLocale(documents, locale);
           }
         } catch (e) {
           stdout.write(
@@ -181,9 +181,9 @@ const prepareJsonForCmd = (json: any) => {
 };
 
 // There is a chance multiple documents will be returned consecutively, without proper containment. Look for them and parse as an array
-const splitUnsafeDocuments = (documentResponse: string): any[] => {
-  const DOCUMENT_SEPARATOR = "}\n{";
-  const DOCUMENT_JOINER = "},\n{";
+const parseConcatenatedDocuments = (documentResponse: string): any[] => {
+  const DOCUMENT_SEPARATOR = `}\n{\n  "__`;
+  const DOCUMENT_JOINER = `},\n{\n  "__`;
   const objects = documentResponse
     .split(DOCUMENT_SEPARATOR)
     .join(DOCUMENT_JOINER);

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -180,7 +180,8 @@ const prepareJsonForCmd = (json: any) => {
   return jsonString;
 };
 
-// There is a chance multiple documents will be returned consecutively, without proper containment. Look for them and parse as an array
+// When using a CLI version <= 0.1_299 there is a chance multiple documents will be returned consecutively, without proper containment.
+// Look for them and parse as an array. This can be removed once the CLI handles multiple documents as an array https://yexttest.atlassian.net/browse/SPR-4712
 const parseConcatenatedDocuments = (documentResponse: string): any[] => {
   const DOCUMENT_SEPARATOR = `}\n{\n  "__`;
   const DOCUMENT_JOINER = `},\n{\n  "__`;

--- a/packages/pages/tests/fixtures/cli_boilerplate.ts
+++ b/packages/pages/tests/fixtures/cli_boilerplate.ts
@@ -18,7 +18,7 @@ export const REAL_FULL_OUTPUT = `This is a beta version of the Yext Command Line
 
 Some arbitrary text
 
-Generated 2 files for stream "my-stream-id-1"
+Generated 1 files for stream "my-stream-id-1"
 {
 	"__": {
 		"entityPageSet": {

--- a/packages/pages/tests/fixtures/cli_stream_data.ts
+++ b/packages/pages/tests/fixtures/cli_stream_data.ts
@@ -202,3 +202,90 @@ export const CLI_STREAM_DATA = {
   slug: "loc3-upper-west-side",
   uid: 26771072,
 };
+
+export const CLI_STREAM_DATA_MULTIPLE_DOCS = [
+  {
+    __: {
+      alternateLanguageFields: ["name"],
+      entityPageSet: {
+        plugin: {},
+      },
+      name: "index",
+      streamId: "my-stream-id-1",
+      templateType: "JS",
+    },
+    address: {
+      city: "Manchester",
+      countryCode: "US",
+      line1: "786 New Bushy Branch Road",
+      postalCode: "37355",
+      region: "TN",
+    },
+    alternateLanguageFields: {
+      "es-US": {
+        name: "Granja de Manchester",
+      },
+    },
+    businessId: 0,
+    geocodedCoordinate: {
+      latitude: 35.480399,
+      longitude: -86.060931,
+    },
+    id: "4092",
+    key: "0:index:knowledgeGraph:45138271:en",
+    locale: "en",
+    meta: {
+      entityType: {
+        id: "location",
+        uid: 0,
+      },
+      locale: "en",
+      updateTimestamp: "2022-06-21T01:50:05Z",
+    },
+    name: "Manchester Farm",
+    siteId: 0,
+    uid: 45138271,
+  },
+  {
+    __: {
+      alternateLanguageFields: ["name"],
+      entityPageSet: {
+        plugin: {},
+      },
+      name: "index",
+      streamId: "my-stream-id-1",
+      templateType: "JS",
+    },
+    address: {
+      city: "Manchester",
+      countryCode: "US",
+      line1: "786 New Bushy Branch Road",
+      postalCode: "37355",
+      region: "TN",
+    },
+    alternateLanguageFields: {
+      en: {
+        name: "Manchester Farm",
+      },
+    },
+    businessId: 0,
+    geocodedCoordinate: {
+      latitude: 35.480399,
+      longitude: -86.060931,
+    },
+    id: "4092",
+    key: "0:index:knowledgeGraph:45138271:en",
+    locale: "es-US",
+    meta: {
+      entityType: {
+        id: "location",
+        uid: 0,
+      },
+      locale: "es-US",
+      updateTimestamp: "2022-06-21T01:50:05Z",
+    },
+    name: "Granja de Manchester",
+    siteId: 0,
+    uid: 45138271,
+  },
+];

--- a/packages/pages/tests/fixtures/feature_config.ts
+++ b/packages/pages/tests/fixtures/feature_config.ts
@@ -24,3 +24,29 @@ export const FEATURE_CONFIG: FeaturesConfig = {
     },
   ],
 };
+
+export const FEATURE_CONFIG_ALTERNATE_LANGUAGE_FIELDS: FeaturesConfig = {
+  features: [
+    {
+      name: "index",
+      streamId: "products",
+      templateType: "JS",
+      entityPageSet: {
+        plugin: {},
+      },
+      alternateLanguageFields: ["name"],
+    },
+  ],
+  streams: [
+    {
+      $id: "products",
+      source: "knowledgeGraph",
+      destination: "pages",
+      fields: [],
+      filter: {},
+      localization: {
+        primary: false,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
The `alternateLanguageFields` feature requires multiple documents to be queried, so the locale cannot be included when using that feature. Additionally since the `alternateLanguageFields` feature uses information from multiple documents (languages), multiple documents will be returned. `parseConcatenatedDocuments()` will transform the output of multiple consecutive documents into an array so that it can be searched by locale for the proper document.

fix #228

J=SLAP-2401
TEST=auto,manual

successfully served multi-lang site with alternateLanguageFields feature enabled and disabled