### PR TITLE
feat(dev/plugin): support secrets

### DIFF
--- a/packages/pages/THIRD-PARTY-NOTICES
+++ b/packages/pages/THIRD-PARTY-NOTICES
@@ -149,38 +149,6 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - dotenv@16.3.1
-
-This package contains the following license and notice below:
-
-Copyright (c) 2015, Scott Motte
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------------
-
-The following npm package may be included in this product:
-
  - escape-html@1.0.3
 
 This package contains the following license and notice below:

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -61,7 +61,6 @@
     "cli-spinners": "^2.9.0",
     "commander": "^11.0.0",
     "cross-fetch": "^4.0.0",
-    "dotenv": "^16.3.1",
     "escape-html": "^1.0.3",
     "esm-module-paths": "^1.1.1",
     "express": "^4.18.2",
@@ -117,8 +116,5 @@
   },
   "overrides": {
     "webpack": "^5.52.0"
-  },
-  "setupFiles": [
-    "dotenv/config"
-  ]
+  }
 }

--- a/packages/pages/src/common/src/loader/esbuild.ts
+++ b/packages/pages/src/common/src/loader/esbuild.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "url";
 import path from "node:path";
 import { processEnvVariables } from "../../../util/processEnvVariables.js";
 import { anyFileLoader } from "./anyFileLoader.js";
