### PR TITLE
feat(dev)!: do not require localization.primary:false

### DIFF
--- a/packages/pages/src/common/src/feature/stream.test.ts
+++ b/packages/pages/src/common/src/feature/stream.test.ts
@@ -1,13 +1,11 @@
-import {
-  convertTemplateConfigToStreamConfig,
-  StreamConfig,
-} from "../../src/feature/stream.js";
-import { TemplateConfig } from "../../src/template/types.js";
+import { convertTemplateConfigToStreamConfig, StreamConfig } from "./stream.js";
+import { TemplateConfigInternal } from "../template/internal/types.js";
 
 describe("stream", () => {
   it("returns void if no stream", async () => {
-    const templateConfig: TemplateConfig = {
+    const templateConfig: TemplateConfigInternal = {
       name: "myTemplateConfig",
+      hydrate: false,
     };
 
     const streamConfig = convertTemplateConfigToStreamConfig(templateConfig);
@@ -16,8 +14,9 @@ describe("stream", () => {
   });
 
   it("adds source and destination if StreamConfig defined", async () => {
-    const templateConfig: TemplateConfig = {
+    const templateConfig: TemplateConfigInternal = {
       name: "myTemplateConfig",
+      hydrate: true,
       stream: {
         $id: "$id",
         fields: ["foo"],

--- a/packages/pages/src/common/src/feature/stream.ts
+++ b/packages/pages/src/common/src/feature/stream.ts
@@ -1,7 +1,4 @@
-import {
-  LocalizationInternal,
-  TemplateConfigInternal,
-} from "../template/internal/types.js";
+import { TemplateConfigInternal } from "../template/internal/types.js";
 
 /**
  * The shape of data that represents a stream configuration.
@@ -25,7 +22,12 @@ export interface StreamConfig {
     savedFilterIds?: string[];
   };
   /** The localization used by the filter */
-  localization: LocalizationInternal;
+  localization: {
+    /** The entity profiles languages to apply to the stream */
+    locales?: string[];
+    /** Whether to include the primary profile language. */
+    primary: boolean;
+  };
   /** The transformation to apply to the stream */
   transform?: {
     /** The option fields to be expanded to include the display fields, numeric values, and selected boolean */

--- a/packages/pages/src/common/src/feature/stream.ts
+++ b/packages/pages/src/common/src/feature/stream.ts
@@ -26,7 +26,7 @@ export interface StreamConfig {
     /** The entity profiles languages to apply to the stream */
     locales?: string[];
     /** Whether to include the primary profile language. Must be false when locales is defined. */
-    primary: boolean;
+    primary?: boolean;
   };
   /** The transformation to apply to the stream */
   transform?: {

--- a/packages/pages/src/common/src/feature/stream.ts
+++ b/packages/pages/src/common/src/feature/stream.ts
@@ -1,4 +1,7 @@
-import { TemplateConfig } from "../template/types.js";
+import {
+  LocalizationInternal,
+  TemplateConfigInternal,
+} from "../template/internal/types.js";
 
 /**
  * The shape of data that represents a stream configuration.
@@ -22,12 +25,7 @@ export interface StreamConfig {
     savedFilterIds?: string[];
   };
   /** The localization used by the filter */
-  localization: {
-    /** The entity profiles languages to apply to the stream */
-    locales?: string[];
-    /** Whether to include the primary profile language. Must be false when locales is defined. */
-    primary?: boolean;
-  };
+  localization: LocalizationInternal;
   /** The transformation to apply to the stream */
   transform?: {
     /** The option fields to be expanded to include the display fields, numeric values, and selected boolean */
@@ -42,10 +40,10 @@ export interface StreamConfig {
  */
 export const convertTemplateConfigToStreamConfig = (
   // config is optional for a user to set
-  config: TemplateConfig | undefined
+  config: TemplateConfigInternal | undefined
 ): StreamConfig | void => {
   if (!config) {
-    config = {};
+    return;
   }
   if (config.stream) {
     return {

--- a/packages/pages/src/common/src/template/internal/types.ts
+++ b/packages/pages/src/common/src/template/internal/types.ts
@@ -10,7 +10,6 @@ import {
   TemplateModule,
   TemplateProps,
   TemplateRenderProps,
-  LocalizationOptions,
 } from "../types.js";
 import { validateTemplateModuleInternal } from "./validateTemplateModuleInternal.js";
 
@@ -58,18 +57,44 @@ export interface TemplateConfigInternal {
   /** The stream that this template uses. If a stream is defined the streamId is not required. */
   streamId?: string;
   /** The stream configuration used by the template */
-  stream?: Stream<LocalizationInternal>;
+  stream?: StreamInternal;
   /** The specific fields to add additional language options to based on the stream's localization */
   alternateLanguageFields?: string[];
   /** The name of the onUrlChange function to use. */
   onUrlChange?: string;
 }
 
-export interface LocalizationInternal {
-  /** The entity profiles languages to apply to the stream */
-  locales?: string[];
-  /** Whether to include the primary profile language. */
-  primary: boolean;
+/**
+ * The stream config defined in {@link TemplateConfigInternal.stream}.
+ */
+export interface StreamInternal {
+  /** The identifier of the stream */
+  $id: string;
+  /** The fields to apply to the stream */
+  fields: string[];
+  /** The filter to apply to the stream */
+  filter: {
+    /** The entity IDs to apply to the stream */
+    entityIds?: string[];
+    /** The entity types to apply to the stream */
+    entityTypes?: string[];
+    /** The saved filters to apply to the stream */
+    savedFilterIds?: string[];
+  };
+  /** The localization used by the filter. Either set primary: true or specify a locales array. */
+  localization: {
+    /** The entity profiles languages to apply to the stream */
+    locales?: string[];
+    /** Whether to include the primary profile language. */
+    primary: boolean;
+  };
+  /** The transformation to apply to the stream */
+  transform?: {
+    /** The option fields to be expanded to include the display fields, numeric values, and selected boolean */
+    expandOptionFields?: string[];
+    /** The option fields to be replaced with display names */
+    replaceOptionValuesWithDisplayNames?: string[];
+  };
 }
 
 /**
@@ -134,12 +159,12 @@ const convertTemplateConfigToTemplateConfigInternal = (
 };
 
 /**
- * Converts a {@link Stream<LocalizationOptions>} into a valid {@link Stream<LocalizationInternal>}
+ * Converts a {@link Stream} into a valid {@link StreamInternal}
  * by setting stream.localization.primary: false if a locales array exists.
  */
 const convertStreamToStreamInternal = (
-  stream: Stream<LocalizationOptions> | undefined
-): Stream<LocalizationInternal> | undefined => {
+  stream: Stream | undefined
+): StreamInternal | undefined => {
   if (!stream) return;
 
   if (stream.localization.locales && stream.localization.locales.length > 0) {

--- a/packages/pages/src/common/src/template/internal/types.ts
+++ b/packages/pages/src/common/src/template/internal/types.ts
@@ -117,6 +117,16 @@ const convertTemplateConfigToTemplateConfigInternal = (
   templateName: string,
   templateConfig: TemplateConfig | undefined
 ): TemplateConfigInternal => {
+  if (
+    templateConfig?.stream?.localization?.locales &&
+    templateConfig.stream.localization.locales.length > 0 &&
+    templateConfig.stream.localization.primary === undefined
+  ) {
+    templateConfig.stream.localization.primary = false;
+  } else if (templateConfig?.stream) {
+    templateConfig.stream.localization = { primary: true };
+  }
+
   return {
     name: templateConfig?.name ?? templateName,
     hydrate: templateConfig?.hydrate ?? false,

--- a/packages/pages/src/common/src/template/types.ts
+++ b/packages/pages/src/common/src/template/types.ts
@@ -129,10 +129,10 @@ export interface Stream<LocalizationType> {
   };
 }
 
-/** The localization to be used. Either */
+/** The localization to be used. Either set primary: true or specify a locales array. */
 export type LocalizationOptions =
   | {
-      /** The entity profiles languages to apply to the stream */
+      /** The entity profiles languages to apply to the stream. */
       locales: string[];
       primary?: never;
     }

--- a/packages/pages/src/common/src/template/types.ts
+++ b/packages/pages/src/common/src/template/types.ts
@@ -122,8 +122,9 @@ export interface Stream {
   localization: {
     /** The entity profiles languages to apply to the stream */
     locales?: string[];
-    /** Whether to include the primary profile language. Must be false when locales is defined. */
-    primary: boolean;
+    /** Whether to include the primary profile language.
+     * Defaults to false when locales is defined. */
+    primary?: boolean;
   };
   /** The transformation to apply to the stream */
   transform?: {

--- a/packages/pages/src/common/src/template/types.ts
+++ b/packages/pages/src/common/src/template/types.ts
@@ -92,7 +92,7 @@ export interface TemplateConfig {
   /** The stream that this template uses. If a stream is defined the streamId is not required. */
   streamId?: string;
   /** The stream configuration used by the template */
-  stream?: Stream<LocalizationOptions>;
+  stream?: Stream;
   /** The specific fields to add additional language options to based on the stream's localization */
   alternateLanguageFields?: string[];
   /** The name of the onUrlChange function to use. */
@@ -104,7 +104,7 @@ export interface TemplateConfig {
  *
  * @public
  */
-export interface Stream<LocalizationType> {
+export interface Stream {
   /** The identifier of the stream */
   $id: string;
   /** The fields to apply to the stream */
@@ -118,8 +118,18 @@ export interface Stream<LocalizationType> {
     /** The saved filters to apply to the stream */
     savedFilterIds?: string[];
   };
-  /** The localization used by the filter */
-  localization: LocalizationType;
+  /** The localization used by the filter. Either set primary: true or specify a locales array. */
+  localization:
+    | {
+        /** The entity profiles languages to apply to the stream. */
+        locales: string[];
+        primary?: never;
+      }
+    | {
+        /** Use the primary profile language. */
+        primary: true;
+        locales?: never;
+      };
   /** The transformation to apply to the stream */
   transform?: {
     /** The option fields to be expanded to include the display fields, numeric values, and selected boolean */
@@ -128,19 +138,6 @@ export interface Stream<LocalizationType> {
     replaceOptionValuesWithDisplayNames?: string[];
   };
 }
-
-/** The localization to be used. Either set primary: true or specify a locales array. */
-export type LocalizationOptions =
-  | {
-      /** The entity profiles languages to apply to the stream. */
-      locales: string[];
-      primary?: never;
-    }
-  | {
-      /** Use the primary profile language. */
-      primary: true;
-      locales?: never;
-    };
 
 /**
  * A manifest of bundled files present during a production build.

--- a/packages/pages/src/common/src/template/types.ts
+++ b/packages/pages/src/common/src/template/types.ts
@@ -92,7 +92,7 @@ export interface TemplateConfig {
   /** The stream that this template uses. If a stream is defined the streamId is not required. */
   streamId?: string;
   /** The stream configuration used by the template */
-  stream?: Stream;
+  stream?: Stream<LocalizationOptions>;
   /** The specific fields to add additional language options to based on the stream's localization */
   alternateLanguageFields?: string[];
   /** The name of the onUrlChange function to use. */
@@ -104,7 +104,7 @@ export interface TemplateConfig {
  *
  * @public
  */
-export interface Stream {
+export interface Stream<LocalizationType> {
   /** The identifier of the stream */
   $id: string;
   /** The fields to apply to the stream */
@@ -119,13 +119,7 @@ export interface Stream {
     savedFilterIds?: string[];
   };
   /** The localization used by the filter */
-  localization: {
-    /** The entity profiles languages to apply to the stream */
-    locales?: string[];
-    /** Whether to include the primary profile language.
-     * Defaults to false when locales is defined. */
-    primary?: boolean;
-  };
+  localization: LocalizationType;
   /** The transformation to apply to the stream */
   transform?: {
     /** The option fields to be expanded to include the display fields, numeric values, and selected boolean */
@@ -134,6 +128,19 @@ export interface Stream {
     replaceOptionValuesWithDisplayNames?: string[];
   };
 }
+
+/** The localization to be used. Either */
+export type LocalizationOptions =
+  | {
+      /** The entity profiles languages to apply to the stream */
+      locales: string[];
+      primary?: never;
+    }
+  | {
+      /** Use the primary profile language. */
+      primary: true;
+      locales?: never;
+    };
 
 /**
  * A manifest of bundled files present during a production build.


### PR DESCRIPTION
Change the public type for `TemplateConfig.Stream.localization` 
to allow `{locales: [...]}` or `{primary: true}` 
but never `{primary: false}` or `{locales: [...], primary: true/false}`.

Under the hood, convert the public type to an internal type that always has `primary` defined with this behavior:

```localization: {} -> localization: {primary: true}
localization: {primary: true} -> localization: {primary: true}
localization: {locales: []} -> localization: {primary: true}
localization: {locales: ['fr']} -> localization: {locales: ['fr'], primary: false}
localization: {locales: ['fr'], primary: true} -> localization: {locales: ['fr'], primary: false}
```
Some of these inputs are not valid TS but we don't call `tsc` when we do `pages generate features` so they could exist.

Breaking because most repos will have `{locales: [...], primary: false}` which is now not allowed.