### PR TITLE
feat(plugin): update `functionMetadata` generation logic

### DIFF
--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -1,21 +1,21 @@
-import fs from "fs";
-import path from "path";
-import esbuild from "esbuild";
-import { importFromString } from "module-from-string";
-import glob from "glob";
+import fs from "fs"
+import path from "path"
+import esbuild from "esbuild"
+import { importFromString } from "module-from-string"
+import glob from "glob"
 
-const FUNCTIONS_PATH = path.resolve("functions");
+const FUNCTIONS_PATH = path.resolve("functions")
 const FUNCTION_METADATA_PATH = path.join(
   FUNCTIONS_PATH,
   "functionMetadata.json"
-);
-const TEMP_DIR = ".temp";
+)
+const TEMP_DIR = ".temp"
 
 /** Metadata for a serverless function. */
 type FunctionMetadata = {
   /** Name of the function. */
-  entrypoint: string;
-};
+  entrypoint: string
+}
 
 /**
  * Returns a mapping of file path (relative to the repo root) to the metadata
@@ -26,38 +26,55 @@ const getFunctionMetadataMap = async (): Promise<
 > => {
   const filepaths = glob
     .sync(path.join(FUNCTIONS_PATH, "**/*.{js,ts}"), { nodir: true })
-    .map((f) => path.resolve(f));
-  const functionMetadataArray: [string, FunctionMetadata][] = await Promise.all(
-    filepaths.map(async (filepath) => {
-      const buildResult = await esbuild.build({
-        entryPoints: [filepath],
-        outdir: TEMP_DIR,
-        write: false,
-        format: "esm",
-        bundle: true,
-      });
-      const importedFile = await importFromString(
-        buildResult.outputFiles[0].text
-      );
-      const relativePath = path.relative(process.cwd(), filepath);
-      return [relativePath, { entrypoint: importedFile.default?.name }];
-    })
-  );
+    .map(f => path.resolve(f))
+  const functionMetadataArray: [string, FunctionMetadata][] = []
+
+  await Promise.allSettled(filepaths.map(generateFunctionMetadata)).then(
+    results =>
+      results.forEach(result => {
+        if (result.status === "fulfilled") {
+          functionMetadataArray.push(result.value)
+        } else {
+          console.error(result.reason)
+        }
+      })
+  )
+
   return Object.fromEntries(
     functionMetadataArray.filter(([, metadata]) => metadata.entrypoint)
-  );
-};
+  )
+}
+
+async function generateFunctionMetadata(
+  filepath: string
+): Promise<[string, FunctionMetadata]> {
+  const buildResult = await esbuild.build({
+    entryPoints: [filepath],
+    outdir: TEMP_DIR,
+    write: false,
+    format: "esm",
+    bundle: true,
+  })
+  const importedFile = await importFromString(buildResult.outputFiles[0].text)
+
+  if (!importedFile.default) {
+    return Promise.reject("Blah")
+  }
+
+  const relativePath = path.relative(process.cwd(), filepath)
+  return [relativePath, { entrypoint: importedFile.default?.name }]
+}
 
 /** Generates a functionMetadata.json file from the functions directory. */
 export const generateFunctionMetadataFile = async () => {
-  const functionMetadataMap = await getFunctionMetadataMap();
+  const functionMetadataMap = await getFunctionMetadataMap()
   fs.writeFileSync(
     FUNCTION_METADATA_PATH,
     JSON.stringify(functionMetadataMap, null, 2)
-  );
-};
+  )
+}
 
 /** Returns whether or not a functionMetadata.json file should be generated. */
 export const shouldGenerateFunctionMetadata = () => {
-  return fs.existsSync(FUNCTIONS_PATH);
-};
+  return fs.existsSync(FUNCTIONS_PATH)
+}

--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -1,22 +1,22 @@
-import fs from "fs"
-import path from "path"
-import esbuild from "esbuild"
-import { importFromString } from "module-from-string"
-import glob from "glob"
-import chalk from "chalk"
+import fs from "fs";
+import path from "path";
+import esbuild from "esbuild";
+import { importFromString } from "module-from-string";
+import glob from "glob";
+import chalk from "chalk";
 