+import { ProjectStructure } from "../project/structure.js";
 
 export const COMMON_ESBUILD_LOADERS: { [ext: string]: Loader } = {
   ".css": "css",
@@ -50,7 +51,8 @@ export type ImportedModule = {
  */
 export const loadModules = async (
   modulePaths: string[],
-  transpile: boolean
+  transpile: boolean,
+  projectStructure: ProjectStructure
 ): Promise<ImportedModule[]> => {
   const importedModules: ImportedModule[] = [];
   for (const modulePath of modulePaths) {
@@ -63,7 +65,9 @@ export const loadModules = async (
           format: "esm",
           bundle: true,
           loader: COMMON_ESBUILD_LOADERS,
-          define: processEnvVariables("YEXT_PUBLIC"),
+          define: processEnvVariables(
+            projectStructure.config.envVarConfig.envVarPrefix
+          ),
           plugins: [anyFileLoader()],
         });
 

--- a/packages/pages/src/common/src/parsers/sourceFileParser.ts
+++ b/packages/pages/src/common/src/parsers/sourceFileParser.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import {
   Project,
   SourceFile,

--- a/packages/pages/src/util/processEnvVariables.test.ts
+++ b/packages/pages/src/util/processEnvVariables.test.ts
@@ -4,30 +4,34 @@ import { processEnvVariables } from "./processEnvVariables.js";
 describe("processEnvVariables", () => {
   beforeAll(() => {
     global.process.env = {
-      NODE_ENV: "development",
+      NODE_ENV: "production",
       VITE_KEY: "pk.abcdefghij",
       YEXT_PUBLIC_KEY: "pk.0123456789",
+      SECRET: "secret",
     };
   });
 
-  it("filters .env for Vite specific variables", () => {
+  it("filters .env for Vite specific variables for production", () => {
     const env = processEnvVariables();
-
     expect(Object.keys(env).length).toEqual(1);
     expect(env.VITE_KEY).toEqual(`"pk.abcdefghij"`);
   });
 
-  it("filters .env for Vite specific variables with custom prefix", () => {
+  it("filters .env for Vite specific variables with custom prefix for production", () => {
     const env = processEnvVariables("YEXT_PUBLIC");
 
     expect(Object.keys(env).length).toEqual(1);
     expect(env.YEXT_PUBLIC_KEY).toEqual(`"pk.0123456789"`);
   });
 
-  it("does not stringify values", () => {
-    const env = processEnvVariables("YEXT_PUBLIC", false);
+  it("returns all env vars for development", () => {
+    global.process.env.NODE_ENV = "development";
+    const env = processEnvVariables("YEXT_PUBLIC");
 
-    expect(Object.keys(env).length).toEqual(1);
-    expect(env.YEXT_PUBLIC_KEY).toEqual("pk.0123456789");
+    expect(Object.keys(env).length).toEqual(4);
+    expect(env.VITE_KEY).toEqual(`"pk.abcdefghij"`);
+    expect(env.YEXT_PUBLIC_KEY).toEqual(`"pk.0123456789"`);
+    expect(env.SECRET).toEqual(`"secret"`);
+    expect(env.NODE_ENV).toEqual(`"development"`);
   });
 });

--- a/packages/pages/src/util/processEnvVariables.ts
+++ b/packages/pages/src/util/processEnvVariables.ts
@@ -8,20 +8,21 @@ import { loadEnv } from "vite";
  * @param prefix string specifying the beginning of the keys to match
  */
 export const processEnvVariables = (
-  prefix = "VITE",
-  // needed for templates and functions, but sourceFileParser double stringifies
-  stringifyValues = true
+  prefix = "VITE"
 ): Record<string, string> => {
   const mode = process.env.NODE_ENV || "development";
-  let processEnv = loadEnv(mode, process.cwd(), "");
-  processEnv = Object.fromEntries(
-    Object.entries(processEnv)
-      .filter(([env]) => env.startsWith(prefix))
-      .map(([key, value]) => [
-        key,
-        stringifyValues ? JSON.stringify(value) : value,
-      ])
-  );
 
-  return processEnv;
+  // If we're development, return all env var keys, otherwise use Vite's default
+  // way of loading env vars in prod.
+  // For prod, only public env vars are loaded since they are statically replaced in code.
+  // Cog makes the non-public env vars available as global vars in the Deno
+  // runtime context.
+  prefix = mode === "development" ? "" : prefix;
+
+  return Object.fromEntries(
+    Object.entries(loadEnv(mode, process.cwd(), prefix)).map(([key, value]) => [
+      key,
+      JSON.stringify(value),
+    ])
+  );
 };

--- a/packages/pages/src/util/processEnvVariables.ts
+++ b/packages/pages/src/util/processEnvVariables.ts
@@ -12,7 +12,7 @@ export const processEnvVariables = (
 ): Record<string, string> => {
   const mode = process.env.NODE_ENV || "development";
 
-  // If we're development, return all env var keys, otherwise use Vite's default
+  // If we're development return all env var keys, otherwise use Vite's default
   // way of loading env vars in prod.
   // For prod, only public env vars are loaded since they are statically replaced in code.
   // Cog makes the non-public env vars available as global vars in the Deno

--- a/packages/pages/src/util/processEnvVariables.ts
+++ b/packages/pages/src/util/processEnvVariables.ts
@@ -20,9 +20,11 @@ export const processEnvVariables = (
   prefix = mode === "development" ? "" : prefix;
 
   return Object.fromEntries(
-    Object.entries(loadEnv(mode, process.cwd(), prefix)).map(([key, value]) => [
-      key,
-      JSON.stringify(value),
-    ])
+    Object.entries(loadEnv(mode, process.cwd(), prefix))
+      // For some reason this env var is automatically set and causes issues so
+      // we filter it out specifically.
+      .filter(([env]) => env !== "_")
+      // The value must be stringified: https://vitejs.dev/config/shared-options.html#define
+      .map(([key, value]) => [key, JSON.stringify(value)])
   );
 };

--- a/packages/pages/src/vite-plugin/build/closeBundle/serverlessFunctions.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/serverlessFunctions.ts
@@ -46,7 +46,7 @@ const bundleServerlessFunction = async (
   projectStructure: ProjectStructure
 ): Promise<void> => {
   const fmp = new FunctionMetadataParser(filepath, projectStructure);
-  const { rootFolders, subfolders } = projectStructure.config;
+  const { rootFolders, subfolders, envVarConfig } = projectStructure.config;
   const outdir = path.join(rootFolders.dist, subfolders.serverlessFunctions);
   const { name } = fmp.functionMetadata;
 
@@ -59,7 +59,7 @@ const bundleServerlessFunction = async (
     format: "esm",
     bundle: true,
     loader: COMMON_ESBUILD_LOADERS,
-    define: processEnvVariables("YEXT_PUBLIC"),
+    define: processEnvVariables(envVarConfig.envVarPrefix),
   });
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       cross-fetch:
         specifier: ^4.0.0
         version: 4.0.0
-      dotenv:
-        specifier: ^16.3.1
-        version: 16.3.1
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
@@ -2992,11 +2989,6 @@ packages:
   /domain-browser@4.22.0:
     resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
     engines: {node: '>=10'}
-    dev: false
-
-  /dotenv@16.3.1:
-    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
-    engines: {node: '>=12'}
     dev: false
 
   /eastasianwidth@0.2.0:


### PR DESCRIPTION
This adds support for truly secret environment variables. Before this change we only supported _public_ environment variables that were prefixed with `YEXT_PUBLIC`.