### PR TITLE
fix(dev): add back favicon support in dev mode

### DIFF
--- a/packages/pages/src/common/src/template/internal/loader.ts
+++ b/packages/pages/src/common/src/template/internal/loader.ts
@@ -11,6 +11,7 @@ const TEMP_DIR = ".temp";
 
 /**
  * Loads all templates in the project.
+ *
  * @param templateModulePaths the templates filepaths to load as modules
  * @param transpile set to true if the templates need to be transpiled (such as when they are in tsx format)
  * @param adjustForFingerprintedAsset removes the fingerprint portion (for server bundles)

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -38,6 +38,7 @@ export const serverRenderSlugRoute =
 
       const document = await getDocument(
         dynamicGenerateData,
+        vite,
         slug,
         locale,
         projectStructure
@@ -78,6 +79,7 @@ export const serverRenderSlugRoute =
 
 const getDocument = async (
   dynamicGenerateData: boolean,
+  vite: ViteDevServer,
   slug: string,
   locale: string,
   projectStructure: ProjectStructure
@@ -85,6 +87,7 @@ const getDocument = async (
   if (dynamicGenerateData) {
     return generateTestDataForSlug(
       process.stdout,
+      vite,
       slug,
       locale,
       projectStructure

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -70,10 +70,6 @@ export const generateTestDataForSlug = async (
   return getDocumentByLocale(parsedData, locale);
 };
 
-/**
- * In dev mode, we cannot use the loadTemplateModules that uses esbuild.
- * Instead we have to rely on vite to import templates.
- */
 const loadTemplateModuleCollectionUsingVite = async (
   vite: ViteDevServer,
   templateFilepaths: string[]

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -52,7 +52,6 @@ export const generateTestDataForSlug = async (
   locale: string,
   projectStructure: ProjectStructure
 ): Promise<any> => {
-  console.log("before loading template modules");
   const templateFilepaths =
     getTemplateFilepathsFromProjectStructure(projectStructure);
   const templateModuleCollection = await loadTemplateModuleCollectionUsingVite(

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -79,18 +79,16 @@ const loadTemplateModuleCollectionUsingVite = async (
   vite: ViteDevServer,
   templateFilepaths: string[]
 ): Promise<TemplateModuleCollection> => {
-  const templateModules: TemplateModuleInternal<any, any>[] = [];
-  for (const templateFilepath of templateFilepaths) {
-    const templateModule = await loadTemplateModule(vite, templateFilepath);
-
-    const templateModuleInternal =
-      convertTemplateModuleToTemplateModuleInternal(
+  const templateModules: TemplateModuleInternal<any, any>[] = await Promise.all(
+    templateFilepaths.map(async (templateFilepath) => {
+      const templateModule = await loadTemplateModule(vite, templateFilepath);
+      return convertTemplateModuleToTemplateModuleInternal(
         templateFilepath,
         templateModule,
         false
       );
-    templateModules.push(templateModuleInternal);
-  }
+    })
+  );
   return templateModules.reduce((prev, module) => {
     return prev.set(module.config.name, module);
   }, new Map());

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -71,9 +71,10 @@ export const generateTestDataForSlug = async (
 };
 
 /**
- * We cannot use the loadTemplateModules that uses esbuild in dev mode,
- * instead we have to rely on vite to import templates.
- * Otherwise, we lose loader support for things like .ico files.
+ * In dev mode, we cannot use the loadTemplateModules that uses esbuild.
+ * Trying to do so results in losing loader support for .ico files and possibly
+ * other file types.
+ * Instead we have to rely on vite to import templates.
  */
 const loadTemplateModuleCollectionUsingVite = async (
   vite: ViteDevServer,

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -72,8 +72,6 @@ export const generateTestDataForSlug = async (
 
 /**
  * In dev mode, we cannot use the loadTemplateModules that uses esbuild.
- * Trying to do so results in losing loader support for .ico files and possibly
- * other file types.
  * Instead we have to rely on vite to import templates.
  */
 const loadTemplateModuleCollectionUsingVite = async (

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -11,8 +11,14 @@ import path from "path";
 import fs from "fs";
 import { ProjectStructure } from "../../../common/src/project/structure.js";
 import { getFeaturesConfig } from "../../../generate/features/createFeaturesJson.js";
-import { loadTemplateModules } from "../../../common/src/template/internal/loader.js";
 import { getTemplateFilepathsFromProjectStructure } from "../../../common/src/template/internal/getTemplateFilepaths.js";
+import {
+  convertTemplateModuleToTemplateModuleInternal,
+  TemplateModuleInternal,
+} from "../../../common/src/template/internal/types.js";
+import { ViteDevServer } from "vite";
+import { loadTemplateModule } from "./loadTemplateModule.js";
+import { TemplateModuleCollection } from "../../../vite-plugin/build/closeBundle/moduleLoader.js";
 
 /**
  * generateTestData will run yext pages generate-test-data and return true in
@@ -41,16 +47,19 @@ export const generateTestData = async (hostname?: string): Promise<boolean> => {
 
 export const generateTestDataForSlug = async (
   stdout: NodeJS.WriteStream,
+  vite: ViteDevServer,
   slug: string,
   locale: string,
   projectStructure: ProjectStructure
 ): Promise<any> => {
-  const templateModules = await loadTemplateModules(
-    getTemplateFilepathsFromProjectStructure(projectStructure),
-    true,
-    false
+  console.log("before loading template modules");
+  const templateFilepaths =
+    getTemplateFilepathsFromProjectStructure(projectStructure);
+  const templateModuleCollection = await loadTemplateModuleCollectionUsingVite(
+    vite,
+    templateFilepaths
   );
-  const featuresConfig = await getFeaturesConfig(templateModules);
+  const featuresConfig = await getFeaturesConfig(templateModuleCollection);
   const featuresConfigForEntityPages: FeaturesConfig = {
     features: featuresConfig.features.filter((f) => "entityPageSet" in f),
     streams: featuresConfig.streams,
@@ -60,6 +69,32 @@ export const generateTestDataForSlug = async (
 
   const parsedData = await spawnTestDataCommand(stdout, "yext", args);
   return getDocumentByLocale(parsedData, locale);
+};
+
+/**
+ * We cannot use the loadTemplateModules that uses esbuild in dev mode,
+ * instead we have to rely on vite to import templates.
+ * Otherwise, we lose loader support for things like .ico files.
+ */
+const loadTemplateModuleCollectionUsingVite = async (
+  vite: ViteDevServer,
+  templateFilepaths: string[]
+): Promise<TemplateModuleCollection> => {
+  const templateModules: TemplateModuleInternal<any, any>[] = [];
+  for (const templateFilepath of templateFilepaths) {
+    const templateModule = await loadTemplateModule(vite, templateFilepath);
+
+    const templateModuleInternal =
+      convertTemplateModuleToTemplateModuleInternal(
+        templateFilepath,
+        templateModule,
+        false
+      );
+    templateModules.push(templateModuleInternal);
+  }
+  return templateModules.reduce((prev, module) => {
+    return prev.set(module.config.name, module);
+  }, new Map());
 };
 
 export const generateTestDataForPage = async (


### PR DESCRIPTION
It appears we can't use loadTemplateModules() in dev mode. If we try to do so we lose support for importing .ico files (and I imagine other kinds of loaders too).

Instead, calling loadTemplateModule() (which is not used in loadTemplateModules()) in a loop works since it relies on vite to import modules.

J=[SlackThread](https://yext.slack.com/archives/C016ZKY42CF/p1668696423830079?thread_ts=1668627719.720419&cid=C016ZKY42CF)
TEST=manual

tested that I can import .ico favicons in the pages react starter, both dev mode and prod mode (yext pages generate -> yext pages serve) work