### PR TITLE
fix(plugin): address "Cannot find module" for deno module imports

### DIFF
--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -33,6 +33,7 @@ const getFunctionMetadataMap = async (
     )
     .map((f) => path.resolve(f));
 
+  project.addSourceFilesAtPaths(filepaths);
   const results = await Promise.allSettled(
     filepaths.map(generateFunctionMetadata)
   );
@@ -60,7 +61,6 @@ const getFunctionMetadataMap = async (
 async function generateFunctionMetadata(
   filepath: string
 ): Promise<[string, FunctionMetadata]> {
-  project.addSourceFileAtPath(filepath);
   const defaultExportDeclaration = project
     .getSourceFile(filepath)
     ?.getDefaultExportSymbol()

--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -72,9 +72,9 @@ async function generateFunctionMetadata(
     )[0];
     if (!exportIdenfitier) {
       throw new Error(
-        `${relativePath} contains a default export assignment that is improperly ` +
-          "formatted. It may have an anonymous arrow function as the default " +
-          "export which is not supported."
+        `${relativePath} contains an improper default export assignment. ` +
+          "The default export must be a function, and it must be formatted " +
+          "as `export default foo;` for function `foo`."
       );
     }
     return [relativePath, { entrypoint: exportIdenfitier.getText() }];
@@ -82,9 +82,9 @@ async function generateFunctionMetadata(
     const entrypoint = defaultExportDeclaration.getName();
     if (!entrypoint) {
       throw new Error(
-        `${relativePath} contains a default function declaration that is improperly ` +
-          "formatted. It may have an anonymous function as the default export " +
-          "which is not supported."
+        `${relativePath} contains an improper default function declaration. ` +
+          "The default export function must be a named function, exported as " +
+          "`export default function foo(){}` for function `foo`"
       );
     }
     return [relativePath, { entrypoint }];

--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -72,7 +72,7 @@ async function generateFunctionMetadata(
       ?.getText();
     if (!entrypoint) {
       throw new Error(
-        `${relativePath} contains an improper default export assignment. ` +
+        `${relativePath} contains an unsupported default export assignment. ` +
           "The default export must be a function, and it must be formatted " +
           "as `export default foo;` for function `foo`."
       );
@@ -82,7 +82,7 @@ async function generateFunctionMetadata(
     const entrypoint = defaultExportDeclaration.getName();
     if (!entrypoint) {
       throw new Error(
-        `${relativePath} contains an improper default function declaration. ` +
+        `${relativePath} contains an unsupported default function declaration. ` +
           "The default export function must be a named function, exported as " +
           "`export default function foo(){}` for function `foo`"
       );
@@ -92,7 +92,7 @@ async function generateFunctionMetadata(
   throw new Error(
     `${relativePath} does not contain a properly formatted default export. ` +
       "The default export must be named and declared either in the function declaration " +
-      "or in an `export default ...;` expresion."
+      "or in an `export default ...;` expression."
   );
 }
 

--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -82,7 +82,7 @@ async function generateFunctionMetadata(
     const entrypoint = defaultExportDeclaration.getName();
     if (!entrypoint) {
       throw new Error(
-        `${relativePath} contains a default export assignment that is improperly ` +
+        `${relativePath} contains a default function declaration that is improperly ` +
           "formatted. It may have an anonymous function as the default export " +
           "which is not supported."
       );

--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -72,9 +72,9 @@ async function generateFunctionMetadata(
     )[0];
     if (!exportIdenfitier) {
       throw new Error(
-        `${relativePath} contains a default export assignment that is ` +
-          "improperly formatted. It may have an anonymous function as the default export " +
-          "which is not supported."
+        `${relativePath} contains a default export assignment that is improperly ` +
+          "formatted. It may have an anonymous arrow function as the default " +
+          "export which is not supported."
       );
     }
     return [relativePath, { entrypoint: exportIdenfitier.getText() }];
@@ -82,8 +82,9 @@ async function generateFunctionMetadata(
     const entrypoint = defaultExportDeclaration.getName();
     if (!entrypoint) {
       throw new Error(
-        `${relativePath} contains a default export function ` +
-          "whose name cannot be parsed."
+        `${relativePath} contains a default export assignment that is improperly ` +
+          "formatted. It may have an anonymous function as the default export " +
+          "which is not supported."
       );
     }
     return [relativePath, { entrypoint }];

--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -67,17 +67,17 @@ async function generateFunctionMetadata(
     ?.getDeclarations()[0];
   const relativePath = path.relative(process.cwd(), filepath);
   if (Node.isExportAssignment(defaultExportDeclaration)) {
-    const exportIdenfitier = defaultExportDeclaration.getChildrenOfKind(
-      SyntaxKind.Identifier
-    )[0];
-    if (!exportIdenfitier) {
+    const entrypoint = defaultExportDeclaration
+      .getChildrenOfKind(SyntaxKind.Identifier)[0]
+      ?.getText();
+    if (!entrypoint) {
       throw new Error(
         `${relativePath} contains an improper default export assignment. ` +
           "The default export must be a function, and it must be formatted " +
           "as `export default foo;` for function `foo`."
       );
     }
-    return [relativePath, { entrypoint: exportIdenfitier.getText() }];
+    return [relativePath, { entrypoint }];
   } else if (Node.isFunctionDeclaration(defaultExportDeclaration)) {
     const entrypoint = defaultExportDeclaration.getName();
     if (!entrypoint) {


### PR DESCRIPTION
Fixes https://github.com/yext/pages/issues/409.

This PR addresses the "Cannot find module" errors that were found when using imports from `deno.land` modules.  In the past, we were using ESBuild to build user files in a temp dir, then using the built file to get the default import name.  However, ESBuild was not able to resolve these `deno.land` imports and would throw errors. In order to resolve `http`/`https` imports, we would need a plugin for ESBuild (see "[Why this is not Recommended](https://esbuild.github.io/getting-started/#deno)").  I looked for an npm package that would provide ESBuild with a plugin to resolve these imports, however none of them seemed well established/stable enough to use.

Here are two I considered:
- [esbuild-plugin-cache](https://www.npmjs.com/package/esbuild-plugin-cache)
- [esbuild-plugin-http-imports](https://github.com/lucsoft/esbuild-plugin-http-imports)

To get around this issue, we now use `ts-morph` to parse through its AST instead since all we need is the name of the default export.  Specifically, we now can get the default export in the following formats.

```
export default function foo() {
  // do something
}
```
```
export default foo;
```

**Note that the `ts-morph` way takes longer than the previous ESBuild way (500ms instead of 30ms for 5 function files).** 

J=SUMO-5418
TEST=manual

Tested that the above formats were properly parsed and their metadatas properly populated in `functionMetadata.json`.  Also tested that on `yext pages serve`, that `http` functions could still be called as expected.