### PR TITLE
feat(dev): Add Scope Flag to Dev Command

### DIFF
--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -83,7 +83,8 @@
     "rollup": "^2.79.0",
     "shelljs": "^0.8.5",
     "typescript": "^4.8.2",
-    "vite": "^3.1.0"
+    "vite": "^3.1.0",
+    "yargs": "^17.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.19.0",
@@ -117,6 +118,7 @@
     "@types/react-dom": "^17.0.17",
     "@types/shelljs": "^0.8.11",
     "@types/ws": "^8.5.3",
+    "@types/yargs": "^17.0.13",
     "babel-loader": "^8.2.5",
     "esbuild": "^0.15.7",
     "generate-license-file": "^1.3.0",

--- a/packages/pages/src/bin/pages.ts
+++ b/packages/pages/src/bin/pages.ts
@@ -1,9 +1,9 @@
-import init from "../init/init.js";
-import dev from "../dev/dev.js";
-import preview from "../preview/preview.js";
-import { features } from "../generate/features.js";
-
-const [, , ...args] = process.argv;
+import { initCommandModule } from "../init/init.js";
+import { devCommandModule } from "../dev/dev.js";
+import { previewCommandModule } from "../preview/preview.js";
+import { generateCommandModule } from "../generate/generate.js";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
 // pages requires react and react-dom be installed to function appropriately. If
 // these are not installed in instruct the user to install them.
@@ -18,56 +18,14 @@ const [, , ...args] = process.argv;
   }
 });
 
-const [command] = args;
-
-switch (command) {
-  case "dev":
-    await dev();
-    break;
-  case "preview":
-    preview();
-    break;
-  case "init": {
-    let folderToCreate;
-
-    if (args.length == 2) {
-      folderToCreate = args[1];
-    }
-    await init(folderToCreate || null);
-    break;
-  }
-  case "generate": {
-    const generateTargets = ["features"];
-
-    if (args.length != 2) {
-      process.stdout.write(
-        `Missing a target to generate. Valid values are: ${generateTargets.join(
-          ", "
-        )}\n`
-      );
-      process.exit(1);
-    }
-
-    const target = args[1];
-
-    switch (target) {
-      case "features": {
-        await features();
-        break;
-      }
-      default: {
-        process.stdout.write(
-          `Target for 'generate' command is invalid: ${target}. Valid values are: ${generateTargets.join(
-            ", "
-          )}\n`
-        );
-        process.exit(1);
-      }
-    }
-    break;
-  }
-  default: {
-    process.stdout.write(`Command not found: ${command}\n`);
-    process.exit(1);
-  }
-}
+yargs(hideBin(process.argv))
+  .scriptName("pages")
+  .command(devCommandModule)
+  .command(previewCommandModule)
+  .command(initCommandModule)
+  .command(generateCommandModule)
+  .demandCommand()
+  .version(false)
+  .strict()
+  .help()
+  .parse();

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -1,15 +1,34 @@
 import { createServer } from "./server/server.js";
 import { viteDevServerPort } from "./server/middleware/constants.js";
+import { CommandModule } from "yargs";
 import open from "open";
 
