### PR TITLE
feat(dev): add .yextrc support for auto yext init

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^8.23.0",
     "execa": "^6.1.0",
     "fs-extra": "^10.1.0",
+    "yaml": "^2.3.1",
     "generate-changelog": "^1.8.0",
     "generate-license-file": "^1.3.0",
     "@typescript-eslint/eslint-plugin": "^5.36.2",

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -1,6 +1,9 @@
 import { createServer } from "./server/server.js";
 import { CommandModule } from "yargs";
 import open from "open";
+import fs from "fs";
+import YAML from "yaml";
+import { spawn } from "child_process";
 import { ProjectFilepaths } from "../common/src/project/structure.js";
 import { devServerPort } from "./server/middleware/constants.js";
 
@@ -16,11 +19,37 @@ const handler = async ({
   "prod-url": useProdURLs,
   "open-browser": openBrowser,
 }: DevArgs) => {
+  await autoYextInit();
   await createServer(!local, !!useProdURLs, scope);
   if (!openBrowser) {
     return;
   }
   await open(`http://localhost:${devServerPort}/`);
+};
+
+const autoYextInit = async () => {
+  if (!fs.existsSync(".yextrc")) return;
+  try {
+    const yextrcContents: string = fs.readFileSync(".yextrc", "utf8");
+    const parsedContents = YAML.parse(yextrcContents);
+    const businessId: string = parsedContents.businessId;
+    const universe: string = parsedContents.universe;
+    await runCommand("yext", ["init", businessId, "-u", universe]);
+  } catch (error) {
+    console.error(
+      "Could not parse .yextrc file properly. Please make sure it is formatted correctly with a valid businessId and universe (valid options include sandbox or production)."
+    );
+    process.exit(1);
+  }
+};
+
+const runCommand = (command: string, args: string[]) => {
+  return new Promise((resolve, reject) => {
+    const childProcess = spawn(command, args);
+    childProcess.on("close", (code) => {
+      code === 0 ? resolve(null) : reject();
+    });
+  });
 };
 
 export const devCommandModule: CommandModule<unknown, DevArgs> = {

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -9,6 +9,7 @@ interface DevArgs extends Pick<ProjectFilepaths, "scope"> {
   local?: boolean;
   "prod-url"?: boolean;
   "open-browser": boolean;
+  "auto-init"?: boolean;
 }
 
 const handler = async ({
@@ -16,8 +17,11 @@ const handler = async ({
   local,
   "prod-url": useProdURLs,
   "open-browser": openBrowser,
+  "auto-init": autoInit,
 }: DevArgs) => {
-  await autoYextInit();
+  if (autoInit) {
+    await autoYextInit();
+  }
   await createServer(!local, !!useProdURLs, scope);
   if (!openBrowser) {
     return;
@@ -49,6 +53,12 @@ export const devCommandModule: CommandModule<unknown, DevArgs> = {
       })
       .option("open-browser", {
         describe: "Automatically opens the browser on server start-up",
+        type: "boolean",
+        demandOption: false,
+        default: true,
+      })
+      .option("auto-init", {
+        describe: "Disables automatic yext init with .yextrc file",
         type: "boolean",
         demandOption: false,
         default: true,

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -1,9 +1,7 @@
 import { createServer } from "./server/server.js";
 import { CommandModule } from "yargs";
 import open from "open";
-import fs from "fs";
-import YAML from "yaml";
-import { spawn } from "child_process";
+import { autoYextInit } from "./server/autoInit.js";
 import { ProjectFilepaths } from "../common/src/project/structure.js";
 import { devServerPort } from "./server/middleware/constants.js";
 
@@ -25,31 +23,6 @@ const handler = async ({
     return;
   }
   await open(`http://localhost:${devServerPort}/`);
-};
-
-const autoYextInit = async () => {
-  if (!fs.existsSync(".yextrc")) return;
-  try {
-    const yextrcContents: string = fs.readFileSync(".yextrc", "utf8");
-    const parsedContents = YAML.parse(yextrcContents);
-    const businessId: string = parsedContents.businessId;
-    const universe: string = parsedContents.universe;
-    await runCommand("yext", ["init", businessId, "-u", universe]);
-  } catch (error) {
-    console.error(
-      "Could not parse .yextrc file properly. Please make sure it is formatted correctly with a valid businessId and universe (valid options include sandbox or production)."
-    );
-    process.exit(1);
-  }
-};
-
-const runCommand = (command: string, args: string[]) => {
-  return new Promise((resolve, reject) => {
-    const childProcess = spawn(command, args);
-    childProcess.on("close", (code) => {
-      code === 0 ? resolve(null) : reject();
-    });
-  });
 };
 
 export const devCommandModule: CommandModule<unknown, DevArgs> = {

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -9,7 +9,7 @@ interface DevArgs extends Pick<ProjectFilepaths, "scope"> {
   local?: boolean;
   "prod-url"?: boolean;
   "open-browser": boolean;
-  "auto-init"?: boolean;
+  noInit?: boolean;
 }
 
 const handler = async ({
@@ -17,9 +17,9 @@ const handler = async ({
   local,
   "prod-url": useProdURLs,
   "open-browser": openBrowser,
-  "auto-init": autoInit,
+  noInit,
 }: DevArgs) => {
-  if (autoInit) {
+  if (!noInit) {
     await autoYextInit();
   }
   await createServer(!local, !!useProdURLs, scope);
@@ -57,11 +57,11 @@ export const devCommandModule: CommandModule<unknown, DevArgs> = {
         demandOption: false,
         default: true,
       })
-      .option("auto-init", {
+      .option("noInit", {
         describe: "Disables automatic yext init with .yextrc file",
         type: "boolean",
         demandOption: false,
-        default: true,
+        default: false,
       });
   },
   handler,

--- a/packages/pages/src/dev/server/autoInit.ts
+++ b/packages/pages/src/dev/server/autoInit.ts
@@ -47,14 +47,16 @@ const parseYextrcContents = () => {
   const parsedContents = YAML.parse(yextrcContents);
   const businessId: string = parsedContents.businessId;
   const universe: string = parsedContents.universe;
-  if (isNaN(Number(businessId)))
+  if (isNaN(Number(businessId))) {
     logErrorAndExit(
-      "Invalid businessId format in .yextrc file. Please enter a valid businessId"
+      "Invalid businessId format in .yextrc file. Please enter a valid businessId."
     );
-  if (universe != "sandbox" && universe != "production")
+  }
+  if (universe != "sandbox" && universe != "production") {
     logErrorAndExit(
-      "Invalide universe in .yextrc file. Please enter a valid universe (sandbox or production)"
+      "Invalid universe in .yextrc file. Please enter a valid universe (sandbox or production)."
     );
+  }
   return { businessId, universe };
 };
 
@@ -82,7 +84,7 @@ const askForBusinessId = async (): Promise<string> => {
   return new Promise((resolve) => {
     readline.question(`Enter your BusinessId: `, (userInput: string) => {
       if (isNaN(Number(userInput))) {
-        console.error(colors.red("BusinessId must be a number"));
+        console.error(colors.red("BusinessId must be a number."));
         readline.close();
         resolve(askForBusinessId());
       }
@@ -91,6 +93,8 @@ const askForBusinessId = async (): Promise<string> => {
     });
   });
 };
+
+const validUniverses = ["sandbox", "production", "sbx", "prod"];
 
 const askForUniverse = async (): Promise<string> => {
   const readline = createInterface({
@@ -102,15 +106,20 @@ const askForUniverse = async (): Promise<string> => {
       `Enter a universe (sandbox or production): `,
       (userInput: string) => {
         userInput = userInput.toLowerCase();
-        const validUniverses = ["sandbox", "production", "sbx", "prod"];
         if (!validUniverses.includes(userInput)) {
-          console.error(colors.red("Invalid universe choice"));
+          console.error(colors.red("Invalid universe."));
           readline.close();
           resolve(askForUniverse());
         }
         readline.close();
-        if (userInput == "sbx") userInput = "sandbox";
-        if (userInput == "prod") userInput = "production";
+        switch (userInput) {
+          case "sbx":
+            userInput = "sandbox";
+            break;
+          case "prod":
+            userInput = "production";
+            break;
+        }
         resolve(userInput);
       }
     );

--- a/packages/pages/src/dev/server/autoInit.ts
+++ b/packages/pages/src/dev/server/autoInit.ts
@@ -1,0 +1,91 @@
+import fs from "fs";
+import YAML from "yaml";
+import { spawn } from "child_process";
+import { createInterface } from "readline";
+import colors from "picocolors";
+
+export const autoYextInit = async () => {
+  if (!fs.existsSync(".yextrc")) {
+    try {
+      const businessId = await askForBusinessId();
+      const universe = await askForUniverse();
+      await runCommand("yext", ["init", businessId, "-u", universe]).then(
+        (output) => console.log(output)
+      );
+      fs.writeFileSync(
+        ".yextrc",
+        `businessId: ${businessId}\nuniverse: ${universe}`
+      );
+    } catch (error) {
+      console.error(
+        "Incorrect credentials. Please enter a valid businessId and universe option"
+      );
+      process.exit(1);
+    }
+  } else {
+    try {
+      const yextrcContents: string = fs.readFileSync(".yextrc", "utf8");
+      const parsedContents = YAML.parse(yextrcContents);
+      const businessId: string = parsedContents.businessId;
+      const universe: string = parsedContents.universe;
+      await runCommand("yext", ["init", businessId, "-u", universe]).then(
+        (output) => console.log(output)
+      );
+    } catch (error) {
+      console.error(
+        "Could not parse .yextrc file properly. Please make sure it is formatted correctly with a valid businessId and universe."
+      );
+      process.exit(1);
+    }
+  }
+};
+
+const runCommand = (command: string, args: string[]) => {
+  return new Promise((resolve, reject) => {
+    const childProcess = spawn(command, args);
+
+    let output = "";
+
+    childProcess.stdout.on("data", (data) => {
+      output += data.toString();
+    });
+
+    childProcess.on("close", (code) => {
+      code === 0 ? resolve(output) : reject();
+    });
+  });
+};
+
+const askForBusinessId = async (): Promise<string> => {
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    readline.question(`Enter your BusinessId: `, (userInput: string) => {
+      readline.close();
+      resolve(userInput);
+    });
+  });
+};
+
+const askForUniverse = async (): Promise<string> => {
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    readline.question(
+      `Enter a universe (sandbox or production): `,
+      (userInput: string) => {
+        if (userInput !== "sandbox" && userInput !== "production") {
+          console.log(colors.red("Invalid universe choice"));
+          readline.close();
+          resolve(askForUniverse());
+        }
+        readline.close();
+        resolve(userInput);
+      }
+    );
+  });
+};

--- a/packages/pages/src/vite-plugin/build/build.ts
+++ b/packages/pages/src/vite-plugin/build/build.ts
@@ -44,6 +44,7 @@ export const build = (projectStructure: ProjectStructure): Plugin => {
               chunkFileNames: "assets/static/[name]-[hash].js",
             },
           },
+          reportCompressedSize: false,
         },
         define: processEnvVariables(projectStructure.envVarPrefix),
         experimental: {

--- a/playground/locations-site/playwright.config.ts
+++ b/playground/locations-site/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
   ...base,
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev -- --no-open-browser",
+    command: "npm run dev -- --no-open-browser --no-auto-init",
     url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
   },

--- a/playground/locations-site/playwright.config.ts
+++ b/playground/locations-site/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
   ...base,
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev -- --no-open-browser --no-auto-init",
+    command: "npm run dev -- --no-open-browser --noInit",
     url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
   },

--- a/playground/locations-site/sites-config/features.json
+++ b/playground/locations-site/sites-config/features.json
@@ -27,11 +27,21 @@
     {
       "$id": "location-stream",
       "filter": {
-        "entityTypes": ["location"]
+        "entityTypes": [
+          "location"
+        ]
       },
-      "fields": ["id", "uid", "meta", "address", "slug"],
+      "fields": [
+        "id",
+        "uid",
+        "meta",
+        "address",
+        "slug"
+      ],
       "localization": {
-        "locales": ["en"],
+        "locales": [
+          "en"
+        ],
         "primary": false
       }
     }

--- a/playground/multibrand-site/playwright.config.ts
+++ b/playground/multibrand-site/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
   ...base,
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: `npm run dev:oakley -- --no-open-browser --no-auto-init`,
+    command: `npm run dev:oakley -- --no-open-browser --noInit`,
     url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
   },

--- a/playground/multibrand-site/playwright.config.ts
+++ b/playground/multibrand-site/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
   ...base,
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: `npm run dev:oakley -- --no-open-browser`,
+    command: `npm run dev:oakley -- --no-open-browser --no-auto-init`,
     url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
   },

--- a/playground/multibrand-site/sites-config/sunglasses.oakley.com/features.json
+++ b/playground/multibrand-site/sites-config/sunglasses.oakley.com/features.json
@@ -26,12 +26,20 @@
   "streams": [
     {
       "$id": "oakley-stream",
-      "fields": ["id", "name", "slug"],
+      "fields": [
+        "id",
+        "name",
+        "slug"
+      ],
       "filter": {
-        "savedFilterIds": ["1241548641"]
+        "savedFilterIds": [
+          "1241548641"
+        ]
       },
       "localization": {
-        "locales": ["en"],
+        "locales": [
+          "en"
+        ],
         "primary": false
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       typescript:
         specifier: ^4.8.2
         version: 4.8.3
+      yaml:
+        specifier: ^2.3.1
+        version: 2.3.1
 
   packages/pages:
     dependencies:
@@ -10955,7 +10958,7 @@ packages:
       object-inspect: 1.12.3
       pidtree: 0.6.0
       string-argv: 0.3.1
-      yaml: 2.2.1
+      yaml: 2.3.1
     transitivePeerDependencies:
       - enquirer
       - supports-color
@@ -15414,8 +15417,8 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /yaml@2.2.1:
-    resolution: {integrity: sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==}
+  /yaml@2.3.1:
+    resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
     engines: {node: '>= 14'}
     dev: true
 


### PR DESCRIPTION
When `pages dev` is run, it will look for a `.yextrc` file (formatted in YAML). If present, it will parse out `businessId` and `universe` and run `yext init [businessId] -u [universe]`. If a `.yextrc` file is not found, it asks the user for their businessID and a universe, creates the `.yextrc` file, and runs the `yext init` command.

Has basic checking both for command line and when reading the `.yextrc` file to make sure that the businessId is a number and that universe string is valid. On error when running `yext init`, the error is logged to the console. 