### PR TITLE
fix(dev): properly support slugs with URL-encoded characters

### DIFF
--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -25,7 +25,7 @@ export const serverRenderSlugRoute =
     try {
       const url = new URL("http://" + req.headers.host + req.originalUrl);
       const locale = req.query.locale?.toString() ?? "en";
-      const slug = url.pathname.substring(1);
+      const slug = decodeURI(url.pathname.substring(1));
 
       const templateFilepaths =
         getTemplateFilepathsFromProjectStructure(projectStructure);
@@ -69,7 +69,7 @@ export const serverRenderSlugRoute =
         locale,
         document,
       });
-      sendAppHTML(res, templateModuleInternal, props, vite, url.pathname);
+      sendAppHTML(res, templateModuleInternal, props, vite, `/${slug}`);
     } catch (e: any) {
       // If an error is caught, calling next with the error will invoke
       // our error handling middleware which will then handle it.


### PR DESCRIPTION
A German partner was running into an issue with local PagesJS development. The slug field values for a number of their locations contained special, German characters. When navigating to an entity page with such a slug, the resultant `generate-test-data` command would fail. An example slug would be something like:

thüringen/gotha/harjesstraße-5

In `serverRenderSlugRoute`, we were re-constructing the slug value using an encoded version of the URL. That is, instead of the value being the above, PagesJS computed it to be:

th%C3%BCringen/gotha/harjesstra%C3%9Fe-5

This URL-encoded slug was then passed directly to `generate-test-data`, which could obviously find no corresponding entity. In this PR, I fixed the re-construction of the slug to ensure that it never includes any URL-encoding. I also had to update the call to `sendAppHTML` because the name/path of the Virtual Module doesn't include URL-encoding either.

Note that this issue was only present when running the PagesJS dev server. Builds worked just fine.

J=SLAP-2676
TEST=manual

Verified that I could navigate to a page with a German character in the slug. Verified that I could navigate to a page with no special characters in the slug. Verified that the produciton build still worked as expected.