### PR TITLE
feat(dev): upgrade script replaces build:local with build

### DIFF
--- a/packages/pages/src/upgrade/migrateConfig.ts
+++ b/packages/pages/src/upgrade/migrateConfig.ts
@@ -45,7 +45,7 @@ const migrateCiJson = async (configYamlPath: string, ciPath: string) => {
         `migrating buildArtifacts from ${ciPath} to ${configYamlPath}`
       );
       const buildConfiguration: BuildConfiguration = {
-        buildCommand: buildArtifacts.buildCmd,
+        buildCommand: buildArtifacts.buildCmd?.replace("build:local", "build"),
       };
       const dependencies = ciJson.dependencies;
       if (dependencies) {

--- a/packages/pages/src/upgrade/pagesUpdater.ts
+++ b/packages/pages/src/upgrade/pagesUpdater.ts
@@ -82,7 +82,7 @@ const updatePackageScripts = (targetDirectory: string) => {
     const scripts = packageJson.scripts;
     scripts.dev = "pages dev";
     scripts.prod = "pages prod";
-    scripts["build:local"] = "pages build";
+    scripts["build"] = "pages build";
     packageJson.scripts = scripts;
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
     console.log("package.json scripts updated.");


### PR DESCRIPTION
Tested manually on starter.
Config.yaml ends up with npm run build as the build command.

package.json has build instead of "build:local": "pages build"

npm run prod and npm run dev work as expected.