-const FUNCTIONS_PATH = path.resolve("functions")
+const FUNCTIONS_PATH = path.resolve("functions");
 const FUNCTION_METADATA_PATH = path.join(
   FUNCTIONS_PATH,
   "functionMetadata.json"
-)
-const TEMP_DIR = ".temp"
+);
+const TEMP_DIR = ".temp";
 
 /** Metadata for a serverless function. */
 type FunctionMetadata = {
   /** Name of the function. */
-  entrypoint: string
-}
+  entrypoint: string;
+};
 
 /**
  * Returns a mapping of file path (relative to the repo root) to the metadata
@@ -29,22 +29,22 @@ const getFunctionMetadataMap = async (): Promise<
 > => {
   const filepaths = glob
     .sync(path.join(FUNCTIONS_PATH, "**/*.{js,ts}"), { nodir: true })
-    .map(f => path.resolve(f))
-  const functionMetadataArray: [string, FunctionMetadata][] = []
+    .map((f) => path.resolve(f));
+  const functionMetadataArray: [string, FunctionMetadata][] = [];
 
   await Promise.allSettled(filepaths.map(generateFunctionMetadata)).then(
-    results =>
-      results.forEach(result => {
+    (results) =>
+      results.forEach((result) => {
         if (result.status === "fulfilled") {
-          functionMetadataArray.push(result.value)
+          functionMetadataArray.push(result.value);
         } else {
-          console.error(chalk.red(result.reason))
+          console.error(chalk.red(result.reason));
         }
       })
-  )
+  );
 
-  return Object.fromEntries(functionMetadataArray)
-}
+  return Object.fromEntries(functionMetadataArray);
+};
 
 /**
  * Generates a tuple containing the relative path of the file and its {@link FunctionMetadata}.
@@ -59,27 +59,27 @@ async function generateFunctionMetadata(
     write: false,
     format: "esm",
     bundle: true,
-  })
-  const importedFile = await importFromString(buildResult.outputFiles[0].text)
-  const relativePath = path.relative(process.cwd(), filepath)
+  });
+  const importedFile = await importFromString(buildResult.outputFiles[0].text);
+  const relativePath = path.relative(process.cwd(), filepath);
 
   if (!importedFile.default) {
-    return Promise.reject(`${relativePath} does not contain a default export.`)
+    return Promise.reject(`${relativePath} does not contain a default export.`);
   }
 
-  return [relativePath, { entrypoint: importedFile.default.name }]
+  return [relativePath, { entrypoint: importedFile.default.name }];
 }
 
 /** Generates a functionMetadata.json file from the functions directory. */
 export const generateFunctionMetadataFile = async () => {
-  const functionMetadataMap = await getFunctionMetadataMap()
+  const functionMetadataMap = await getFunctionMetadataMap();
   fs.writeFileSync(
     FUNCTION_METADATA_PATH,
     JSON.stringify(functionMetadataMap, null, 2)
-  )
-}
+  );
+};
 
 /** Returns whether or not a functionMetadata.json file should be generated. */
 export const shouldGenerateFunctionMetadata = () => {
-  return fs.existsSync(FUNCTIONS_PATH)
-}
+  return fs.existsSync(FUNCTIONS_PATH);
+};

--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -64,7 +64,7 @@ async function generateFunctionMetadata(
   const relativePath = path.relative(process.cwd(), filepath);
 
   if (!importedFile.default) {
-    return Promise.reject(`${relativePath} does not contain a default export.`);
+    throw new Error(`${relativePath} does not contain a default export.`);
   }
 
   return [relativePath, { entrypoint: importedFile.default.name }];


### PR DESCRIPTION
Updated the generation logic for the `functionMetadata.json` file. Now, if there's a file without a `default` export, we log an error in the console that includes the file name. 

J=SLAP-2658
TEST=manual