### PR TITLE
feat: gracefully handle Analytics failures in the `Link` Component.

### DIFF
--- a/packages/pages/src/components/link/link.test.tsx
+++ b/packages/pages/src/components/link/link.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Link } from "./link.js";
 
 describe("Link", () => {
@@ -24,6 +24,41 @@ describe("Link", () => {
 
   it("renders component when given full cta prop and no children", () => {
     render(<Link cta={{ link: "https://yext.com" }} />);
+  });
+});
+
+jest.mock("../../components/analytics", () => {
+  const trackClick = () => {
+    return () => {
+      throw new Error("Error");
+    };
+  };
+  return {
+    useAnalytics: () => {
+      return { trackClick };
+    },
+  };
+});
+
+describe("Link Component Handles Analytics Failures", () => {
+  it("registers console.error", () => {
+    const errorMock = jest.spyOn(console, "error").mockImplementation();
+
+    render(<Link cta={{ link: "https://yext.com" }} />);
+    const link = screen.getByRole("link");
+
+    link.click();
+    expect(errorMock).toBeCalledTimes(1);
+    expect(errorMock).toBeCalledWith("Failed to report click Analytics Event");
+  });
+
+  it("still invokes onClick", () => {
+    const onClick = jest.fn();
+    render(<Link cta={{ link: "https://yext.com" }} onClick={onClick} />);
+    const link = screen.getByRole("link");
+
+    link.click();
+    expect(onClick).toHaveBeenCalled();
   });
 });
 

--- a/packages/pages/src/components/link/link.tsx
+++ b/packages/pages/src/components/link/link.tsx
@@ -35,7 +35,11 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     const handleClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
       setHumanInteraction(true);
       if (analytics !== null) {
-        await analytics.trackClick(trackEvent, props.conversionDetails)(e);
+        try {
+          await analytics.trackClick(trackEvent, props.conversionDetails)(e);
+        } catch (exception) {
+          console.error("Failed to report click Analytics Event");
+        }
       }
 
       if (onClick) {


### PR DESCRIPTION
The `trackClick` Analytics call in `Link` is now wrapped in a try-catch block. So, if there's an issue reporting Analytics, we will still invoke the `onCall` method.

J=SLAP-2509
TEST=auto