### PR TITLE
fix(dev): fix dev command on Windows

### DIFF
--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -50,7 +50,7 @@
     "prepare": "pnpm build"
   },
   "bin": {
-    "pages": "dist/bin/pages.sh"
+    "pages": "dist/bin/pages.js"
   },
   "files": [
     "dist/**/*",

--- a/packages/pages/src/bin/pages.sh
+++ b/packages/pages/src/bin/pages.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-/usr/bin/env node --experimental-specifier-resolution=node --experimental-vm-modules node_modules/@yext/pages/dist/bin/pages.js "$@"

--- a/packages/pages/src/bin/pages.ts
+++ b/packages/pages/src/bin/pages.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node --experimental-specifier-resolution=node --experimental-vm-modules
+
 import { initCommandModule } from "../init/init.js";
 import { devCommandModule } from "../dev/dev.js";
 import { generateCommandModule } from "../generate/generate.js";

--- a/packages/pages/src/bundler.js
+++ b/packages/pages/src/bundler.js
@@ -21,7 +21,7 @@ const testFilter = (f) =>
   !f.endsWith(".test.ts") &&
   !f.endsWith(".test.tsx") &&
   !f.endsWith(".test.js");
-const filters = new Set(["./src/bundler.js", "./src/bin/pages.sh"]);
+const filters = new Set(["./src/bundler.js"]);
 
 const files = glob
   .sync("./src/**/*\\.*")
@@ -75,11 +75,3 @@ try {
 } catch (e) {
   console.error(e);
 }
-
-/**
- * Copy the sh binary.
- */
-copyFileSync(
-  path.resolve("./src/bin/pages.sh"),
-  path.resolve("./dist/bin/pages.sh")
-);

--- a/packages/pages/tsconfig.json
+++ b/packages/pages/tsconfig.json
@@ -16,5 +16,5 @@
     "types": ["vite/client", "jest", "node"]
   },
   "include": ["src", "index.d.ts"],
-  "exclude": ["src/bundler.js", "src/bin/pages.sh", "node_modules"]
+  "exclude": ["src/bundler.js", "node_modules"]
 }


### PR DESCRIPTION
Removes pages.sh because bash scripts don't work on Windows. A follow up PR will add an acceptance test so this doesn't break again.

J=SLAP-2496
TEST=manual

pages dev works on my physical windows machine after this change