### PR TITLE
fix(dev): use ts-morph to parse template configs

### DIFF
--- a/packages/pages/THIRD-PARTY-NOTICES
+++ b/packages/pages/THIRD-PARTY-NOTICES
@@ -1285,6 +1285,36 @@ Repository: https://github.com/yargs/yargs-parser.git
 
 The following npm package may be included in this product:
 
+ - ts-morph@19.0.0
+
+This package contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 David Sherret
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----------
+
+The following npm package may be included in this product:
+
  - typescript@5.1.6
 
 This package contains the following license and notice below:

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -74,6 +74,7 @@
     "pretty-ms": "^8.0.0",
     "prompts": "^2.4.2",
     "rollup": "^3.28.0",
+    "ts-morph": "^19.0.0",
     "typescript": "^5.1.6",
     "vite": "^4.4.9",
     "vite-plugin-node-polyfills": "^0.11.0"

--- a/packages/pages/src/common/src/parsers/sourceFileParser.ts
+++ b/packages/pages/src/common/src/parsers/sourceFileParser.ts
@@ -1,0 +1,113 @@
+import {
+  Project,
+  SourceFile,
+  SyntaxKind,
+  FunctionDeclaration,
+  ObjectLiteralExpression,
+  ArrowFunction,
+} from "ts-morph";
+import vm from "node:vm";
+import typescript from "typescript";
+import { processEnvVariables } from "../../../util/processEnvVariables.js";
+
+export function createTsMorphProject() {
+  return new Project({
+    compilerOptions: {
+      jsx: typescript.JsxEmit.ReactJSX,
+    },
+  });
+}
+
+export default class SourceFileParser {
+  private sourceFile: SourceFile;
+
+  constructor(
+    private filepath: string,
+    project: Project
+  ) {
+    if (!project.getSourceFile(filepath)) {
+      project.addSourceFileAtPath(filepath);
+    }
+    this.sourceFile = project.getSourceFileOrThrow(filepath);
+  }
+
+  getExportedObjectExpression(
+    variableName: string
+  ): ObjectLiteralExpression | undefined {
+    const variableStatement = this.sourceFile
+      .getVariableStatements()
+      .find((variableStatement) => {
+        return (
+          variableStatement.isExported() &&
+          variableStatement
+            .getFirstDescendantByKindOrThrow(SyntaxKind.VariableDeclaration)
+            .getName() === variableName
+        );
+      });
+    if (!variableStatement) {
+      return;
+    }
+    const objectLiteralExp = variableStatement.getFirstDescendantByKind(
+      SyntaxKind.ObjectLiteralExpression
+    );
+    if (!objectLiteralExp) {
+      throw new Error(
+        `Could not find ObjectLiteralExpression within \`${variableStatement.getFullText()}\`.`
+      );
+    }
+    return objectLiteralExp;
+  }
+
+  getExportFunctionExpression(
+    functionName?: string
+  ): ObjectLiteralExpression[] | ObjectLiteralExpression | undefined {
+    if (functionName) {
+      const functionDeclaration = this.sourceFile.getFunction(
+        (f) => f.isExported() && f.getName() === functionName
+      );
+      const objectLiteralExp = functionDeclaration?.getFirstDescendantByKind(
+        SyntaxKind.ObjectLiteralExpression
+      );
+      return objectLiteralExp;
+    }
+    const functionDeclarations = this.sourceFile.getFunctions();
+    const objectLiteralExpressions: ObjectLiteralExpression[] = [];
+    functionDeclarations.forEach((fd) => {
+      if (fd.isExported()) {
+        objectLiteralExpressions.push(
+          fd.getFirstAncestorByKindOrThrow(SyntaxKind.ObjectLiteralExpression)
+        );
+      }
+    });
+    return objectLiteralExpressions;
+  }
+
+  getFunctions() {
+    return this.sourceFile.getFunctions();
+  }
+
+  getFunctionNode(
+    funcName: string
+  ): FunctionDeclaration | ArrowFunction | undefined {
+    return (
+      this.sourceFile.getFunction(funcName) ??
+      this.sourceFile
+        .getVariableDeclaration(funcName)
+        ?.getFirstChildByKind(SyntaxKind.ArrowFunction)
+    );
+  }
+
+  /**
+   * This function takes in an {@link ObjectLiteralExpression} and returns it's data.
+   *
+   * It converts a js object string and converts it into an object using vm.runInNewContext,
+   * which can be thought of as a safe version of `eval`. Note that we cannot use JSON.parse here,
+   * because we are working with a js object not a JSON.
+   */
+  getCompiledObjectLiteral<T>(objectLiteralExp: ObjectLiteralExpression): T {
+    return vm.runInNewContext(
+      "(" + objectLiteralExp.getText() + ")",
+      processEnvVariables("YEXT_PUBLIC")
+    );
+  }
+}

