### PR TITLE
refactor: remove duplicate makeClientFiles

### DIFF
--- a/packages/pages/src/build/build.ts
+++ b/packages/pages/src/build/build.ts
@@ -1,17 +1,11 @@
 import { Command } from "commander";
 import { build } from "vite";
-import { ProjectStructure } from "../common/src/project/structure.js";
-import { makeClientFiles } from "../common/src/template/client.js";
 
 const handler = async ({ scope }: { scope: string }) => {
   // Pass CLI arguments as env variables to use in vite-plugin
   if (scope) {
     process.env.YEXT_PAGES_SCOPE = scope;
   }
-  const projectStructure = await ProjectStructure.init({
-    scope: scope,
-  });
-  await makeClientFiles(projectStructure);
   await build();
 };
 


### PR DESCRIPTION
makeClientFiles was unnecessarily being called in build.ts

TEST=manual, auto 

Confirmed client dist files generate as expected and `npm run prod` works. 