### PR TITLE
chore(dev/plugin): add file extension to node_module/file import

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node-version: [18.x]
+        node-version: [18.x, 19.x]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -32,7 +32,7 @@
     }
   },
   "engines": {
-    "node": ">=17"
+    "node": "17"
   },
   "scripts": {
     "watch": "node src/bundler --watch",

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -32,7 +32,7 @@
     }
   },
   "engines": {
-    "node": "17"
+    "node": "^17 || ^18 || ^19"
   },
   "scripts": {
     "watch": "node src/bundler --watch",

--- a/packages/pages/src/bin/spawn.ts
+++ b/packages/pages/src/bin/spawn.ts
@@ -15,12 +15,7 @@ const pathToPagesScript = path.resolve(
 
 spawnSync(
   "node",
-  [
-    "--experimental-specifier-resolution=node",
-    "--experimental-vm-modules",
-    pathToPagesScript,
-    ...process.argv.slice(2),
-  ],
+  ["--experimental-vm-modules", pathToPagesScript, ...process.argv.slice(2)],
   {
     stdio: "inherit",
   }

--- a/packages/pages/src/components/hours/hours.test.tsx
+++ b/packages/pages/src/components/hours/hours.test.tsx
@@ -7,6 +7,12 @@ import { Hours } from ".";
 import { HOURS, HOURS_WITH_REOPEN_DATE } from "./sampleData.js";
 
 describe("Hours", () => {
+  beforeAll(() => {
+    jest
+      .spyOn(global.Date.prototype, "toISOString")
+      .mockReturnValue("6-11-2022 00:00:00");
+  });
+
   it("properly renders a full week", () => {
     render(<Hours hours={HOURS} />);
 

--- a/packages/pages/src/components/hours/sampleData.ts
+++ b/packages/pages/src/components/hours/sampleData.ts
@@ -100,7 +100,7 @@ export const HOURS_WITH_REOPEN_DATE = {
     isClosed: false,
     openIntervals: [{ start: "9:07", end: "18:07" }],
   },
-  reopenDate: offsetDate(3),
+  reopenDate: "6-14-2022",
 };
 
 export function offsetDate(daysForward: number) {

--- a/packages/pages/src/dev/server/middleware/sendAppHTML.ts
+++ b/packages/pages/src/dev/server/middleware/sendAppHTML.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOMServer from "react-dom/server";
+import ReactDOMServer from "react-dom/server.js";
 import { ViteDevServer } from "vite";
 import { TemplateModuleInternal } from "../../../common/src/template/internal/types.js";
 import { TemplateRenderProps } from "../../../common/src/template/types.js";

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
@@ -1,5 +1,5 @@
 import { createElement } from "react";
-import { renderToString } from "react-dom/server";
+import { renderToString } from "react-dom/server.js";
 import {
   TemplateProps,
   TemplateRenderProps,


### PR DESCRIPTION
file extensions are required for relative imports but not for node_modules. react-dom/server is unique because it is a node_modules import, but it references a specific file. This is fine in Node 16-18, but errors in Node 19. This item fixes support for Node 19

J=SLAP-2501
TEST=manual

successfully served the site using Node 16, 17, 18, and 19