### PR TITLE
refactor: restore command handlers

### DIFF
--- a/packages/pages/src/build/build.ts
+++ b/packages/pages/src/build/build.ts
@@ -1,5 +1,16 @@
 import { Command } from "commander";
 import { build } from "vite";
+import { ProjectFilepaths } from "../common/src/project/structure.js";
+
+type BuildArgs = Pick<ProjectFilepaths, "scope">;
+
+const handler = async ({ scope }: BuildArgs) => {
+  // Pass CLI arguments as env variables to use in vite-plugin
+  if (scope) {
+    process.env.YEXT_PAGES_SCOPE = scope;
+  }
+  build();
+};
 
 export const buildCommand = (program: Command) => {
   program
@@ -9,12 +20,5 @@ export const buildCommand = (program: Command) => {
       "--scope <string>",
       "The subfolder to scope the served templates from"
     )
-    .action(async (options) => {
-      // Pass CLI arguments as env variables to use in vite-plugin
-      const scope = options.scope;
-      if (scope) {
-        process.env.YEXT_PAGES_SCOPE = scope;
-      }
-      build();
-    });
+    .action(handler);
 };

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -8,8 +8,8 @@ import { ProjectFilepaths } from "../common/src/project/structure.js";
 
 interface DevArgs extends Pick<ProjectFilepaths, "scope"> {
   local?: boolean;
-  "prod-url"?: boolean;
-  "open-browser": boolean;
+  prodUrl?: boolean;
+  openBrowser: boolean;
   noInit?: boolean;
   scope?: string;
   noGenFeatures?: boolean;
@@ -18,8 +18,8 @@ interface DevArgs extends Pick<ProjectFilepaths, "scope"> {
 
 const handler = async ({
   local,
-  "prod-url": useProdURLs,
-  "open-browser": openBrowser,
+  prodUrl,
+  openBrowser,
   noInit,
   scope,
   noGenFeatures,
@@ -33,7 +33,7 @@ const handler = async ({
       scope ? ["--scope" + " " + scope] : []
     );
 
-  await createServer(!local, !!useProdURLs, scope);
+  await createServer(!local, !!prodUrl, scope);
 
   if (openBrowser) await open(`http://localhost:${devServerPort}/`);
 };

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -4,6 +4,39 @@ import runSubProcess from "../util/runSubprocess.js";
 import { devServerPort } from "./server/middleware/constants.js";
 import { autoYextInit } from "./server/autoInit.js";
 import open from "open";
+import { ProjectFilepaths } from "../common/src/project/structure.js";
+
+interface DevArgs extends Pick<ProjectFilepaths, "scope"> {
+  local?: boolean;
+  "prod-url"?: boolean;
+  "open-browser": boolean;
+  noInit?: boolean;
+  scope?: string;
+  noGenFeatures?: boolean;
+  noGenTestData?: boolean;
+}
+
+const handler = async ({
+  local,
+  "prod-url": useProdURLs,
+  "open-browser": openBrowser,
+  noInit,
+  scope,
+  noGenFeatures,
+}: DevArgs) => {
+  if (!noInit) {
+    await autoYextInit();
+  }
+  if (!noGenFeatures)
+    await runSubProcess(
+      "pages generate features",
+      scope ? ["--scope" + " " + scope] : []
+    );
+
+  await createServer(!local, !!useProdURLs, scope);
+
+  if (openBrowser) await open(`http://localhost:${devServerPort}/`);
+};
 
 export const devCommand = (program: Command) => {
   program
@@ -39,16 +72,5 @@ export const devCommand = (program: Command) => {
     )
     .option("--noInit", "Disables automatic yext init with .yextrc file")
     .option("--noGenFeatures", "Disable feature.json generation step")
-    .action(async (options) => {
-      if (!options.noInit) {
-        await autoYextInit();
-      }
-      if (!options.noGenFeatures)
-        await runSubProcess(
-          "pages generate features",
-          options.scope ? ["--scope" + " " + options.scope] : []
-        );
-      await createServer(!options.local, !!options.useProdURLs, options.scope);
-      if (options.openBrowser) await open(`http://localhost:${devServerPort}/`);
-    });
+    .action(handler);
 };

--- a/packages/pages/src/generate/ci/ci.ts
+++ b/packages/pages/src/generate/ci/ci.ts
@@ -1,11 +1,29 @@
 import path from "path";
 import { Path } from "../../common/src/project/path.js";
-import { defaultProjectStructureConfig } from "../../common/src/project/structure.js";
+import {
+  ProjectFilepaths,
+  defaultProjectStructureConfig,
+} from "../../common/src/project/structure.js";
 import { CiConfig, Plugin } from "../../common/src/ci/ci.js";
 import fs from "node:fs";
 import colors from "picocolors";
 import { loadFunctions } from "../../common/src/function/internal/loader.js";
 import { Command } from "commander";
+
+type FeaturesArgs = Pick<ProjectFilepaths, "scope">;
+
+const handler = ({ scope }: FeaturesArgs): void => {
+  const ciConfigFilename =
+    defaultProjectStructureConfig.filenamesConfig.ciConfig;
+  const sitesConfigRoot =
+    defaultProjectStructureConfig.filepathsConfig.sitesConfigRoot;
+  const ciConfigAbsolutePath = scope
+    ? new Path(
+        path.join(process.cwd(), sitesConfigRoot, scope, ciConfigFilename)
+      )
+    : new Path(path.join(process.cwd(), sitesConfigRoot, ciConfigFilename));
+  updateCiConfig(ciConfigAbsolutePath.getAbsolutePath(), true);
+};
 
 export const ciCommand = (program: Command) => {
   program
@@ -15,19 +33,7 @@ export const ciCommand = (program: Command) => {
       "--scope <string>",
       "The subfolder to scope the served templates from"
     )
-    .action((options, command) => {
-      const scope = options.scope;
-      const ciConfigFilename =
-        defaultProjectStructureConfig.filenamesConfig.ciConfig;
-      const sitesConfigRoot =
-        defaultProjectStructureConfig.filepathsConfig.sitesConfigRoot;
-      const ciConfigAbsolutePath = scope
-        ? new Path(
-            path.join(process.cwd(), sitesConfigRoot, scope, ciConfigFilename)
-          )
-        : new Path(path.join(process.cwd(), sitesConfigRoot, ciConfigFilename));
-      updateCiConfig(ciConfigAbsolutePath.getAbsolutePath(), true);
-    });
+    .action(handler);
 };
 
 /**

--- a/packages/pages/src/generate/features/features.ts
+++ b/packages/pages/src/generate/features/features.ts
@@ -1,10 +1,42 @@
 import path from "path";
 import { Path } from "../../common/src/project/path.js";
-import { ProjectStructure } from "../../common/src/project/structure.js";
+import {
+  ProjectStructure,
+  ProjectFilepaths,
+} from "../../common/src/project/structure.js";
 import { getTemplateFilepaths } from "../../common/src/template/internal/getTemplateFilepaths.js";
 import { loadTemplateModules } from "../../common/src/template/internal/loader.js";
 import { createFeaturesJson } from "./createFeaturesJson.js";
 import { Command } from "commander";
+
+type FeaturesArgs = Pick<ProjectFilepaths, "scope">;
+
+const handler = async ({ scope }: FeaturesArgs): Promise<void> => {
+  const projectStructure = new ProjectStructure();
+  const templatesRoot = projectStructure.templatesRoot.path;
+  const sitesConfigRoot = projectStructure.sitesConfigRoot.path;
+  const templateRootAbsolutePath = path.join(process.cwd(), templatesRoot);
+  const templateFilepaths = getTemplateFilepaths(
+    scope
+      ? [
+          new Path(path.join(templateRootAbsolutePath, scope)),
+          new Path(templateRootAbsolutePath),
+        ]
+      : [new Path(templateRootAbsolutePath)]
+  );
+  const templateModules = await loadTemplateModules(
+    templateFilepaths,
+    true,
+    false
+  );
+  const featuresFilepath = path.join(
+    process.cwd(),
+    sitesConfigRoot,
+    scope ?? "",
+    "features.json"
+  );
+  await createFeaturesJson(templateModules, featuresFilepath);
+};
 
 export const featureCommand = (program: Command) => {
   program
@@ -14,31 +46,5 @@ export const featureCommand = (program: Command) => {
       "--scope <string>",
       "The subfolder to scope the served templates from"
     )
-    .action(async (options) => {
-      const scope = options.scope;
-      const projectStructure = new ProjectStructure();
-      const templatesRoot = projectStructure.templatesRoot.path;
-      const sitesConfigRoot = projectStructure.sitesConfigRoot.path;
-      const templateRootAbsolutePath = path.join(process.cwd(), templatesRoot);
-      const templateFilepaths = getTemplateFilepaths(
-        scope
-          ? [
-              new Path(path.join(templateRootAbsolutePath, scope)),
-              new Path(templateRootAbsolutePath),
-            ]
-          : [new Path(templateRootAbsolutePath)]
-      );
-      const templateModules = await loadTemplateModules(
-        templateFilepaths,
-        true,
-        false
-      );
-      const featuresFilepath = path.join(
-        process.cwd(),
-        sitesConfigRoot,
-        scope ?? "",
-        "features.json"
-      );
-      await createFeaturesJson(templateModules, featuresFilepath);
-    });
+    .action(handler);
 };

--- a/packages/pages/src/prod/prod.ts
+++ b/packages/pages/src/prod/prod.ts
@@ -1,5 +1,18 @@
 import runSubprocess from "../util/runSubprocess.js";
 import { Command } from "commander";
+import { ProjectFilepaths } from "../common/src/project/structure.js";
+
+interface ProdArgs extends Pick<ProjectFilepaths, "scope"> {
+  noBuild?: boolean;
+  noRender?: boolean;
+}
+
+const handler = async (args: ProdArgs) => {
+  const command = "yext pages";
+  if (!args.noBuild) await runSubprocess(command, ["build"]);
+  if (!args.noRender) await runSubprocess(command, ["render"]);
+  await runSubprocess(command, ["serve"]);
+};
 
 export const prodCommand = (program: Command) => {
   program
@@ -7,10 +20,5 @@ export const prodCommand = (program: Command) => {
     .description("Runs a custom local production server")
     .option("--noBuild", "Disable build step")
     .option("--noRender", "Disable render step")
-    .action(async (options) => {
-      const commandName = "yext pages";
-      if (!options.noBuild) await runSubprocess(commandName, ["build"]);
-      if (!options.noRender) await runSubprocess(commandName, ["render"]);
-      await runSubprocess(commandName, ["serve"]);
-    });
+    .action(handler);
 };


### PR DESCRIPTION
Use command handlers that were used previously with Yargs.

As opposed to action written directly in command.

This also fixes 'useProdUrls' in dev.ts


Tested all commands and ran auto tests.