### PR TITLE
fix(plugin): allow "main" function exports and actually fail the build

### DIFF
--- a/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/functionMetadata.ts
@@ -92,7 +92,7 @@ async function generateFunctionMetadata(
       throw (
         `${relativePath} contains an unsupported default function declaration. ` +
         "The default export function must be a named function, exported as " +
-        "`export default function foo(){}` for function `foo`"
+        "`export default function foo(){}` for function `foo`."
       );
     }
     return [relativePath, { entrypoint }];


### PR DESCRIPTION
The platform allows "main" exports and reads them specifically from the /functions folder (meaning that they shouldn't be defined in functionMetadata.json...only default exports go in there). Since platform allows it, we should too.

Additionally, function errors will now properly fail the build instead of continuing on.