### PR TITLE
chore(dev): use logWarning for index page messages

### DIFF
--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -23,6 +23,7 @@ import { parseYextrcContents } from "../../../util/yextrcContents.js";
 import { getPartition } from "../../../util/partition.js";
 import { getYextUrlForPartition } from "../../../util/url.js";
 import path from "node:path";
+import { logWarning } from "../../../util/logError.js";
 
 type Props = {
   vite: ViteDevServer;
@@ -261,7 +262,7 @@ const createEntityPageListItems = (
   const entities = localDataManifest.entity.get(templateName) || [];
   return entities.reduce((entityAccumulator, { uid, entityId, slug }) => {
     if (useProdURLs && !slug) {
-      console.error(
+      logWarning(
         `No document.slug found for entityId "${entityId}", no link will be rendered in the index page.`
       );
       return entityAccumulator;

--- a/packages/pages/src/dev/server/ssr/findMatchingStaticTemplate.ts
+++ b/packages/pages/src/dev/server/ssr/findMatchingStaticTemplate.ts
@@ -12,14 +12,14 @@ export default async function findMatchingStaticTemplate(
   return findTemplateModuleInternal(
     vite,
     async (t) => {
+      if (!isStaticTemplateConfig(t.config)) {
+        return false;
+      }
       const document = await getLocalDataForEntityOrStaticPage({
         entityId: "",
         locale,
         featureName: t.config.name,
       });
-      if (!isStaticTemplateConfig(t.config)) {
-        return false;
-      }
       return slug === t.getPath({ document });
     },
     templateFilepaths

--- a/packages/pages/src/dev/server/ssr/getLocalData.ts
+++ b/packages/pages/src/dev/server/ssr/getLocalData.ts
@@ -4,6 +4,7 @@ import { readdir } from "fs/promises";
 import { findTemplateModuleInternal } from "./findTemplateModuleInternal.js";
 import { ViteDevServer } from "vite";
 import { validateGetPathValue } from "../../../common/src/template/internal/validateGetPathValue.js";
+import { logWarning } from "../../../util/logError.js";
 
 const LOCAL_DATA_PATH = "localData";
 
@@ -91,7 +92,7 @@ export const getLocalDataManifest = async (
         templateFilepaths
       );
       if (!templateModuleInternal) {
-        console.error(
+        logWarning(
           `Could not find a static template for feature "${featureName}", skipping.`
         );
         continue;
@@ -105,7 +106,7 @@ export const getLocalDataManifest = async (
         try {
           validateGetPathValue(staticURL, templateModuleInternal.path);
         } catch (e) {
-          console.error(`${(e as Error).message}, skipping"`);
+          logWarning(`${(e as Error).message}, skipping."`);
           continue;
         }
         localDataManifest.static.set(featureName, {


### PR DESCRIPTION
Use `logWarning` instead of `console.error` to make messages more visible when pages are not included on the index page. Also, reordered actions in `findMatchingStaticTemplate` to make it a little more performant.