--- a/packages/pages/src/common/src/parsers/templateConfigParser.ts
+++ b/packages/pages/src/common/src/parsers/templateConfigParser.ts
@@ -1,0 +1,25 @@
+import { TemplateConfig } from "../template/types.js";
+import SourceFileParser from "./sourceFileParser.js";
+
+export const TEMPLATE_CONFIG_VARIABLE_NAME = "config";
+
+/**
+ * TemplateConfigParser is a class for parsing the template config.
+ */
+export default class TemplateConfigParser {
+  constructor(private sourceFileParser: SourceFileParser) {}
+
+  /** Returns the template config exported from the page if one is present. */
+  getTemplateConfig(): TemplateConfig | undefined {
+    const configObjectLiteralExp =
+      this.sourceFileParser.getExportedObjectExpression(
+        TEMPLATE_CONFIG_VARIABLE_NAME
+      );
+    return (
+      configObjectLiteralExp &&
+      this.sourceFileParser.getCompiledObjectLiteral<TemplateConfig>(
+        configObjectLiteralExp
+      )
+    );
+  }
+}

--- a/packages/pages/src/common/src/template/internal/types.ts
+++ b/packages/pages/src/common/src/template/internal/types.ts
@@ -146,7 +146,7 @@ export const convertTemplateModuleToTemplateModuleInternal = (
   return templateModuleInternal;
 };
 
