### PR TITLE
feat(plugin): include static assets in platform

### DIFF
--- a/packages/pages/src/generate/artifacts/createArtifactsJson.test.ts
+++ b/packages/pages/src/generate/artifacts/createArtifactsJson.test.ts
@@ -13,6 +13,10 @@ describe("createArtifactsJson - getArtifactsConfig", () => {
             root: "dist",
             pattern: "assets/**/*",
           },
+          {
+            root: "dist",
+            pattern: "*",
+          },
         ],
         plugins: [
           {

--- a/packages/pages/src/generate/artifacts/createArtifactsJson.ts
+++ b/packages/pages/src/generate/artifacts/createArtifactsJson.ts
@@ -38,9 +38,15 @@ export const getArtifactsConfig = async (
   const artifactConfig: ArtifactsConfig = {
     artifactStructure: {
       assets: [
+        // assets from the plugin
         {
           root: projectStructure.config.rootFolders.dist,
           pattern: `${projectStructure.config.subfolders.assets}/**/*`,
+        },
+        // static assets based on the Vite publicDir
+        {
+          root: projectStructure.config.rootFolders.dist,
+          pattern: "*",
         },
       ],
       plugins: [getGeneratorPlugin(projectStructure)],

--- a/packages/pages/src/generate/ci/ci.test.ts
+++ b/packages/pages/src/generate/ci/ci.test.ts
@@ -35,6 +35,10 @@ describe("ci - getUpdatedCiConfig", () => {
             root: "dist",
             pattern: "assets/**/*",
           },
+          {
+            root: "dist",
+            pattern: "*",
+          },
         ],
         features: "sites-config/features.json",
         plugins: [
@@ -119,6 +123,10 @@ describe("ci - getUpdatedCiConfig", () => {
           {
             root: "dist",
             pattern: "assets/**/*",
+          },
+          {
+            root: "dist",
+            pattern: "*",
           },
         ],
         features: "sites-config/features.json",

--- a/packages/pages/src/generate/ci/ci.ts
+++ b/packages/pages/src/generate/ci/ci.ts
@@ -84,9 +84,17 @@ export const getUpdatedCiConfig = async (
   const ciConfigCopy = structuredClone(ciConfig);
 
   ciConfigCopy.artifactStructure.assets = [];
+
+  // assets from the plugin
   ciConfigCopy.artifactStructure.assets.push({
     root: projectStructure.config.rootFolders.dist,
     pattern: `${projectStructure.config.subfolders.assets}/**/*`,
+  });
+
+  // static assets based on the Vite publicDir
+  ciConfigCopy.artifactStructure.assets.push({
+    root: projectStructure.config.rootFolders.dist,
+    pattern: "*",
   });
 
   ciConfigCopy.artifactStructure.plugins = [];


### PR DESCRIPTION
Since ci.json is auto-generated, specifically the assets portion, there's no option for a user to manually set the static assets anymore. Now we include everything in the root of dist which is where Vite will dump those files.