### PR TITLE
fix(dev): duplicated generate-test-data

### DIFF
--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -52,6 +52,7 @@ export const devCommandModule: CommandModule<unknown, DevArgs> = {
         demandOption: false,
       })
       .option("local", {
+        alias: "noGenTestData",
         describe: "Disables dynamically generated test data",
         type: "boolean",
         demandOption: false,

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -23,7 +23,6 @@ const handler = async ({
   noInit,
   scope,
   noGenFeatures,
-  noGenTestData,
 }: DevArgs) => {
   if (!noInit) {
     await autoYextInit();
@@ -34,7 +33,6 @@ const handler = async ({
       scope ? ["--scope" + " " + scope] : []
     );
 
-  if (!noGenTestData) await runSubProcess("yext pages generate-test-data", []);
   await createServer(!local, !!useProdURLs, scope);
 
   if (openBrowser) await open(`http://localhost:${devServerPort}/`);
@@ -84,11 +82,6 @@ export const devCommandModule: CommandModule<unknown, DevArgs> = {
       })
       .option("noGenFeatures", {
         describe: "Disable feature.json generation step",
-        type: "boolean",
-        demandOption: false,
-      })
-      .option("noGenTestData", {
-        describe: "Disable test data generation step",
         type: "boolean",
         demandOption: false,
       });

--- a/packages/pages/src/dev/server/ssr/getLocalData.ts
+++ b/packages/pages/src/dev/server/ssr/getLocalData.ts
@@ -117,7 +117,7 @@ const getLocalData = async (
     }
   } catch (err: any) {
     if (err.code === "ENOENT") {
-      throw "No localData exists. Please run `yext sites generate-test-data`";
+      throw "No localData exists. Please run `yext pages generate-test-data`";
     } else {
       throw err;
     }
@@ -184,7 +184,7 @@ const getAllLocalData = async (): Promise<Record<string, any>[]> => {
     });
   } catch (err: any) {
     if (err.code === "ENOENT") {
-      throw "No localData exists. Please run `yext sites generate-test-data`";
+      throw "No localData exists. Please run `yext pages generate-test-data`";
     } else {
       throw err;
     }


### PR DESCRIPTION
The updated `pages dev` called `pages generate features` then `yext pages generate-test-data` then `createServer()`.
However, `createServer()` calls `yext pages generate-test-data` in [server.ts:57](https://github.com/yext/pages/blob/8b3454f33a9ed35e2ebbf4455ad98eb9fa1cb2a1/packages/pages/src/dev/server/server.ts#L57)

The pages dev call is managed by `--noGenTestData` while the `createServer` call is managed by `--local` (ie a user would need both `--noGenTestData` and `--local` to disable generation).

This PR removes the `pages dev` call and leaves the original one in `createServer`.