### PR TITLE
fix(dev/plugin): clearer error for non-string getPath value

### DIFF
--- a/packages/pages/src/common/src/template/internal/validateGetPathValue.ts
+++ b/packages/pages/src/common/src/template/internal/validateGetPathValue.ts
@@ -1,0 +1,10 @@
+export const validateGetPathValue = (
+  value: unknown,
+  templateIdentifier: string
+) => {
+  if (!value || typeof value !== "string") {
+    throw new Error(
+      `getPath does not return a valid string in template '${templateIdentifier}'`
+    );
+  }
+};

--- a/packages/pages/src/dev/server/ssr/getLocalData.ts
+++ b/packages/pages/src/dev/server/ssr/getLocalData.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import { readdir } from "fs/promises";
 import { findTemplateModuleInternal } from "./findTemplateModuleInternal.js";
 import { ViteDevServer } from "vite";
+import { validateGetPathValue } from "../../../common/src/template/internal/validateGetPathValue.js";
 
 const LOCAL_DATA_PATH = "localData";
 
@@ -100,9 +101,16 @@ export const getLocalDataManifest = async (
           .get(featureName)
           ?.locales.push(data.meta.locale);
       } else {
+        const staticURL = templateModuleInternal.getPath({ document: data });
+        try {
+          validateGetPathValue(staticURL, templateModuleInternal.path);
+        } catch (e) {
+          console.error(`${(e as Error).message}, skipping"`);
+          continue;
+        }
         localDataManifest.static.set(featureName, {
           featureName,
-          staticURL: templateModuleInternal.getPath({ document: data }),
+          staticURL,
           locales: [data.meta.locale],
         });
       }

--- a/packages/pages/src/dev/server/ssr/propsLoader.ts
+++ b/packages/pages/src/dev/server/ssr/propsLoader.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../common/src/template/types.js";
 import { getRelativePrefixToRootFromPath } from "../../../common/src/template/paths.js";
 import { TemplateModuleInternal } from "../../../common/src/template/internal/types.js";
+import { validateGetPathValue } from "../../../common/src/template/internal/validateGetPathValue.js";
 
 type PageLoaderValues = {
   templateModuleInternal: TemplateModuleInternal<any, any>;
@@ -37,11 +38,7 @@ export const propsLoader = async ({
   }
 
   const path = getPath(templateProps);
-  if (!path) {
-    throw new Error(
-      `getPath does not return a valid string in template '${templateModuleInternal.path}'`
-    );
-  }
+  validateGetPathValue(path, templateModuleInternal.path);
 
   return {
     ...templateProps,

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
@@ -12,6 +12,7 @@ import {
   TemplateModuleInternal,
 } from "../../../../common/src/template/internal/types.js";
 import { ProjectStructure } from "../../../../common/src/project/structure.js";
+import { validateGetPathValue } from "../../../../common/src/template/internal/validateGetPathValue.js";
 
 const pathToModule = new Map<string, TemplateModule<any, any>>();
 
@@ -118,11 +119,7 @@ export const generateResponses = async (
   }
 
   const path = templateModuleInternal.getPath(templateProps);
-  if (!path) {
-    throw new Error(
-      `getPath does not return a valid string in template '${templateModuleInternal.templateName}'`
-    );
-  }
+  validateGetPathValue(path, templateModuleInternal.templateName);
 
   const templateRenderProps: TemplateRenderProps = {
     ...templateProps,


### PR DESCRIPTION
Fixes #423.

Now, we explicitly check for and throw an error with a more clear message if the `getPath` value is not a string.

J=SUMO-5458
TEST=manual

In a test site in dev mode, see that the index page does not include any pages with a non-string `getPath` value and console error is logged instead. In `--no-prod-url` mode, see that visiting an entity page with a non-string `getPath` value throws an error with the more specific message instead of `path2.split is not a function`. Running `yext pages build && yext pages render` locally, as well as page generation in the platform, will throw the clearer error for a non-string `getPath` rather than `n.split is not a function`.