### PR TITLE
fix: fix watch command

### DIFF
--- a/packages/pages/src/bundler.js
+++ b/packages/pages/src/bundler.js
@@ -39,7 +39,7 @@ const commonBuildOpts = {
     ".ico": "copy",
   },
   tsconfig: "tsconfig.json",
-  logLevel: "error",
+  logLevel: "info",
   platform: "node",
 };
 
@@ -58,7 +58,7 @@ pluginFiles.map((filepath) =>
 );
 
 try {
-  const ctx = await esbuild.build({
+  const ctx = await esbuild.context({
     ...commonBuildOpts,
     outdir: "dist",
     format: "esm",
@@ -66,6 +66,9 @@ try {
 
   if (watch) {
     await ctx.watch();
+  } else {
+    await ctx.rebuild();
+    await ctx.dispose();
   }
 } catch (e) {
   console.error(e);


### PR DESCRIPTION
Fix the `watch` command in `packages/pages/package.json` so `npm run build` doesn't need to be manually run each time a change is made to see the effects in a linked test site. Previously, this command would throw an error.

J=SUMO-5462
TEST=manual

Check that `npm run build` still works as expected. Run `npm run watch` and see that changes are automatically picked up and trigger a rebuild.