### PR TITLE
fix(utils): improve runtime environment checking

### DIFF
--- a/packages/pages/src/components/analytics/provider.tsx
+++ b/packages/pages/src/components/analytics/provider.tsx
@@ -42,7 +42,7 @@ export function AnalyticsProvider(
   }
 
   let enableDebuggingDefault = debuggingParamDetected();
-  if (typeof process !== "undefined") {
+  if (getRuntime().name === "node") {
     enableDebuggingDefault =
       enableDebuggingDefault || process.env?.NODE_ENV === "development";
   }

--- a/packages/pages/src/util/runtime.ts
+++ b/packages/pages/src/util/runtime.ts
@@ -9,7 +9,7 @@ class Runtime {
   version: string;
 
   constructor() {
-    if (typeof process !== "undefined") {
+    if (this.isNodeProcess()) {
       this.name = "node";
       this.version = process.versions.node;
       this.isServerSide = true;
@@ -25,6 +25,13 @@ class Runtime {
       }
       this.isServerSide = true;
     }
+  }
+
+  isNodeProcess(): boolean {
+    return (
+      typeof process !== "undefined" &&
+      process.release?.name?.search(/node|io.js/) !== -1
+    );
   }
 
   getNodeMajorVersion(): number {

--- a/packages/pages/src/util/runtime.ts
+++ b/packages/pages/src/util/runtime.ts
@@ -1,5 +1,5 @@
 class Runtime {
-  name: "node" | "deno" | "browser";
+  name: "node" | "deno" | "browser" | "unknown";
   /**
    * Whether or not the current runtime is being executed server-side or client-side. If the runtime
    * is node or deno then isServerSide will be true. When the runtime is browser isServerSide is
@@ -9,29 +9,33 @@ class Runtime {
   version: string;
 
   constructor() {
-    if (this.isNodeProcess()) {
-      this.name = "node";
-      this.version = process.versions.node;
-      this.isServerSide = true;
-    } else if (typeof window !== "undefined" && !("Deno" in window)) {
+    if (this.isBrowser()) {
       this.name = "browser";
       this.version = navigator.userAgent;
       this.isServerSide = false;
-    } else {
+      return;
+    }
+
+    if (this.isNode()) {
+      this.name = "node";
+      this.version = process.versions.node;
+      this.isServerSide = true;
+      return;
+    }
+
+    if (this.isDeno()) {
       this.name = "deno";
       this.version = "";
       if (typeof window !== "undefined") {
         this.version = (window as any).Deno?.version.deno || "";
       }
       this.isServerSide = true;
+      return;
     }
-  }
 
-  isNodeProcess(): boolean {
-    return (
-      typeof process !== "undefined" &&
-      process.release?.name?.search(/node|io.js/) !== -1
-    );
+    this.name = "unknown";
+    this.isServerSide = true;
+    this.version = "";
   }
 
   getNodeMajorVersion(): number {
@@ -40,6 +44,33 @@ class Runtime {
     }
 
     return +this.version.split(".")[0];
+  }
+
+  isBrowser(): boolean {
+    return (
+      typeof window != "undefined" &&
+      typeof window.document !== "undefined" &&
+      !("Deno" in window)
+    );
+  }
+
+  isDeno(): boolean {
+    // @ts-expect-error Deno may be undefined
+    return (
+      typeof Deno !== "undefined" &&
+      // @ts-expect-error Deno may be undefined
+      typeof Deno.version !== "undefined" &&
+      // @ts-expect-error Deno may be undefined
+      typeof Deno.version.deno !== "undefined"
+    );
+  }
+
+  isNode(): boolean {
+    return (
+      typeof process !== "undefined" &&
+      process.versions != null &&
+      process.versions.node != null
+    );
   }
 }
 

--- a/packages/pages/src/util/runtime.ts
+++ b/packages/pages/src/util/runtime.ts
@@ -1,12 +1,12 @@
 class Runtime {
-  name: "node" | "deno" | "browser" | "unknown";
+  name?: "node" | "deno" | "browser";
   /**
    * Whether or not the current runtime is being executed server-side or client-side. If the runtime
    * is node or deno then isServerSide will be true. When the runtime is browser isServerSide is
    * false.
    */
-  isServerSide: boolean;
-  version: string;
+  isServerSide?: boolean;
+  version?: string;
 
   constructor() {
     if (this.isBrowser()) {
@@ -32,15 +32,15 @@ class Runtime {
       this.isServerSide = true;
       return;
     }
-
-    this.name = "unknown";
-    this.isServerSide = true;
-    this.version = "";
   }
 
   getNodeMajorVersion(): number {
     if (this.name != "node") {
       throw new Error("Not running in Node.");
+    }
+
+    if (!this.version) {
+      throw new Error("No version found.");
     }
 
     return +this.version.split(".")[0];

--- a/packages/pages/src/util/runtime.ts
+++ b/packages/pages/src/util/runtime.ts
@@ -55,8 +55,8 @@ class Runtime {
   }
 
   isDeno(): boolean {
-    // @ts-expect-error Deno may be undefined
     return (
+      // @ts-expect-error Deno may be undefined
       typeof Deno !== "undefined" &&
       // @ts-expect-error Deno may be undefined
       typeof Deno.version !== "undefined" &&


### PR DESCRIPTION
fix #244 
Employ more comprehensive environment checking following the checks in [browser-or-node](https://github.com/flexdinesh/browser-or-node/blob/master/src/index.js)

J=SLAP-2435
TEST=manual

create and install pages binary in starter, compared old check to new check with a global variable `process` as described in Github issue.