-const convertTemplateConfigToTemplateConfigInternal = (
+export const convertTemplateConfigToTemplateConfigInternal = (
   templateName: string,
   templateConfig: TemplateConfig | undefined
 ): TemplateConfigInternal => {

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -10,7 +10,6 @@ import {
 import path from "path";
 import fs from "fs";
 import { ProjectStructure } from "../../../common/src/project/structure.js";
-import { getFeaturesConfig } from "../../../generate/features/createFeaturesJson.js";
 import { getTemplateFilepathsFromProjectStructure } from "../../../common/src/template/internal/getTemplateFilepaths.js";
 import {
   convertTemplateModuleToTemplateModuleInternal,
@@ -20,6 +19,7 @@ import { ViteDevServer } from "vite";
 import { loadViteModule } from "./loadViteModule.js";
 import { TemplateModuleCollection } from "../../../common/src/template/internal/loader.js";
 import { TemplateModule } from "../../../common/src/template/types.js";
+import { getFeaturesConfig } from "../../../generate/templates/createTemplatesJsonFromModule.js";
 
 /**
  * generateTestData will run yext pages generate-test-data and return true in

--- a/packages/pages/src/generate/features/features.ts
+++ b/packages/pages/src/generate/features/features.ts
@@ -1,21 +1,15 @@
 import { ProjectStructure } from "../../common/src/project/structure.js";
 import { getTemplateFilepaths } from "../../common/src/template/internal/getTemplateFilepaths.js";
-import { loadTemplateModules } from "../../common/src/template/internal/loader.js";
-import { createFeaturesJson } from "./createFeaturesJson.js";
 import { Command } from "commander";
+import { createTemplatesJson } from "../templates/createTemplatesJson.js";
 
 const handler = async ({ scope }: { scope: string }): Promise<void> => {
   const projectStructure = await ProjectStructure.init({ scope });
   const templateFilepaths = getTemplateFilepaths(
     projectStructure.getTemplatePaths()
   );
-  const templateModules = await loadTemplateModules(
-    templateFilepaths,
-    true,
-    false
-  );
 
-  createFeaturesJson(templateModules, projectStructure);
+  createTemplatesJson(templateFilepaths, projectStructure, "FEATURES");
 };
 
 export const featureCommand = (program: Command) => {

--- a/packages/pages/src/generate/templates/createTemplatesJsonFromModule.test.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJsonFromModule.test.ts
@@ -1,8 +1,8 @@
 import { FeaturesConfig } from "../../common/src/feature/features.js";
 import { TemplateModuleCollection } from "../../common/src/template/internal/loader.js";
-import { getTemplatesConfig } from "./createTemplatesJson.js";
+import { getFeaturesConfig } from "./createTemplatesJsonFromModule.js";
 
-describe("createTemplatesJson - getTemplatesConfig", () => {
+describe("createTemplatesJsonFromModule - getFeaturesConfig", () => {
   it("creates the proper default templates structure", async () => {
     const templateModules: TemplateModuleCollection = new Map();
     templateModules.set("turtlehead-tacos", {
@@ -82,6 +82,6 @@ describe("createTemplatesJson - getTemplatesConfig", () => {
       ],
     };
 
-    expect(getTemplatesConfig(templateModules)).toEqual(expected);
+    expect(getFeaturesConfig(templateModules)).toEqual(expected);
   });
 });

--- a/packages/pages/src/generate/templates/createTemplatesJsonFromModule.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJsonFromModule.ts
@@ -7,16 +7,26 @@ import {
 } from "../../common/src/feature/features.js";
 import { TemplateModuleCollection } from "../../common/src/template/internal/loader.js";
 import { ProjectStructure } from "../../common/src/project/structure.js";
+import { StreamConfig } from "../../common/src/feature/stream.js";
+
+// TODO: rename functions in this file once there is a migration flow and checks for it
+// TODO: mergeFeatureJson will no longer be necessary
+// TODO: write to dist/templates.json
 
 export const getFeaturesConfig = (
   templateModules: TemplateModuleCollection
 ): FeaturesConfig => {
   const features: FeatureConfig[] = [];
-  const streams: any[] = [];
+  const streams: StreamConfig[] = [];
   for (const module of templateModules.values()) {
     const featureConfig = convertTemplateConfigToFeatureConfig(module.config);
     features.push(featureConfig);
-    module.config.stream && streams.push({ ...module.config.stream });
+    module.config.stream &&
+      streams.push({
+        ...module.config.stream,
+        source: "knowledgeGraph",
+        destination: "pages",
+      });
   }
 
   return { features, streams };
@@ -54,7 +64,7 @@ export const createFeaturesJson = (
  * Overwrites the "features" and "streams" fields in the feature.json while keeping other fields
  * if the feature.json already exists.
  */
-const mergeFeatureJson = (
+export const mergeFeatureJson = (
   featurePath: string,
   features: FeatureConfig[],
   streams: any

--- a/packages/pages/src/generate/templates/templates.ts
+++ b/packages/pages/src/generate/templates/templates.ts
@@ -1,6 +1,5 @@
 import { ProjectStructure } from "../../common/src/project/structure.js";
 import { getTemplateFilepaths } from "../../common/src/template/internal/getTemplateFilepaths.js";
-import { loadTemplateModules } from "../../common/src/template/internal/loader.js";
 import { createTemplatesJson } from "./createTemplatesJson.js";
 import { Command } from "commander";
 
@@ -9,13 +8,8 @@ const handler = async ({ scope }: { scope: string }): Promise<void> => {
   const templateFilepaths = getTemplateFilepaths(
     projectStructure.getTemplatePaths()
   );
-  const templateModules = await loadTemplateModules(
-    templateFilepaths,
-    true,
-    false
-  );
 
-  createTemplatesJson(templateModules, projectStructure);
+  createTemplatesJson(templateFilepaths, projectStructure, "TEMPLATES");
 };
 
 export const templatesCommand = (program: Command) => {

--- a/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
@@ -10,7 +10,6 @@ import {
   loadTemplateModules,
   TemplateModuleCollection,
 } from "../../../common/src/template/internal/loader.js";
-import { createFeaturesJson } from "../../../generate/features/createFeaturesJson.js";
 import {
   generateFunctionMetadataFile,
   shouldGenerateFunctionMetadata,
@@ -21,6 +20,7 @@ import {
   bundleServerlessFunctions,
   shouldBundleServerlessFunctions,
 } from "./serverlessFunctions.js";
+import { createFeaturesJson } from "../../../generate/templates/createTemplatesJsonFromModule.js";
 
 export default (projectStructure: ProjectStructure) => {
   return async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       rollup:
         specifier: ^3.28.0
         version: 3.28.0
+      ts-morph:
+        specifier: ^19.0.0
+        version: 19.0.0
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -1754,12 +1757,10 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    dev: true
 
   /@nodelib/fs.stat@2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
-    dev: true
 
   /@nodelib/fs.walk@1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
@@ -1767,7 +1768,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
-    dev: true
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1920,6 +1920,15 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
     dev: true
+
+  /@ts-morph/common@0.20.0:
+    resolution: {integrity: sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==}
+    dependencies:
+      fast-glob: 3.3.0
+      minimatch: 7.4.6
+      mkdirp: 2.1.6
+      path-browserify: 1.0.1
+    dev: false
 
   /@types/argparse@1.0.38:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -2939,7 +2948,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
 
   /brorand@1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
@@ -3230,6 +3238,10 @@ packages:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
+
+  /code-block-writer@12.0.0:
+    resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
+    dev: false
 
   /collect-v8-coverage@1.0.2:
     resolution: {integrity: sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==}
@@ -4526,7 +4538,6 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: true
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -4540,7 +4551,6 @@ packages:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
-    dev: true
 
   /fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -4560,7 +4570,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
   /finalhandler@1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
@@ -4779,7 +4788,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -5168,7 +5176,6 @@ packages:
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -5196,7 +5203,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -5242,7 +5248,6 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
@@ -6257,7 +6262,6 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-    dev: true
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -6270,7 +6274,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: true
 
   /miller-rabin@4.0.1:
     resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
@@ -6318,6 +6321,13 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
+  /minimatch@7.4.6:
+    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6338,6 +6348,12 @@ packages:
     dependencies:
       minimist: 1.2.8
     dev: true
+
+  /mkdirp@2.1.6:
+    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: false
 
   /module-from-string@3.3.0:
     resolution: {integrity: sha512-VsjwtQtXZloDF7ZpBXON53U4Zz02K1/njJmfZcK+QDlYKgdL0ETq8/FeuU0G9EHxdG5XiTaITcGaldDAqJpGXA==}
@@ -7072,7 +7088,6 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -7282,7 +7297,6 @@ packages:
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
 
   /rfdc@1.3.0:
     resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
@@ -7319,7 +7333,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-    dev: true
 
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
@@ -7926,7 +7939,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -8005,6 +8017,13 @@ packages:
       typescript: 5.1.6
       yargs-parser: 21.1.1
     dev: true
+
+  /ts-morph@19.0.0:
+    resolution: {integrity: sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==}
+    dependencies:
+      '@ts-morph/common': 0.20.0
+      code-block-writer: 12.0.0
+    dev: false
 
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}


### PR DESCRIPTION
Previous to this change, we used esbuild to compile the templates into modules in order to pull off the config const. This led to various issues for people. It works fine with Vite since Vite does a lot of CJS/polyfill magic, but we weren't handling that with esbuild. This was overkill anyways as we only need to grab the config off of the templates, so compilation is irrelevant at this step.