### PR TITLE
feat(dev): export createServer and add --port arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lerna-debug.log*
 
 dist
 *.local
+**/.yextrc
 
 # Editor directories and files
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ lerna-debug.log*
 
 dist
 *.local
-**/.yextrc
 
 # Editor directories and files
 .vscode/*

--- a/packages/pages/src/dev/server/middleware/constants.ts
+++ b/packages/pages/src/dev/server/middleware/constants.ts
@@ -1,10 +1,3 @@
-import getPort, { portNumbers } from "get-port";
-
-// Will use any available port from 5173 to 6000, otherwise fall back to a random port
-export const devServerPort = await getPort({
-  port: portNumbers(5173, 6000),
-});
-
 export const dynamicModeInfoText = `URLs displayed here are generated 
 from the contents of the <span class="code">localData</span> folder. This folder is auto-generated 
 every time you re-run the dev server.  By default, you will receive real-time data updates from the 

--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -5,7 +5,6 @@ import {
 } from "../ssr/getLocalData.js";
 import index from "../public/index.js";
 import {
-  devServerPort,
   dynamicModeInfoText,
   localDevUrlInfoText,
   localDevUrlHelpText,
@@ -29,6 +28,7 @@ type Props = {
   dynamicGenerateData: boolean;
   useProdURLs: boolean;
   projectStructure: ProjectStructure;
+  devServerPort: number;
 };
 
 export const indexPage =
@@ -37,6 +37,7 @@ export const indexPage =
     dynamicGenerateData,
     useProdURLs,
     projectStructure,
+    devServerPort,
   }: Props): RequestHandler =>
   async (_req, res, next) => {
     try {
@@ -102,7 +103,7 @@ export const indexPage =
           indexPageHtml = indexPageHtml.replace(
             `<!--static-pages-html-->`,
             `<h3>Static Pages</h3>
-            ${createStaticPageListItems(localDataManifest)}`
+            ${createStaticPageListItems(localDataManifest, devServerPort)}`
           );
         }
 
@@ -136,7 +137,8 @@ export const indexPage =
                     ${createEntityPageListItems(
                       localDataManifest,
                       templateName,
-                      useProdURLs
+                      useProdURLs,
+                      devServerPort
                     )}
                   </tbody>
                 </table>`,
@@ -159,7 +161,11 @@ export const indexPage =
       const functionsList = [
         ...(await loadFunctions("src/functions")).values(),
       ];
-      indexPageHtml = createFunctionsTable(functionsList, indexPageHtml);
+      indexPageHtml = createFunctionsTable(
+        functionsList,
+        indexPageHtml,
+        devServerPort
+      );
 
       // Send the HTML back.
       res.status(200).set({ "Content-Type": "text/html" }).end(indexPageHtml);
@@ -170,7 +176,10 @@ export const indexPage =
     }
   };
 
-const createStaticPageListItems = (localDataManifest: LocalDataManifest) => {
+const createStaticPageListItems = (
+  localDataManifest: LocalDataManifest,
+  devServerPort: number
+) => {
   return Array.from(localDataManifest.static).reduce(
     (templateAccumulator, [, { featureName, staticURL, locales }]) =>
       templateAccumulator +
@@ -213,7 +222,8 @@ const createStaticPageListItems = (localDataManifest: LocalDataManifest) => {
 const createEntityPageListItems = (
   localDataManifest: LocalDataManifest,
   templateName: string,
-  useProdURLs: boolean
+  useProdURLs: boolean,
+  devServerPort: number
 ) => {
   const formatLink = (entityId: string, slug: string | undefined) => {
     if (useProdURLs) {
@@ -284,7 +294,8 @@ const getInfoMessage = (isDynamic: boolean, isProdUrl: boolean): string => {
 
 const createFunctionsTable = (
   functionsList: FunctionModuleInternal[],
-  indexPageHtml: string
+  indexPageHtml: string,
+  devServerPort: number
 ) => {
   if (functionsList.length > 0) {
     return indexPageHtml.replace(

--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -5,7 +5,6 @@ import { createServer as createViteServer } from "vite";
 import { serverRenderRoute } from "./middleware/serverRenderRoute.js";
 import { ignoreFavicon } from "./middleware/ignoreFavicon.js";
 import { errorMiddleware } from "./middleware/errorMiddleware.js";
-import { devServerPort } from "./middleware/constants.js";
 import { indexPage } from "./middleware/indexPage.js";
 import { generateTestData } from "./ssr/generateTestData.js";
 import { ProjectStructure } from "../../common/src/project/structure.js";
@@ -24,6 +23,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export const createServer = async (
   dynamicGenerateData: boolean,
   useProdURLs: boolean,
+  devServerPort: number,
   scope?: string
 ) => {
   // creates a standard express app
@@ -179,6 +179,7 @@ export const createServer = async (
       dynamicGenerateData,
       useProdURLs,
       projectStructure,
+      devServerPort,
     })
   );
 

--- a/packages/pages/src/index.ts
+++ b/packages/pages/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./dev/dev.js";
+export { createServer as createDevServer } from "./dev/server/server.js";
 export * from "./common/src/template/head.js";
 export * from "./common/src/template/paths.js";
 export * from "./common/src/template/types.js";


### PR DESCRIPTION
This PR exports createServer as createDevServer, and adds a port CLI arg and also to createServer itself.
The main purpose of this is to address inconsistencies with spawning pages as a child process from within `@yext/studio`.
But I think these changes are also useful outside of that purpose.

J=SLAP-2885
TEST=manual

test that I can start up the playground/locations-site with a --port arg
test that I can import createDevServer in a separate package and start the pages dev server with it