### PR TITLE
fix(plugin): update the single file size limit

### DIFF
--- a/packages/pages/src/vite-plugin/build/closeBundle/bundleValidator.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/bundleValidator.ts
@@ -2,7 +2,7 @@ import { statSync } from "fs";
 import glob from "glob";
 import path from "path";
 
-const PLUGIN_FILESIZE_LIMIT = 1.5; // MB
+const PLUGIN_FILESIZE_LIMIT = 10; // MB
 const PLUGIN_TOTAL_FILESIZE_LIMIT = 10; // MB
 
 /**


### PR DESCRIPTION
The Yext Plugin system has updated its single filesize limitation and now only cares that the total size is under 10MB. This reflects that change during build.