### PR TITLE
fix(dev): static page locale support

### DIFF
--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -64,9 +64,9 @@ export const indexPage =
 
       // If there is any localData, display hyperlinks to each page that will be generated
       // from each data document.
-      if (localDataManifest.static.length + localDataManifest.entity.size) {
+      if (localDataManifest.static.size + localDataManifest.entity.size) {
         // If there are any data documents for static pages, render that section.
-        if (localDataManifest.static.length) {
+        if (localDataManifest.static.size) {
           indexPageHtml = indexPageHtml.replace(
             `<!--static-pages-html-->`,
             `<h3>Static Pages</h3>
@@ -174,24 +174,40 @@ const addHttpFuncs = (indexPageHtml: string) => {
 
 const createStaticPageListItems = (localDataManifest: LocalDataManifest) => {
   return Array.from(localDataManifest.static).reduce(
-    (templateAccumulator, { featureName, staticURL }) =>
+    (templateAccumulator, [, { featureName, staticURL, locales }]) =>
       templateAccumulator +
-      `<h4>${featureName} pages (1):</h4>
-      <table>
+      `<h4>${featureName} pages (${locales.length}):</h4>` +
+      `<table>
         <thead>
           <tr>
             <td>URL</td>
+            ${locales.length > 1 ? "<td>Locale</td>" : ""}
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>
-              <a href="http://localhost:${devServerPort}/${encodeURIComponent(
-        staticURL
-      )}">
-                ${staticURL}
-              </a>
-            </td>
+          ${locales
+            .map(
+              (locale) => `<tr>
+            ${
+              locales.length > 1
+                ? `<td>
+                <a href="http://localhost:${devServerPort}/${encodeURIComponent(
+                    staticURL
+                  )}?locale=${locale}">
+                  ${staticURL}?locale=${locale}
+                </a>
+              </td>`
+                : `<td>
+                <a href="http://localhost:${devServerPort}/${encodeURIComponent(
+                    staticURL
+                  )}">
+                  ${staticURL}
+                </a>
+              </td>`
+            }
+            ${locales.length > 1 ? `<td>${locale}</td>` : ""}`
+            )
+            .join("")}
           </tr>
         </tbody>
       </table>

--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -18,10 +18,16 @@ type Props = {
   vite: ViteDevServer;
   dynamicGenerateData: boolean;
   projectStructure: ProjectStructure;
+  defaultLocale: string;
 };
 
 export const serverRenderRoute =
-  ({ vite, dynamicGenerateData, projectStructure }: Props): RequestHandler =>
+  ({
+    vite,
+    dynamicGenerateData,
+    projectStructure,
+    defaultLocale,
+  }: Props): RequestHandler =>
   async (req, res, next): Promise<void> => {
     try {
       const url = new URL("http://" + req.headers.host + req.originalUrl);
@@ -36,7 +42,7 @@ export const serverRenderRoute =
           res,
           vite,
           matchingStaticTemplate,
-          locale,
+          locale ?? defaultLocale,
           url.pathname,
           projectStructure
         );

--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -38,7 +38,7 @@ export const serverRenderRoute =
       const matchingStaticTemplate: TemplateModuleInternal<any, any> | null =
         await findMatchingStaticTemplate(vite, staticURL, templateFilepaths);
       if (matchingStaticTemplate) {
-        sendStaticPage(
+        await sendStaticPage(
           res,
           vite,
           matchingStaticTemplate,

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -17,14 +17,20 @@ type Props = {
   vite: ViteDevServer;
   dynamicGenerateData: boolean;
   projectStructure: ProjectStructure;
+  defaultLocale: string;
 };
 
 export const serverRenderSlugRoute =
-  ({ vite, dynamicGenerateData, projectStructure }: Props): RequestHandler =>
+  ({
+    vite,
+    dynamicGenerateData,
+    projectStructure,
+    defaultLocale,
+  }: Props): RequestHandler =>
   async (req, res, next): Promise<void> => {
     try {
       const url = new URL("http://" + req.headers.host + req.originalUrl);
-      const locale = req.query.locale?.toString() ?? "en";
+      const locale = req.query.locale?.toString() ?? defaultLocale;
       const slug = decodeURI(url.pathname.substring(1));
 
       const templateFilepaths =

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -38,7 +38,7 @@ export const serverRenderSlugRoute =
       const matchingStaticTemplate: TemplateModuleInternal<any, any> | null =
         await findMatchingStaticTemplate(vite, slug, templateFilepaths);
       if (matchingStaticTemplate) {
-        sendStaticPage(
+        await sendStaticPage(
           res,
           vite,
           matchingStaticTemplate,

--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -49,9 +49,7 @@ export const createServer = async (
       defaultLocale = featuresJson.locales[0];
     }
   } catch (e) {
-    if (e === "Error: ENOENT: no such file or directory") {
-      console.warn("Could not find features.json");
-    } else {
+    if (e !== "Error: ENOENT: no such file or directory") {
       console.warn(e);
     }
   }

--- a/packages/pages/src/dev/server/ssr/getLocalData.ts
+++ b/packages/pages/src/dev/server/ssr/getLocalData.ts
@@ -11,12 +11,17 @@ const LOCAL_DATA_PATH = "localData";
  * to generate in the indexPage.
  */
 export interface LocalDataManifest {
-  static: {
-    // The featureName for a specific static template
-    featureName: string;
-    // The return value of the template's getPath()
-    staticURL: string;
-  }[];
+  static: Map<
+    string,
+    {
+      // The featureName for a specific static template
+      featureName: string;
+      // The return value of the template's getPath()
+      staticURL: string;
+      // The locale codes
+      locales: string[];
+    }
+  >;
   entity: Map<
     string,
     {
@@ -36,7 +41,7 @@ export const getLocalDataManifest = async (
   templateFilepaths: string[]
 ): Promise<LocalDataManifest> => {
   const localDataManifest: LocalDataManifest = {
-    static: [],
+    static: new Map(),
     entity: new Map(),
   };
 
@@ -87,10 +92,17 @@ export const getLocalDataManifest = async (
         );
         continue;
       }
-      localDataManifest.static.push({
-        featureName,
-        staticURL: templateModuleInternal.getPath({}),
-      });
+      if (localDataManifest.static.has(featureName)) {
+        localDataManifest.static
+          .get(featureName)
+          ?.locales.push(data.meta.locale);
+      } else {
+        localDataManifest.static.set(featureName, {
+          featureName,
+          staticURL: templateModuleInternal.getPath({}),
+          locales: [data.meta.locale],
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Support static page locales based on `features.json`

**`features.json` does not include key `locales` or `features.json` does not exist**
The dev server behaves as before, with default locale `en`.

**`features.json` includes `locales` with array length 1**
The dev server index page behaves as before, default locale is set to the locale in the `locales` array.

**`features.json` includes `locales` with array length >1**
The dev server index page includes a static page listing for each locale. The default local is set to the first locale in the `locales` array.

<img width="1904" alt="Screen Shot 2023-07-07 at 10 27 08 AM" src="https://github.com/yext/pages/assets/77246839/3d5dd84d-b15f-4bd3-9626-cc3f443daa24">
