### PR TITLE
fix: empty yaml leads to parse error

### DIFF
--- a/packages/pages/src/common/src/assets/getAssetsFilepath.ts
+++ b/packages/pages/src/common/src/assets/getAssetsFilepath.ts
@@ -25,9 +25,9 @@ export const determineAssetsFilepath = async (
   if (fs.existsSync(configYamlPath)) {
     const configYaml = yaml.load(
       fs.readFileSync(configYamlPath, "utf-8")
-    ) as ConfigYaml;
+    ) as ConfigYaml | null;
 
-    if (configYaml.assetsDir && configYaml.assetsDir !== "") {
+    if (configYaml?.assetsDir && configYaml.assetsDir !== "") {
       return configYaml.assetsDir;
     }
   }


### PR DESCRIPTION
Running `pages generate templates` would fail when a config.yaml file existed but it was completely empty.