### PR TITLE
chore: update GH workflows to remove deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
 
       - name: Build with NodeJS 18
         uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
 
       - name: Set node version to 17.x
         uses: actions/setup-node@v3

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -7,13 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
 
       - name: Global install generate-license-file
         run: pnpm i -g generate-license-file
@@ -36,7 +38,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update THIRD-PARTY-NOTICES
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           message: "Automated update to THIRD-PARTY-NOTICES from github action's 3rd party notices check"
           push: true

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
 
       - name: "test with node ${{ matrix.node-version }}"
         uses: actions/setup-node@v3


### PR DESCRIPTION
Upgrade GitHub actions (`pnpm/action-setup`, `amannn/action-semantic-pull-request`, and `EndBug/add-and-commit`) to remove all deprecation warnings from the workflows. These warnings were for the deprecation of [Node 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and for the `set-output` and `save-state` [commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

J=SLAP-2427
TEST=manual

Test in this PR as well as #260 and #261. See that the warnings are no longer present. Note: the linting workflow will still show warnings until this PR is merged in.