-export default async () => {
-  const [, , ...args] = process.argv;
+interface DevArgs {
+  scope?: string;
+  local?: boolean;
+}
 
-  if (args.some((arg) => ["local"].includes(arg))) {
-    await createServer(false);
-  } else {
-    await createServer(true);
-  }
-
+const handler = async ({ scope, local }: DevArgs) => {
+  await createServer(!local, scope);
   await open(`http://localhost:${viteDevServerPort}/`);
+};
+
+export const devCommandModule: CommandModule<unknown, DevArgs> = {
+  command: "dev",
+  describe: "Runs a custom local development server that is backed by Vite",
+  builder: (yargs) => {
+    return yargs
+      .option("local", {
+        describe: "Disable dynamically generate test data",
+        type: "boolean",
+        demandOption: false,
+      })
+      .option("scope", {
+        describe:
+          "The subfolder to scope a build to a subset of templates using specific sites-config folder.",
+        type: "string",
+        demandOption: false,
+      });
+  },
+  handler,
 };

--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -9,13 +9,20 @@ import { generateTestData } from "./ssr/generateTestData.js";
 import { ProjectStructure } from "../../common/src/project/structure.js";
 import { finalSlashRedirect } from "./middleware/finalSlashRedirect.js";
 
-export const createServer = async (dynamicGenerateData: boolean) => {
+export const createServer = async (
+  dynamicGenerateData: boolean,
+  scope?: string
+) => {
   // creates a standard express app
   const app = express();
 
   // initialize the default project structure and use to help configure the
   // dev server
-  const projectStructure = new ProjectStructure();
+  const projectStructure = new ProjectStructure({
+    filepathsConfig: {
+      scope,
+    },
+  });
 
   // create vite using ssr mode
   const vite = await createViteServer({

--- a/packages/pages/src/generate/generate.ts
+++ b/packages/pages/src/generate/generate.ts
@@ -1,0 +1,21 @@
+import { CommandModule } from "yargs";
+import { features } from "./features.js";
+
+const featureCommandModule: CommandModule = {
+  command: "features",
+  describe: "Generates features.json file",
+  handler: () => {
+    features();
+  },
+};
+
+export const generateCommandModule: CommandModule = {
+  command: "generate",
+  describe: "Generates specified data type",
+  builder: (yargs) => {
+    return yargs.command(featureCommandModule).demandCommand();
+  },
+  handler: () => {
+    console.log('Must provide a subcommand of "generate".');
+  },
+};

--- a/packages/pages/src/init/init.ts
+++ b/packages/pages/src/init/init.ts
@@ -1,7 +1,12 @@
 import fs from "fs";
 import { runGenerate } from "./generate/interface.js";
+import { CommandModule } from "yargs";
 
-export default async (folderToCreate: string | null) => {
+interface InitArgs {
+  folderToCreate?: string;
+}
+
+const handler = async ({ folderToCreate }: InitArgs) => {
   if (folderToCreate) {
     await fs.promises.mkdir(folderToCreate);
     process.chdir(folderToCreate);
@@ -16,4 +21,18 @@ export default async (folderToCreate: string | null) => {
     }
     runGenerate();
   }
+};
+
+export const initCommandModule: CommandModule<unknown, InitArgs> = {
+  command: "init",
+  describe:
+    "Clones a pages starter repo, runs `npm install`, and performs the first build, all in one simple command.",
+  builder: (yargs) => {
+    return yargs.option("folderToCreate", {
+      describe: "Destination folder path to create the repo",
+      type: "string",
+      demandOption: false,
+    });
+  },
+  handler,
 };

--- a/packages/pages/src/preview/preview.ts
+++ b/packages/pages/src/preview/preview.ts
@@ -1,3 +1,12 @@
 import shell from "shelljs";
+import { CommandModule } from "yargs";
 
-export default () => shell.exec("vite preview");
+const handler = () => {
+  shell.exec("vite preview");
+};
+
+export const previewCommandModule: CommandModule = {
+  command: "preview",
+  describe: "Preview site using Vite",
+  handler,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,7 @@ importers:
       '@types/react-dom': ^17.0.17
       '@types/shelljs': ^0.8.11
       '@types/ws': ^8.5.3
+      '@types/yargs': ^17.0.13
       '@yext/analytics': ^0.3.0
       '@yext/components-tsx-geo': ^1.0.3
       '@yext/components-tsx-maps': ^1.0.9
@@ -126,6 +127,7 @@ importers:
       ts-jest: ^28.0.8
       typescript: ^4.8.2
       vite: ^3.1.0
+      yargs: ^17.6.0
     dependencies:
       '@yext/analytics': 0.3.0
       '@yext/components-tsx-geo': 1.0.3
@@ -154,6 +156,7 @@ importers:
       shelljs: 0.8.5
       typescript: 4.8.3
       vite: 3.1.3
+      yargs: 17.6.0
     devDependencies:
       '@babel/core': 7.19.1
       '@microsoft/api-documenter': 7.19.13
@@ -186,6 +189,7 @@ importers:
       '@types/react-dom': 17.0.17
       '@types/shelljs': 0.8.11
       '@types/ws': 8.5.3
+      '@types/yargs': 17.0.13
       babel-loader: 8.2.5_rhsdbzevgb5tizdhlla5jsbgyu
       esbuild: 0.15.8
       generate-license-file: 1.3.0_eslint@8.23.1
@@ -2156,7 +2160,7 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 17.0.45
-      '@types/yargs': 17.0.11
+      '@types/yargs': 17.0.13
       chalk: 4.1.2
     dev: true
 
@@ -4204,8 +4208,8 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@types/yargs/17.0.11:
-    resolution: {integrity: sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==}
+  /@types/yargs/17.0.13:
+    resolution: {integrity: sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==}
     dependencies:
       '@types/yargs-parser': 21.0.0
     dev: true
@@ -5907,6 +5911,14 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
+  /cliui/8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   /clone-deep/4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
@@ -7238,7 +7250,6 @@ packages:
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
-    dev: true
 
   /escape-html/1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -8254,7 +8265,6 @@ packages:
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-    dev: true
 
   /get-intrinsic/1.1.2:
     resolution: {integrity: sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==}
@@ -9477,7 +9487,7 @@ packages:
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
-      yargs: 17.5.1
+      yargs: 17.6.0
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -12289,7 +12299,6 @@ packages:
   /require-directory/2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /require-from-string/2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -14306,7 +14315,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -14382,7 +14390,6 @@ packages:
   /y18n/5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-    dev: true
 
   /yallist/3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -14410,7 +14417,6 @@ packages:
   /yargs-parser/21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
-    dev: true
 
   /yargs/16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
@@ -14425,18 +14431,17 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /yargs/17.5.1:
-    resolution: {integrity: sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==}
+  /yargs/17.6.0:
+    resolution: {integrity: sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==}
     engines: {node: '>=12'}
     dependencies:
-      cliui: 7.0.4
+      cliui: 8.0.1
       escalade: 3.1.1
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: true
 
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}


### PR DESCRIPTION
This PR updates pages `dev` command to accept a new argument `scope` which indicates The subfolder path inside templatesRoot and sitesConfigRoot to scope a build to -- use for multibrand setup.

Additionally, this PR update pages cli to use [yargs](https://www.npmjs.com/package/yargs) to build a more interactive CLI, and handle parsing arguments as we add more flags and options to current commands.

TEST=manual

tested the following commands:
- `pages preview` (although the actual command functionality doesn't seem to work, potentially a bug? -- http://localhost:4173/ doesn't display anything)
- `pages init` and `pages init --folderToCreate` - created the repo folder successfully
- `pages generate features` - generated features.json for root level (will update in another pr to add `scope` flag)
- `pages dev` and `pages dev --scope locations1.brand.com` - served a local build successfully for root and scoped level
- `pages dec --local` - disabled dynamic generate test data