### PR TITLE
fix(plugin): polyfill upgrade breaking build

### DIFF
--- a/packages/pages/src/vite-plugin/plugin.ts
+++ b/packages/pages/src/vite-plugin/plugin.ts
@@ -15,7 +15,16 @@ const plugin = (): PluginOption[] => {
   };
   const projectStructure = new ProjectStructure(projectConfigFromBuildArgs);
 
-  return [build(projectStructure), nodePolyfills()];
+  return [
+    build(projectStructure),
+    nodePolyfills({
+      globals: {
+        Buffer: "build",
+        global: "build",
+        process: "build",
+      },
+    }),
+  ];
 };
 
 export default plugin;

--- a/playground/locations-site/sites-config/features.json
+++ b/playground/locations-site/sites-config/features.json
@@ -1,43 +1,4 @@
 {
-  "features": [
-    {
-      "name": "turtlehead-tacos",
-      "templateType": "JS",
-      "staticPage": {}
-    },
-    {
-      "name": "robots",
-      "templateType": "JS",
-      "staticPage": {}
-    },
-    {
-      "name": "location",
-      "streamId": "location-stream",
-      "templateType": "JS",
-      "entityPageSet": {}
-    }
-  ],
-  "streams": [
-    {
-      "$id": "location-stream",
-      "filter": {
-        "entityTypes": [
-          "location"
-        ]
-      },
-      "fields": [
-        "id",
-        "uid",
-        "meta",
-        "address",
-        "slug"
-      ],
-      "localization": {
-        "locales": [
-          "en"
-        ],
-        "primary": false
-      }
-    }
-  ]
+  "features": [],
+  "streams": []
 }

--- a/playground/multibrand-site/sites-config/sunglasses.oakley.com/features.json
+++ b/playground/multibrand-site/sites-config/sunglasses.oakley.com/features.json
@@ -1,41 +1,4 @@
 {
-  "features": [
-    {
-      "name": "sunglasses",
-      "streamId": "oakley-stream",
-      "templateType": "JS",
-      "entityPageSet": {}
-    },
-    {
-      "name": "turtlehead-tacos",
-      "templateType": "JS",
-      "staticPage": {}
-    },
-    {
-      "name": "robots",
-      "templateType": "JS",
-      "staticPage": {}
-    }
-  ],
-  "streams": [
-    {
-      "$id": "oakley-stream",
-      "fields": [
-        "id",
-        "name",
-        "slug"
-      ],
-      "filter": {
-        "savedFilterIds": [
-          "1241548641"
-        ]
-      },
-      "localization": {
-        "locales": [
-          "en"
-        ],
-        "primary": false
-      }
-    }
-  ]
+  "features": [],
+  "streams": []
 }


### PR DESCRIPTION
A minor version [change](https://github.com/davidmyersdev/vite-plugin-node-polyfills/commit/abf35b8c0309b0d5fc43d5e51e037d4ee4f675e3#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R164) to vite-plugin-node-polyfill adds a dev-only polyfill because it always assumes dev. This breaks the build when generating features because window is undefined. This changes the globals to be polyfilled as "build".