### PR TITLE
feat(plugin): generate functionMetadata.json

### DIFF
--- a/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
@@ -10,6 +10,10 @@ import {
   TemplateModuleCollection,
 } from "../../../common/src/template/internal/loader.js";
 import { createFeaturesJson } from "../../../generate/features/createFeaturesJson.js";
+import {
+  generateFunctionMetadataFile,
+  shouldGenerateFunctionMetadata,
+} from "./functionMetadata.js";
 
 export default (projectStructure: ProjectStructure) => {
   return async () => {
@@ -55,6 +59,18 @@ export default (projectStructure: ProjectStructure) => {
       finisher.fail("Failed to write manifest.json");
       console.error(colors.red(e.message));
       return;
+    }
+
+    if (shouldGenerateFunctionMetadata()) {
+      finisher = logger.timedLog({ startLog: "Writing functionMetadata.json" });
+      try {
+        await generateFunctionMetadataFile();
+        finisher.succeed("Successfully wrote functionMetadata.json");
+      } catch (e: any) {
+        finisher.fail("Failed to write functionMetadata.json");
+        console.error(colors.red(e.message));
+        return;
+      }
     }
   };
 };

--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -25,7 +25,7 @@ const getFunctionMetadataMap = async (): Promise<
   Record<string, FunctionMetadata>
 > => {
   const filepaths = glob
-    .sync(path.join(FUNCTIONS_PATH, "**/*.{tsx,jsx,js,ts}"), { nodir: true })
+    .sync(path.join(FUNCTIONS_PATH, "**/*.{js,ts}"), { nodir: true })
     .map((f) => path.resolve(f));
   const functionMetadataArray: [string, FunctionMetadata][] = await Promise.all(
     filepaths.map(async (filepath) => {
@@ -53,7 +53,7 @@ export const generateFunctionMetadataFile = async () => {
   const functionMetadataMap = await getFunctionMetadataMap();
   fs.writeFileSync(
     FUNCTION_METADATA_PATH,
-    JSON.stringify(functionMetadataMap, null, "  ")
+    JSON.stringify(functionMetadataMap, null, 2)
   );
 };
 

--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -1,0 +1,63 @@
+import fs from "fs";
+import path from "path";
+import esbuild from "esbuild";
+import { importFromString } from "module-from-string";
+import glob from "glob";
+
+const FUNCTIONS_PATH = path.resolve("functions");
+const FUNCTION_METADATA_PATH = path.join(
+  FUNCTIONS_PATH,
+  "functionMetadata.json"
+);
+const TEMP_DIR = ".temp";
+
+/** Metadata for a serverless function. */
+type FunctionMetadata = {
+  /** Name of the function. */
+  entrypoint: string;
+};
+
+/**
+ * Returns a mapping of file path (relative to the repo root) to the metadata
+ * for the function that is the default export of that file.
+ */
+const getFunctionMetadataMap = async (): Promise<
+  Record<string, FunctionMetadata>
+> => {
+  const filepaths = glob
+    .sync(path.join(FUNCTIONS_PATH, "**/*.{tsx,jsx,js,ts}"), { nodir: true })
+    .map((f) => path.resolve(f));
+  const functionMetadataArray: [string, FunctionMetadata][] = await Promise.all(
+    filepaths.map(async (filepath) => {
+      const buildResult = await esbuild.build({
+        entryPoints: [filepath],
+        outdir: TEMP_DIR,
+        write: false,
+        format: "esm",
+        bundle: true,
+      });
+      const importedFile = await importFromString(
+        buildResult.outputFiles[0].text
+      );
+      const relativePath = path.relative(process.cwd(), filepath);
+      return [relativePath, { entrypoint: importedFile.default?.name }];
+    })
+  );
+  return Object.fromEntries(
+    functionMetadataArray.filter(([, metadata]) => metadata.entrypoint)
+  );
+};
+
+/** Generates a functionMetadata.json file from the functions directory. */
+export const generateFunctionMetadataFile = async () => {
+  const functionMetadataMap = await getFunctionMetadataMap();
+  fs.writeFileSync(
+    FUNCTION_METADATA_PATH,
+    JSON.stringify(functionMetadataMap, null, "  ")
+  );
+};
+
+/** Returns whether or not a functionMetadata.json file should be generated. */
+export const shouldGenerateFunctionMetadata = () => {
+  return fs.existsSync(FUNCTIONS_PATH);
+};


### PR DESCRIPTION
This PR adds a step to the vite-plugin's `build` command (i.e. `pages build`) to generate `functionMetadata.json`. This file contains a mapping of the files in the `functions` directory to the names of the functions that are their default exports. If there is no top-level `functions` directory, `functionMetadata.json` is not generated.

J=SLAP-2625
TEST=manual

Point the locations starter to a local pack of PagesJS and see that the file is correctly generated when there is a `functions` directory, and is not generated if there is no `functions` directory.