### PR TITLE
feat(dev): replace fetch imports in upgrade command

### DIFF
--- a/packages/pages/src/upgrade/pagesUpdater.ts
+++ b/packages/pages/src/upgrade/pagesUpdater.ts
@@ -6,6 +6,7 @@ import { execSync } from "child_process";
 import { readJsonSync } from "./migrateConfig.js";
 
 const pagesImportRegex = /"@yext\/pages\/components"/g;
+const fetchImportRegex = /\nimport { fetch } from "@yext\/pages\/util";/g;
 const replacementText = '"@yext/sites-components"';
 const markdownRegex = 'Markdown.{1,10}from "@yext\\/react-components';
 
@@ -56,10 +57,9 @@ const processDirectoryRecursively = (currentPath: string) => {
 const replaceImports = (filePath: string) => {
   try {
     const fileContent = fs.readFileSync(filePath, "utf8");
-    const modifiedContent = fileContent.replace(
-      pagesImportRegex,
-      replacementText
-    );
+    const modifiedContent = fileContent
+      .replace(pagesImportRegex, replacementText)
+      .replace(fetchImportRegex, "");
     if (fileContent.match(markdownRegex)) {
       console.log(
         `Legacy Markdown import from react-components detected in ${filePath}.` +


### PR DESCRIPTION
Successfully replaces imports in pages-starter-react-locations.

Note that this will not cover imports such as
import {tacos, fetch} from "@yext/pages/util"

It only replaces \nimport { fetch } from "@yext/pages/util"; which fixes the starter.