### PR TITLE
feat(dev/plugin): add build command with scope flag

### DIFF
--- a/packages/pages/src/bin/pages.ts
+++ b/packages/pages/src/bin/pages.ts
@@ -1,6 +1,7 @@
 import { initCommandModule } from "../init/init.js";
 import { devCommandModule } from "../dev/dev.js";
 import { generateCommandModule } from "../generate/generate.js";
+import { buildCommandModule } from "../build/build.js";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
@@ -22,6 +23,7 @@ yargs(hideBin(process.argv))
   .command(devCommandModule)
   .command(initCommandModule)
   .command(generateCommandModule)
+  .command(buildCommandModule)
   .demandCommand()
   .version(false)
   .strict()

--- a/packages/pages/src/build/build.ts
+++ b/packages/pages/src/build/build.ts
@@ -6,10 +6,12 @@ type BuildArgs = Pick<ProjectFilepaths, "scope">;
 
 const handler = async ({ scope }: BuildArgs) => {
   // Pass CLI arguments as env variables to use in vite-plugin
-  if (scope) {
-    process.env.YEXT_PAGES_SCOPE = scope;
-  }
-  shell.exec("vite build");
+  shell.exec("vite build", {
+    env: {
+      ...process.env,
+      YEXT_PAGES_SCOPE: scope,
+    },
+  });
 };
 
 export const buildCommandModule: CommandModule<unknown, BuildArgs> = {

--- a/packages/pages/src/build/build.ts
+++ b/packages/pages/src/build/build.ts
@@ -1,0 +1,26 @@
+import shell from "shelljs";
+import { CommandModule } from "yargs";
+import { ProjectFilepaths } from "../common/src/project/structure.js";
+
+type BuildArgs = Pick<ProjectFilepaths, "scope">;
+
+const handler = async ({ scope }: BuildArgs) => {
+  // Pass CLI arguments as env variables to use in vite-plugin
+  if (scope) {
+    process.env.YEXT_PAGES_SCOPE = scope;
+  }
+  shell.exec("vite build");
+};
+
+export const buildCommandModule: CommandModule<unknown, BuildArgs> = {
+  command: "build",
+  describe: "Build site using Vite",
+  builder: (yargs) => {
+    return yargs.option("scope", {
+      describe: "The subfolder to scope the served templates from",
+      type: "string",
+      demandOption: false,
+    });
+  },
+  handler,
+};

--- a/packages/pages/src/common/src/project/structure.ts
+++ b/packages/pages/src/common/src/project/structure.ts
@@ -1,5 +1,5 @@
 import pathLib from "path";
-import _ from "lodash";
+import merge from "lodash/merge.js";
 import { Path } from "./path.js";
 
 /**
@@ -124,7 +124,7 @@ export class ProjectStructure {
   siteStreamConfig: string;
 
   constructor(config?: Optional<ProjectStructureConfig>) {
-    this.#config = _.merge(defaultProjectStructureConfig, config);
+    this.#config = merge(defaultProjectStructureConfig, config);
     this.sitesConfigRoot = new Path(
       this.#config.filepathsConfig.sitesConfigRoot
     );

--- a/packages/pages/src/vite-plugin/plugin.ts
+++ b/packages/pages/src/vite-plugin/plugin.ts
@@ -5,6 +5,7 @@ import {
   ProjectStructureConfig,
 } from "../common/src/project/structure.js";
 import { build } from "./build/build.js";
+import _ from "lodash";
 
 /**
  * Options to configure functionality of the plugin.
@@ -16,7 +17,16 @@ export type Options = {
 };
 
 const plugin = (opts: Options = {}): PluginOption[] => {
-  const projectStructure = new ProjectStructure(opts.projectStructureConfig);
+  const projectConfigFromBuildArgs: Optional<ProjectStructureConfig> = {
+    filepathsConfig: {
+      scope: process.env.YEXT_PAGES_SCOPE,
+    },
+  };
+  const userProjectStructureConfig = _.merge(
+    opts.projectStructureConfig,
+    projectConfigFromBuildArgs
+  );
+  const projectStructure = new ProjectStructure(userProjectStructureConfig);
 
   return [build(projectStructure)];
 };

--- a/packages/pages/src/vite-plugin/plugin.ts
+++ b/packages/pages/src/vite-plugin/plugin.ts
@@ -5,7 +5,7 @@ import {
   ProjectStructureConfig,
 } from "../common/src/project/structure.js";
 import { build } from "./build/build.js";
-import _ from "lodash";
+import merge from "lodash/merge.js";
 
 /**
  * Options to configure functionality of the plugin.
@@ -22,7 +22,7 @@ const plugin = (opts: Options = {}): PluginOption[] => {
       scope: process.env.YEXT_PAGES_SCOPE,
     },
   };
-  const userProjectStructureConfig = _.merge(
+  const userProjectStructureConfig = merge(
     opts.projectStructureConfig,
     projectConfigFromBuildArgs
   );


### PR DESCRIPTION
Vite CLI does not allow user to pass non-vite arguments (github discussions: [[1](https://github.com/vitejs/vite/issues/7065)][[2](https://github.com/vitejs/vite/pull/1188)][[3](https://github.com/vitejs/vite/issues/2891)]) -- it will throw an error for unorganized options. The recommended approach in these github discussions is to use environment variable to pass flags or info to custom vite plugins.

This PR added a new pages command: `build`, which will accepts a `scope` option for multibrand setup. Internally, it will set  an env var `YEXT_PAGES_SCOPE` and executes `vite build`. In our pages vite plugin construction, the `scope` value store in env var will be use to construct the `ProjectStructure` object.

J=SLAP-2413
TEST=manual

tested the following commands in a [test repo](https://github.com/yen-tt/pages-starter/tree/dev/test-multibrand):
- `pages build` - successfully build a `dist` folder with expected server and static files based on templates at root level
- `pages build --scope locations.brand2.com` - successfully build a `dist` folder with expected server and static files based on templates from locations.brand2.com folder

- ran `npm run build` for root level temmplates and `npm run build:multibrand` for locations.brand1.com templates, and `npm run serve`. See that both builds contain the expected pages.
