### PR TITLE
feat: add node engines to upgrade script

### DIFF
--- a/packages/pages/src/upgrade/pagesUpdater.ts
+++ b/packages/pages/src/upgrade/pagesUpdater.ts
@@ -119,16 +119,18 @@ const installDependencies = async (
 };
 
 // Function to update package.json engines
+const NODE_ENGINES = "^18.0.0 || >=20.0.0";
 const updatePackageEngines = (targetDirectory: string) => {
   const packageJsonPath = path.resolve(targetDirectory, "package.json");
 
   try {
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
     let engines = packageJson.engines;
-    if (!engines) {
-      engines = { node: "" };
+    if (engines) {
+      engines.node = NODE_ENGINES;
+    } else {
+      engines = { node: NODE_ENGINES };
     }
-    engines.node = "^18.0.0 || >=20.0.0";
     packageJson.engines = engines;
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
     console.log("package.json engines updated.");

--- a/packages/pages/src/upgrade/pagesUpdater.ts
+++ b/packages/pages/src/upgrade/pagesUpdater.ts
@@ -118,6 +118,25 @@ const installDependencies = async (
   }
 };
 
+// Function to update package.json engines
+const updatePackageEngines = (targetDirectory: string) => {
+  const packageJsonPath = path.resolve(targetDirectory, "package.json");
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    let engines = packageJson.engines;
+    if (!engines) {
+      engines = { node: "" };
+    }
+    engines.node = "^18.0.0 || >=20.0.0";
+    packageJson.engines = engines;
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+    console.log("package.json engines updated.");
+  } catch (e) {
+    console.error("Error updating package.json: ", (e as Error).message);
+  }
+};
+
 /**
  * Install packages, recursively process imports (excluding .git and node_modules directories),
  * and update package.json scripts in the specified directory
@@ -130,6 +149,7 @@ export const updatePages = async (projectStructure: ProjectStructure) => {
     path.resolve(projectStructure.config.rootFolders.source)
   );
   updatePackageScripts(rootPath);
+  updatePackageEngines(rootPath);
   await installDependencies(
     rootPath,
     path.resolve(


### PR DESCRIPTION
Adds supported engines to package.json

```
"engines": {
    "node": "^18.0.0 || >=20.0.0"
  },
```