### PR TITLE
feat(dev): list serverless functions on index page

### DIFF
--- a/packages/pages/src/dev/server/public/index.html
+++ b/packages/pages/src/dev/server/public/index.html
@@ -10,6 +10,7 @@
     <!--error-html-->
     <!--static-pages-html-->
     <!--entity-pages-html-->
+    <!--serverless-functions-html-->
   </body>
 </html>
 

--- a/packages/pages/src/dev/server/ssr/getPluginFileMap.ts
+++ b/packages/pages/src/dev/server/ssr/getPluginFileMap.ts
@@ -1,9 +1,6 @@
-import path from "path";
 import fs from "fs";
 
-const PLUGIN_FILE_MAP_PATH = path.resolve(
-  ".artifact-output/pluginFileMap.json"
-);
+const PLUGIN_FILE_MAP_PATH = ".artifact-output/pluginFileMap.json";
 
 /** The type of event for the serverless function. */
 export enum EventType {
@@ -13,24 +10,27 @@ export enum EventType {
   ON_URL_CHANGE = 1,
   /** A function that is invoked on a page generate event. */
   ON_PAGE_GENERATE = 2,
-  /** An API (or HTTP) function. */
-  API = 3,
+  /** An HTTP (or API) function. */
+  HTTP = 3,
 }
 
 /** Source data associated with a serverless function. */
-export type PluginSource = {
+type ServerlessFunctionSource = {
   /** File names of the source files for the function. */
   sourceFileNames: string[];
   /** Name of the function. */
   functionName: string;
   /** {@inheritDoc EventType} */
   event: EventType;
-  /** The endpoint path if it is an API function. */
-  serverlessFunctionPath?: string;
+  /** The API endpoint path if it is an HTTP function. */
+  apiPath?: string;
 };
 
 /** Returns the pluginFileMap as a mapping of function name to source data. */
-export const getPluginFileMap = (): Record<string, PluginSource> => {
+export const getPluginFileMap = (): Record<
+  string,
+  ServerlessFunctionSource
+> => {
   try {
     return JSON.parse(fs.readFileSync(PLUGIN_FILE_MAP_PATH).toString());
   } catch (err: any) {

--- a/packages/pages/src/dev/server/ssr/getPluginFileMap.ts
+++ b/packages/pages/src/dev/server/ssr/getPluginFileMap.ts
@@ -31,7 +31,6 @@ export type PluginSource = {
 
 /** Returns the pluginFileMap as a mapping of function name to source data. */
 export const getPluginFileMap = (): Record<string, PluginSource> => {
-  JSON.parse(fs.readFileSync(PLUGIN_FILE_MAP_PATH).toString());
   try {
     return JSON.parse(fs.readFileSync(PLUGIN_FILE_MAP_PATH).toString());
   } catch (err: any) {

--- a/packages/pages/src/dev/server/ssr/getPluginFileMap.ts
+++ b/packages/pages/src/dev/server/ssr/getPluginFileMap.ts
@@ -1,0 +1,34 @@
+import path from "path";
+import fs from "fs";
+
+const PLUGIN_FILE_MAP_PATH = path.resolve(
+  ".artifact-output/pluginFileMap.json"
+);
+
+/** The type of event for the serverless function. */
+export enum EventType {
+  /** The function is in an error state. */
+  UNKNOWN_EVENT = 0,
+  /** A function that is invoked on a URL change event. */
+  ON_URL_CHANGE = 1,
+  /** A function that is invoked on a page generate event. */
+  ON_PAGE_GENERATE = 2,
+  /** An API (or HTTP) function. */
+  API = 3,
+}
+
+/** Source data associated with a serverless function. */
+export type PluginSource = {
+  /** File names of the source files for the function. */
+  sourceFileNames: string[];
+  /** Name of the function. */
+  functionName: string;
+  /** {@inheritDoc EventType} */
+  event: EventType;
+  /** The endpoint path if it is an API function. */
+  serverlessFunctionPath?: string;
+};
+
+/** Returns the pluginFileMap as a mapping of function name to source data. */
+export const getPluginFileMap = (): Record<string, PluginSource> =>
+  JSON.parse(fs.readFileSync(PLUGIN_FILE_MAP_PATH).toString());

--- a/packages/pages/src/dev/server/ssr/getPluginFileMap.ts
+++ b/packages/pages/src/dev/server/ssr/getPluginFileMap.ts
@@ -30,5 +30,16 @@ export type PluginSource = {
 };
 
 /** Returns the pluginFileMap as a mapping of function name to source data. */
-export const getPluginFileMap = (): Record<string, PluginSource> =>
+export const getPluginFileMap = (): Record<string, PluginSource> => {
   JSON.parse(fs.readFileSync(PLUGIN_FILE_MAP_PATH).toString());
+  try {
+    return JSON.parse(fs.readFileSync(PLUGIN_FILE_MAP_PATH).toString());
+  } catch (err: any) {
+    if (err.code === "ENOENT") {
+      // If there is no pluginFileMap, then just return an empty object.
+      return {};
+    } else {
+      throw err;
+    }
+  }
+};


### PR DESCRIPTION
Parse `pluginFileMap.json` and list the resulting serverless HTTP functions on the local dev index page.

J=SLAP-2568
TEST=manual

Point the locations starter to a local pack of PagesJS and see that all HTTP functions with paths are listed on the index page, and no event-driven functions.
<img width="543" alt="Screen Shot 2023-02-23 at 1 41 13 PM" src="https://user-images.githubusercontent.com/88398086/221000529-208f7eb0-faa7-487a-bcde-08bff8dc1347.png">