### PR TITLE
fix(dev): env vars through ts-morph double quoted

### DIFF
--- a/packages/pages/src/common/src/parsers/sourceFileParser.ts
+++ b/packages/pages/src/common/src/parsers/sourceFileParser.ts
@@ -107,7 +107,7 @@ export default class SourceFileParser {
   getCompiledObjectLiteral<T>(objectLiteralExp: ObjectLiteralExpression): T {
     return vm.runInNewContext(
       "(" + objectLiteralExp.getText() + ")",
-      processEnvVariables("YEXT_PUBLIC")
+      processEnvVariables("YEXT_PUBLIC", false)
     );
   }
 }

--- a/packages/pages/src/util/processEnvVariables.test.ts
+++ b/packages/pages/src/util/processEnvVariables.test.ts
@@ -22,4 +22,11 @@ describe("processEnvVariables", () => {
     expect(Object.keys(env).length).toEqual(1);
     expect(env.YEXT_PUBLIC_KEY).toEqual(`"pk.0123456789"`);
   });
+
+  it("does not stringify values", () => {
+    const env = processEnvVariables("YEXT_PUBLIC", false);
+
+    expect(Object.keys(env).length).toEqual(1);
+    expect(env.YEXT_PUBLIC_KEY).toEqual("pk.0123456789");
+  });
 });

--- a/packages/pages/src/util/processEnvVariables.ts
+++ b/packages/pages/src/util/processEnvVariables.ts
@@ -8,14 +8,19 @@ import { loadEnv } from "vite";
  * @param prefix string specifying the beginning of the keys to match
  */
 export const processEnvVariables = (
-  prefix = "VITE"
+  prefix = "VITE",
+  // needed for templates and functions, but sourceFileParser double stringifies
+  stringifyValues = true
 ): Record<string, string> => {
   const mode = process.env.NODE_ENV || "development";
   let processEnv = loadEnv(mode, process.cwd(), "");
   processEnv = Object.fromEntries(
     Object.entries(processEnv)
       .filter(([env]) => env.startsWith(prefix))
-      .map(([key, value]) => [key, JSON.stringify(value)])
+      .map(([key, value]) => [
+        key,
+        stringifyValues ? JSON.stringify(value) : value,
+      ])
   );
 
   return processEnv;


### PR DESCRIPTION
Environment variable string need to be quoted normally (within templates and functions) but were being double quote escaped when running through ts-morph during feature/template.json generation.