### PR TITLE
fix(plugin): finalize reverse proxy support

### DIFF
--- a/packages/pages/src/vite-plugin/build/build.ts
+++ b/packages/pages/src/vite-plugin/build/build.ts
@@ -47,6 +47,7 @@ export const build = (projectStructure: ProjectStructure): Plugin => {
           reportCompressedSize: false,
         },
         define: processEnvVariables(projectStructure.envVarPrefix),
+        base: "", // makes static assets relative for reverse proxies and doesn't affect non-RP sites
         experimental: {
           renderBuiltUrl(filename, { hostType }) {
             // Assets are returned with a leading slash for some reason. This adjusts the

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
@@ -40,8 +40,12 @@ export const reactWrapper = async <T extends TemplateRenderProps>(
   let clientHydrationString;
   if (hydrate) {
     clientHydrationString = getHydrationTemplate(
-      pluginRenderTemplates.client,
-      path.join("assets", templateModuleInternal.path.replace("..", "")),
+      path.join(props.relativePrefixToRoot, pluginRenderTemplates.client),
+      path.join(
+        props.relativePrefixToRoot,
+        "assets",
+        templateModuleInternal.path.replace("..", "")
+      ),
       props
     );
   }


### PR DESCRIPTION
`relativePathToRoot` was missing in some places. This also sets the Vite `base` to always be relative instead of root so users don't have to configure it.