### PR TITLE
feat(dev): use new available port if default dev server port is occupied

### DIFF
--- a/packages/pages/THIRD-PARTY-NOTICES
+++ b/packages/pages/THIRD-PARTY-NOTICES
@@ -104,6 +104,7 @@ The following NPM packages may be included in this product:
 
  - chalk@5.0.1
  - cli-spinners@2.7.0
+ - get-port@6.1.2
  - open@8.4.0
  - ora@6.1.2
 

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -70,6 +70,7 @@
     "esm-module-paths": "^1.1.1",
     "express": "^4.18.1",
     "fs-extra": "^10.1.0",
+    "get-port": "^6.1.2",
     "glob": "^7.2.3",
     "handlebars": "^4.7.7",
     "ink": "^3.2.0",

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -1,5 +1,4 @@
 import { createServer } from "./server/server.js";
-import { viteDevServerPort } from "./server/middleware/constants.js";
 import { CommandModule } from "yargs";
 import open from "open";
 import { ProjectFilepaths } from "../common/src/project/structure.js";
@@ -10,8 +9,8 @@ interface DevArgs extends Pick<ProjectFilepaths, "scope"> {
 }
 
 const handler = async ({ scope, local, "prod-url": useProdURLs }: DevArgs) => {
-  await createServer(!local, !!useProdURLs, scope);
-  await open(`http://localhost:${viteDevServerPort}/`);
+  const devServerPort = await createServer(!local, !!useProdURLs, scope);
+  await open(`http://localhost:${devServerPort}/`);
 };
 
 export const devCommandModule: CommandModule<unknown, DevArgs> = {

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -2,6 +2,7 @@ import { createServer } from "./server/server.js";
 import { CommandModule } from "yargs";
 import open from "open";
 import { ProjectFilepaths } from "../common/src/project/structure.js";
+import { devServerPort } from "./server/middleware/constants.js";
 
 interface DevArgs extends Pick<ProjectFilepaths, "scope"> {
   local?: boolean;
@@ -9,7 +10,7 @@ interface DevArgs extends Pick<ProjectFilepaths, "scope"> {
 }
 
 const handler = async ({ scope, local, "prod-url": useProdURLs }: DevArgs) => {
-  const devServerPort = await createServer(!local, !!useProdURLs, scope);
+  await createServer(!local, !!useProdURLs, scope);
   await open(`http://localhost:${devServerPort}/`);
 };
 

--- a/packages/pages/src/dev/server/middleware/constants.ts
+++ b/packages/pages/src/dev/server/middleware/constants.ts
@@ -1,12 +1,17 @@
-export const defaultDevServerPort = 5173;
+import getPort, { portNumbers } from "get-port";
+
+// Will use any available port from 5173 to 6000, otherwise fall back to a random port
+export const devServerPort = await getPort({
+  port: portNumbers(5173, 6000),
+});
 
 export const dynamicModeInfoText = `Dynamic mode enabled. Below are sample URLs generated based on the contents 
 of the localData folder, but entity data will be re-fetched on each page load and reflect updates in real time. 
 Also, all entites specified by your stream config will be available at a url of the form: 
-localhost:{devServerPort}/[templateName]/[entityId]`;
+localhost:${devServerPort}/[templateName]/[entityId]`;
 
 export const localModeInfoText = `Local mode enabled. Below are the URLs that are available based on 
-the contents of the localData folder. URLs are of the form: localhost:{devServerPort}/[templateName]/[entityId].  
+the contents of the localData folder. URLs are of the form: localhost:${devServerPort}/[templateName]/[entityId].  
 Entity Data will only be refreshed upon regenerating the test data, so updates to entities will not be 
 reflected in real time. To regenerate test data, enter the command yext sites generate-test-data. 
 Also, entities other than the ones listed below will not be available unless run in dynamic mode.`;

--- a/packages/pages/src/dev/server/middleware/constants.ts
+++ b/packages/pages/src/dev/server/middleware/constants.ts
@@ -1,12 +1,12 @@
-export const viteDevServerPort = 5173;
+export const defaultDevServerPort = 5173;
 
 export const dynamicModeInfoText = `Dynamic mode enabled. Below are sample URLs generated based on the contents 
 of the localData folder, but entity data will be re-fetched on each page load and reflect updates in real time. 
 Also, all entites specified by your stream config will be available at a url of the form: 
-localhost:${viteDevServerPort}/[templateName]/[entityId]`;
+localhost:{devServerPort}/[templateName]/[entityId]`;
 
 export const localModeInfoText = `Local mode enabled. Below are the URLs that are available based on 
-the contents of the localData folder. URLs are of the form: localhost:${viteDevServerPort}/[templateName]/[entityId].  
+the contents of the localData folder. URLs are of the form: localhost:{devServerPort}/[templateName]/[entityId].  
 Entity Data will only be refreshed upon regenerating the test data, so updates to entities will not be 
 reflected in real time. To regenerate test data, enter the command yext sites generate-test-data. 
 Also, entities other than the ones listed below will not be available unless run in dynamic mode.`;

--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -5,6 +5,7 @@ import {
 } from "../ssr/getLocalData.js";
 import index from "../public/index.js";
 import {
+  devServerPort,
   dynamicModeInfoText,
   generateTestDataWarningText,
   localModeInfoText,
@@ -16,7 +17,6 @@ import { getTemplateFilepathsFromProjectStructure } from "../../../common/src/te
 
 type Props = {
   vite: ViteDevServer;
-  devServerPort: number;
   dynamicGenerateData: boolean;
   displayGenerateTestDataWarning: boolean;
   useProdURLs: boolean;
@@ -26,7 +26,6 @@ type Props = {
 export const indexPage =
   ({
     vite,
-    devServerPort,
     dynamicGenerateData,
     displayGenerateTestDataWarning,
     useProdURLs,
@@ -41,17 +40,15 @@ export const indexPage =
         templateFilepaths
       );
 
-      // Inject an informative message depending on if the user is in dynamic mode or not.
-      const infoText = (
-        dynamicGenerateData ? dynamicModeInfoText : localModeInfoText
-      ).replace(/{devServerPort}/g, devServerPort.toString());
-      let indexPageHtml = index.replace(
-        `<!--info-html-->`,
-        `<div class="info">
+      let indexPageHtml = index
+        // Inject an informative message depending on if the user is in dynamic mode or not.
+        .replace(
+          `<!--info-html-->`,
+          `<div class="info">
           <i class="fa fa-info-circle"></i>
-          ${infoText}
+          ${dynamicGenerateData ? dynamicModeInfoText : localModeInfoText}
         </div>`
-      );
+        );
 
       // If there is any localData, display hyperlinks to each page that will be generated
       // from each data document.
@@ -62,7 +59,7 @@ export const indexPage =
             `<!--static-pages-html-->`,
             `<div class="section-title">Static Pages</div>
           <div class="list">
-          ${createStaticPageListItems(localDataManifest, devServerPort)}
+          ${createStaticPageListItems(localDataManifest)}
           </div>
           `
           );
@@ -90,8 +87,7 @@ export const indexPage =
                   <ul>${createEntityPageListItems(
                     localDataManifest,
                     templateName,
-                    useProdURLs,
-                    devServerPort
+                    useProdURLs
                   )}</ul>`,
             ""
           )}
@@ -131,10 +127,7 @@ export const indexPage =
     }
   };
 
-const createStaticPageListItems = (
-  localDataManifest: LocalDataManifest,
-  devServerPort: number
-) => {
+const createStaticPageListItems = (localDataManifest: LocalDataManifest) => {
   return Array.from(localDataManifest.static).reduce(
     (templateAccumulator, { featureName, staticURL }) =>
       templateAccumulator +
@@ -155,8 +148,7 @@ const createStaticPageListItems = (
 const createEntityPageListItems = (
   localDataManifest: LocalDataManifest,
   templateName: string,
-  useProdURLs: boolean,
-  devServerPort: number
+  useProdURLs: boolean
 ) => {
   const formatLink = (entityId: string, slug: string | undefined) => {
     if (useProdURLs) {

--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -9,7 +9,6 @@ import {
   generateTestDataWarningText,
   localModeInfoText,
   noLocalDataErrorText,
-  viteDevServerPort,
 } from "./constants.js";
 import { ViteDevServer } from "vite";
 import { ProjectStructure } from "../../../common/src/project/structure.js";
@@ -17,6 +16,7 @@ import { getTemplateFilepathsFromProjectStructure } from "../../../common/src/te
 
 type Props = {
   vite: ViteDevServer;
+  devServerPort: number;
   dynamicGenerateData: boolean;
   displayGenerateTestDataWarning: boolean;
   useProdURLs: boolean;
@@ -26,6 +26,7 @@ type Props = {
 export const indexPage =
   ({
     vite,
+    devServerPort,
     dynamicGenerateData,
     displayGenerateTestDataWarning,
     useProdURLs,
@@ -40,13 +41,17 @@ export const indexPage =
         templateFilepaths
       );
 
+      const infoText = (
+        dynamicGenerateData ? dynamicModeInfoText : localModeInfoText
+      ).replace(new RegExp(/{devServerPort}/g), devServerPort.toString());
+
       let indexPageHtml = index
         // Inject an informative message depending on if the user is in dynamic mode or not.
         .replace(
           `<!--info-html-->`,
           `<div class="info">
           <i class="fa fa-info-circle"></i>
-          ${dynamicGenerateData ? dynamicModeInfoText : localModeInfoText}
+          ${infoText}
         </div>`
         );
 
@@ -59,7 +64,7 @@ export const indexPage =
             `<!--static-pages-html-->`,
             `<div class="section-title">Static Pages</div>
           <div class="list">
-          ${createStaticPageListItems(localDataManifest)}
+          ${createStaticPageListItems(localDataManifest, devServerPort)}
           </div>
           `
           );
@@ -87,7 +92,8 @@ export const indexPage =
                   <ul>${createEntityPageListItems(
                     localDataManifest,
                     templateName,
-                    useProdURLs
+                    useProdURLs,
+                    devServerPort
                   )}</ul>`,
             ""
           )}
@@ -127,14 +133,17 @@ export const indexPage =
     }
   };
 
-const createStaticPageListItems = (localDataManifest: LocalDataManifest) => {
+const createStaticPageListItems = (
+  localDataManifest: LocalDataManifest,
+  devServerPort: number
+) => {
   return Array.from(localDataManifest.static).reduce(
     (templateAccumulator, { featureName, staticURL }) =>
       templateAccumulator +
       `<div class="list-title"> <span class="list-title-templateName">${featureName}</span> Pages (1):</div>
     <ul>
       <li>
-        <a href="http://localhost:${viteDevServerPort}/${encodeURIComponent(
+        <a href="http://localhost:${devServerPort}/${encodeURIComponent(
         staticURL
       )}">
           ${staticURL}
@@ -148,14 +157,15 @@ const createStaticPageListItems = (localDataManifest: LocalDataManifest) => {
 const createEntityPageListItems = (
   localDataManifest: LocalDataManifest,
   templateName: string,
-  useProdURLs: boolean
+  useProdURLs: boolean,
+  devServerPort: number
 ) => {
   const formatLink = (entityId: string, slug: string | undefined) => {
     if (useProdURLs) {
-      return `http://localhost:${viteDevServerPort}/${slug}`;
+      return `http://localhost:${devServerPort}/${slug}`;
     }
 
-    return `http://localhost:${viteDevServerPort}/${encodeURIComponent(
+    return `http://localhost:${devServerPort}/${encodeURIComponent(
       templateName
     )}/${entityId}`;
   };

--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -41,19 +41,17 @@ export const indexPage =
         templateFilepaths
       );
 
+      // Inject an informative message depending on if the user is in dynamic mode or not.
       const infoText = (
         dynamicGenerateData ? dynamicModeInfoText : localModeInfoText
-      ).replace(new RegExp(/{devServerPort}/g), devServerPort.toString());
-
-      let indexPageHtml = index
-        // Inject an informative message depending on if the user is in dynamic mode or not.
-        .replace(
-          `<!--info-html-->`,
-          `<div class="info">
+      ).replace(/{devServerPort}/g, devServerPort.toString());
+      let indexPageHtml = index.replace(
+        `<!--info-html-->`,
+        `<div class="info">
           <i class="fa fa-info-circle"></i>
           ${infoText}
         </div>`
-        );
+      );
 
       // If there is any localData, display hyperlinks to each page that will be generated
       // from each data document.

--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -3,13 +3,12 @@ import { createServer as createViteServer } from "vite";
 import { serverRenderRoute } from "./middleware/serverRenderRoute.js";
 import { ignoreFavicon } from "./middleware/ignoreFavicon.js";
 import { errorMiddleware } from "./middleware/errorMiddleware.js";
-import { defaultDevServerPort } from "./middleware/constants.js";
+import { devServerPort } from "./middleware/constants.js";
 import { indexPage } from "./middleware/indexPage.js";
 import { generateTestData } from "./ssr/generateTestData.js";
 import { ProjectStructure } from "../../common/src/project/structure.js";
 import { finalSlashRedirect } from "./middleware/finalSlashRedirect.js";
 import { serverRenderSlugRoute } from "./middleware/serverRenderSlugRoute.js";
-import getPort from "get-port";
 
 export const createServer = async (
   dynamicGenerateData: boolean,
@@ -55,11 +54,6 @@ export const createServer = async (
     ));
   }
 
-  // Will use defaultDevServerPort if available, otherwise fall back to a random available port
-  const devServerPort = await getPort({
-    port: defaultDevServerPort,
-  });
-
   // When a page is requested that is anything except the root, call our
   // serverRenderRoute middleware.
   app.use(
@@ -74,7 +68,6 @@ export const createServer = async (
     "/",
     indexPage({
       vite,
-      devServerPort,
       dynamicGenerateData,
       displayGenerateTestDataWarning,
       useProdURLs,

--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -3,18 +3,19 @@ import { createServer as createViteServer } from "vite";
 import { serverRenderRoute } from "./middleware/serverRenderRoute.js";
 import { ignoreFavicon } from "./middleware/ignoreFavicon.js";
 import { errorMiddleware } from "./middleware/errorMiddleware.js";
-import { viteDevServerPort } from "./middleware/constants.js";
+import { defaultDevServerPort } from "./middleware/constants.js";
 import { indexPage } from "./middleware/indexPage.js";
 import { generateTestData } from "./ssr/generateTestData.js";
 import { ProjectStructure } from "../../common/src/project/structure.js";
 import { finalSlashRedirect } from "./middleware/finalSlashRedirect.js";
 import { serverRenderSlugRoute } from "./middleware/serverRenderSlugRoute.js";
+import getPort from "get-port";
 
 export const createServer = async (
   dynamicGenerateData: boolean,
   useProdURLs: boolean,
   scope?: string
-) => {
+): Promise<number> => {
   // creates a standard express app
   const app = express();
 
@@ -54,6 +55,11 @@ export const createServer = async (
     ));
   }
 
+  // Will use defaultDevServerPort if available, otherwise fall back to a random available port
+  const devServerPort = await getPort({
+    port: defaultDevServerPort,
+  });
+
   // When a page is requested that is anything except the root, call our
   // serverRenderRoute middleware.
   app.use(
@@ -68,6 +74,7 @@ export const createServer = async (
     "/",
     indexPage({
       vite,
+      devServerPort,
       dynamicGenerateData,
       displayGenerateTestDataWarning,
       useProdURLs,
@@ -77,8 +84,8 @@ export const createServer = async (
 
   app.use(errorMiddleware(vite));
 
-  // start the server on port 3000
-  app.listen(viteDevServerPort, () =>
-    process.stdout.write(`listening on :${viteDevServerPort}\n`)
+  app.listen(devServerPort, () =>
+    process.stdout.write(`listening on :${devServerPort}\n`)
   );
+  return devServerPort;
 };

--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -14,7 +14,7 @@ export const createServer = async (
   dynamicGenerateData: boolean,
   useProdURLs: boolean,
   scope?: string
-): Promise<number> => {
+) => {
   // creates a standard express app
   const app = express();
 
@@ -80,5 +80,4 @@ export const createServer = async (
   app.listen(devServerPort, () =>
     process.stdout.write(`listening on :${devServerPort}\n`)
   );
-  return devServerPort;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,7 @@ importers:
       express: ^4.18.1
       fs-extra: ^10.1.0
       generate-license-file: ^1.3.0
+      get-port: ^6.1.2
       glob: ^7.2.3
       handlebars: ^4.7.7
       identity-obj-proxy: ^3.0.0
@@ -142,6 +143,7 @@ importers:
       esm-module-paths: 1.1.1
       express: 4.18.1
       fs-extra: 10.1.0
+      get-port: 6.1.2
       glob: 7.2.3
       handlebars: 4.7.7
       ink: 3.2.0_pxzommwrsowkd4kgag6q3sluym
@@ -8277,6 +8279,11 @@ packages:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
     dev: true
+
+  /get-port/6.1.2:
+    resolution: {integrity: sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
 
   /get-stdin/4.0.1:
     resolution: {integrity: sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==}


### PR DESCRIPTION
Update pages dev command to use new port if the default port 5173 is already occupied.

J=SLAP-2461
TEST=manual

- run `pages dev` and see that the default port is used as normal.
- run `npx serve -p 5173` to occupy the default port. Then run `pages dev` and see that a random available port is use (instead of erroring out and exit like before), and the info text also display the new port.