### PR TITLE
fix(plugin): make min Node 20 version 20.2.0

### DIFF
--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -32,7 +32,7 @@
     }
   },
   "engines": {
-    "node": "^18 || ^20"
+    "node": "^18 || ^20.2.0"
   },
   "scripts": {
     "watch": "node src/bundler --watch",

--- a/packages/pages/src/upgrade/pagesUpdater.ts
+++ b/packages/pages/src/upgrade/pagesUpdater.ts
@@ -362,7 +362,8 @@ export const installDependencies = async () => {
   }
 };
 
-const NODE_ENGINES = "^18.0.0 || >=20.0.0";
+// Note that Node 20 <20.2.0 leads to build errors: `Unexpected early exit.`
+const NODE_ENGINES = "^18.0.0 || >=20.2.0";
 /**
  * Update package engines to latest supported node versions.
  */


### PR DESCRIPTION
Versions of Node 20 before 20.2.0 led to build errors `Unexpected early exit.`