### PR TITLE
fix(plugin): remove space from pluginName

### DIFF
--- a/packages/pages/src/generate/ci/ci.test.ts
+++ b/packages/pages/src/generate/ci/ci.test.ts
@@ -36,7 +36,7 @@ describe("ci - getUpdatedCiConfig", () => {
         features: "sites-config/features.json",
         plugins: [
           {
-            pluginName: "Pages Generator",
+            pluginName: "PagesGenerator",
             sourceFiles: [
               {
                 root: "dist/plugin",
@@ -119,7 +119,7 @@ describe("ci - getUpdatedCiConfig", () => {
         features: "sites-config/features.json",
         plugins: [
           {
-            pluginName: "Pages Generator",
+            pluginName: "PagesGenerator",
             sourceFiles: [
               {
                 root: "dist/plugin",

--- a/packages/pages/src/generate/ci/ci.ts
+++ b/packages/pages/src/generate/ci/ci.ts
@@ -94,7 +94,7 @@ export const getUpdatedCiConfig = (ciConfig: CiConfig): CiConfig => {
 };
 
 const generatorPlugin: Plugin = {
-  pluginName: "Pages Generator",
+  pluginName: "PagesGenerator",
   sourceFiles: [
     {
       root: "dist/plugin",


### PR DESCRIPTION
A space in the name causes issues during `yext pages render`.