### PR TITLE
fix(plugin): fail platform build when PagesJS build fails (fix #347)

### DIFF
--- a/packages/pages/src/bin/spawn.ts
+++ b/packages/pages/src/bin/spawn.ts
@@ -22,5 +22,5 @@ const results = spawnSync(
 );
 
 if (results?.status != undefined && results.status !== 0) {
-  process.exit(results.status);
+  process.exitCode = results.status;
 }

--- a/packages/pages/src/bin/spawn.ts
+++ b/packages/pages/src/bin/spawn.ts
@@ -13,10 +13,14 @@ const pathToPagesScript = path.resolve(
   "pages.js"
 );
 
-spawnSync(
+const results = spawnSync(
   "node",
   ["--experimental-vm-modules", pathToPagesScript, ...process.argv.slice(2)],
   {
     stdio: "inherit",
   }
 );
+
+if (results?.status != undefined && results.status !== 0) {
+  process.exit(results.status);
+}

--- a/packages/pages/src/build/build.ts
+++ b/packages/pages/src/build/build.ts
@@ -9,7 +9,7 @@ const handler = async ({ scope }: BuildArgs) => {
   if (scope) {
     process.env.YEXT_PAGES_SCOPE = scope;
   }
-  build();
+  await build();
 };
 
 export const buildCommandModule: CommandModule<unknown, BuildArgs> = {

--- a/packages/pages/src/build/build.ts
+++ b/packages/pages/src/build/build.ts
@@ -9,7 +9,7 @@ const handler = async ({ scope }: BuildArgs) => {
   if (scope) {
     process.env.YEXT_PAGES_SCOPE = scope;
   }
-  await build();
+  build();
 };
 
 export const buildCommandModule: CommandModule<unknown, BuildArgs> = {

--- a/playground/locations-site/sites-config/ci.json
+++ b/playground/locations-site/sites-config/ci.json
@@ -1,0 +1,43 @@
+{
+  "artifactStructure": {
+    "assets": [
+      {
+        "root": "packages/pages/storybook-static"
+      }
+    ],
+    "plugins": [
+      {
+        "pluginName": "PagesGenerator",
+        "sourceFiles": [
+          {
+            "root": "dist/plugin",
+            "pattern": "*{.ts,.json}"
+          },
+          {
+            "root": "dist",
+            "pattern": "assets/{server,static,renderer,render}/**/*{.js,.css}"
+          }
+        ],
+        "event": "ON_PAGE_GENERATE",
+        "functionName": "PagesGenerator"
+      }
+    ]
+  },
+  "dependencies": {
+    "installDepsCmd": "npm install -g pnpm && pnpm install",
+    "requiredFiles": [
+      "package.json",
+      "pnpm-lock.json",
+      "pnpm-workspace.yaml",
+      ".npmrc",
+      "packages/pages/package.json"
+    ]
+  },
+  "buildArtifacts": {
+    "buildCmd": "(cd packages/pages && pnpm run build-storybook)"
+  },
+  "livePreview": {
+    "serveSetupCmd": "(cd packages/pages && pnpm run build-storybook)",
+    "serveCmd": "(cd packages/pages && pnpm run storybook -- -p 8080)"
+  }
+}

--- a/playground/locations-site/sites-config/features.json
+++ b/playground/locations-site/sites-config/features.json
@@ -4,23 +4,17 @@
       "name": "location",
       "streamId": "location-stream",
       "templateType": "JS",
-      "entityPageSet": {
-        "plugin": {}
-      }
+      "entityPageSet": {}
     },
     {
       "name": "robots",
       "templateType": "JS",
-      "staticPage": {
-        "plugin": {}
-      }
+      "staticPage": {}
     },
     {
       "name": "turtlehead-tacos",
       "templateType": "JS",
-      "staticPage": {
-        "plugin": {}
-      }
+      "staticPage": {}
     }
   ],
   "streams": [

--- a/playground/multibrand-site/sites-config/ci.json
+++ b/playground/multibrand-site/sites-config/ci.json
@@ -1,0 +1,43 @@
+{
+  "artifactStructure": {
+    "assets": [
+      {
+        "root": "packages/pages/storybook-static"
+      }
+    ],
+    "plugins": [
+      {
+        "pluginName": "PagesGenerator",
+        "sourceFiles": [
+          {
+            "root": "dist/plugin",
+            "pattern": "*{.ts,.json}"
+          },
+          {
+            "root": "dist",
+            "pattern": "assets/{server,static,renderer,render}/**/*{.js,.css}"
+          }
+        ],
+        "event": "ON_PAGE_GENERATE",
+        "functionName": "PagesGenerator"
+      }
+    ]
+  },
+  "dependencies": {
+    "installDepsCmd": "npm install -g pnpm && pnpm install",
+    "requiredFiles": [
+      "package.json",
+      "pnpm-lock.json",
+      "pnpm-workspace.yaml",
+      ".npmrc",
+      "packages/pages/package.json"
+    ]
+  },
+  "buildArtifacts": {
+    "buildCmd": "(cd packages/pages && pnpm run build-storybook)"
+  },
+  "livePreview": {
+    "serveSetupCmd": "(cd packages/pages && pnpm run build-storybook)",
+    "serveCmd": "(cd packages/pages && pnpm run storybook -- -p 8080)"
+  }
+}

--- a/playground/multibrand-site/sites-config/sunglasses.oakley.com/ci.json
+++ b/playground/multibrand-site/sites-config/sunglasses.oakley.com/ci.json
@@ -1,0 +1,43 @@
+{
+  "artifactStructure": {
+    "assets": [
+      {
+        "root": "packages/pages/storybook-static"
+      }
+    ],
+    "plugins": [
+      {
+        "pluginName": "PagesGenerator",
+        "sourceFiles": [
+          {
+            "root": "dist/plugin",
+            "pattern": "*{.ts,.json}"
+          },
+          {
+            "root": "dist",
+            "pattern": "assets/{server,static,renderer,render}/**/*{.js,.css}"
+          }
+        ],
+        "event": "ON_PAGE_GENERATE",
+        "functionName": "PagesGenerator"
+      }
+    ]
+  },
+  "dependencies": {
+    "installDepsCmd": "npm install -g pnpm && pnpm install",
+    "requiredFiles": [
+      "package.json",
+      "pnpm-lock.json",
+      "pnpm-workspace.yaml",
+      ".npmrc",
+      "packages/pages/package.json"
+    ]
+  },
+  "buildArtifacts": {
+    "buildCmd": "(cd packages/pages && pnpm run build-storybook)"
+  },
+  "livePreview": {
+    "serveSetupCmd": "(cd packages/pages && pnpm run build-storybook)",
+    "serveCmd": "(cd packages/pages && pnpm run storybook -- -p 8080)"
+  }
+}

--- a/playground/multibrand-site/sites-config/sunglasses.rayban.com/ci.json
+++ b/playground/multibrand-site/sites-config/sunglasses.rayban.com/ci.json
@@ -1,0 +1,43 @@
+{
+  "artifactStructure": {
+    "assets": [
+      {
+        "root": "packages/pages/storybook-static"
+      }
+    ],
+    "plugins": [
+      {
+        "pluginName": "PagesGenerator",
+        "sourceFiles": [
+          {
+            "root": "dist/plugin",
+            "pattern": "*{.ts,.json}"
+          },
+          {
+            "root": "dist",
+            "pattern": "assets/{server,static,renderer,render}/**/*{.js,.css}"
+          }
+        ],
+        "event": "ON_PAGE_GENERATE",
+        "functionName": "PagesGenerator"
+      }
+    ]
+  },
+  "dependencies": {
+    "installDepsCmd": "npm install -g pnpm && pnpm install",
+    "requiredFiles": [
+      "package.json",
+      "pnpm-lock.json",
+      "pnpm-workspace.yaml",
+      ".npmrc",
+      "packages/pages/package.json"
+    ]
+  },
+  "buildArtifacts": {
+    "buildCmd": "(cd packages/pages && pnpm run build-storybook)"
+  },
+  "livePreview": {
+    "serveSetupCmd": "(cd packages/pages && pnpm run build-storybook)",
+    "serveCmd": "(cd packages/pages && pnpm run storybook -- -p 8080)"
+  }
+}

--- a/playground/multibrand-site/sites-config/sunglasses.rayban.com/features.json
+++ b/playground/multibrand-site/sites-config/sunglasses.rayban.com/features.json
@@ -3,24 +3,18 @@
     {
       "name": "robots",
       "templateType": "JS",
-      "staticPage": {
-        "plugin": {}
-      }
+      "staticPage": {}
     },
     {
       "name": "turtlehead-tacos",
       "templateType": "JS",
-      "staticPage": {
-        "plugin": {}
-      }
+      "staticPage": {}
     },
     {
       "name": "sunglasses",
       "streamId": "ray-ban-stream",
       "templateType": "JS",
-      "entityPageSet": {
-        "plugin": {}
-      }
+      "entityPageSet": {}
     }
   ],
   "streams": [


### PR DESCRIPTION
PagesJS commands now throw error codes properly. Subsequent commands no longer get executed on failure.

Example with an error added in closeBundle
![errrorInCloseBundle](https://github.com/yext/pages/assets/115099870/f3b514bc-87ac-4752-939a-36a1b0873d3f)
