### PR TITLE
fix(plugin): manifest not created correctly

### DIFF
--- a/packages/pages/src/vite-plugin/build/closeBundle/manifest.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/manifest.ts
@@ -48,9 +48,9 @@ export const generateManifestFile = async (
   };
 
   let bundlerManifest = Buffer.from("{}");
-  if (fs.existsSync(path.join(distPath.path, "manifest.json"))) {
+  if (fs.existsSync(path.join(distPath.path, ".vite", "manifest.json"))) {
     bundlerManifest = fs.readFileSync(
-      path.join(distPath.path, "manifest.json")
+      path.join(distPath.path, ".vite", "manifest.json")
     );
   }
   const manifest: Manifest = {


### PR DESCRIPTION
With the upgrade to Vite 5 they [moved](https://vitejs.dev/guide/migration#manifest-files-are-now-generated-in-vite-directory-by-default) where the manifest file lives during build. Before this fix a prod build was missing all CSS.