### PR TITLE
fix(dev/plugin): support HTML in Content fields

### DIFF
--- a/packages/pages/src/common/src/template/hydration.ts
+++ b/packages/pages/src/common/src/template/hydration.ts
@@ -36,7 +36,7 @@ export const getHydrationTemplateDev = (
     render(
     {
         Page: Component,
-        pageProps: ${JSON.stringify(props)},
+        pageProps: ${getPagePropsString(props)},
     }
     );
   `;
@@ -76,10 +76,16 @@ export const getHydrationTemplate = (
         render.render(
         {
             Page: component.default,
-            pageProps: ${JSON.stringify(props)},
+            pageProps: ${getPagePropsString(props)},
         }
         );
     `;
+};
+
+const getPagePropsString = (props: TemplateRenderProps) => {
+  return `JSON.parse(decodeURIComponent("${encodeURIComponent(
+    JSON.stringify(props)
+  )}"))`;
 };
 
 const makeAbsolute = (path: string): string => {


### PR DESCRIPTION
Fixes #225.

To support this, we now encode the page props before injecting the JS bundle in the DOM and have the JS bundle decode the props before passing it to the `render` function that renders the page.

J=SUMO-5337
TEST=manual

In a test site, see that both `dev` and `build:serve` can successfully serve a page that is using a Content field with HTML in it that includes a `</script>` closing tag. Test in the platform as well and see the page has errors without this change, and renders properly with the fix.