### PR TITLE
fix(dev): add additional filetypes to esbuild loader for features.json

### DIFF
--- a/packages/pages/src/common/src/template/internal/loader.ts
+++ b/packages/pages/src/common/src/template/internal/loader.ts
@@ -34,7 +34,15 @@ export const loadTemplateModules = async (
           format: "esm",
           bundle: true,
           loader: {
+            ".css": "css",
+            ".scss": "css",
             ".ico": "dataurl",
+            ".avif": "dataurl",
+            ".jpg": "dataurl",
+            ".png": "dataurl",
+            ".gif": "dataurl",
+            ".svg": "dataurl",
+            ".webp": "dataurl",
           },
         });
 


### PR DESCRIPTION
The features.json generation was failing in some circumstances when unknown filetypes were being imported into the templates. This is only an issue when running `pages features` directly and does not affect the build process. It's possible we may want to just remove this feature altogether as its own command.