### PR TITLE
fix(dev): locale query params not part of request

### DIFF
--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -53,7 +53,7 @@ export const serverRenderRoute =
           vite,
           matchingStaticTemplate,
           locale,
-          url.pathname,
+          req.originalUrl,
           projectStructure
         );
         return;
@@ -96,7 +96,7 @@ export const serverRenderRoute =
         templateModuleInternal,
         props,
         vite,
-        url.pathname,
+        req.originalUrl,
         projectStructure
       );
     } catch (e: any) {

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -43,7 +43,7 @@ export const serverRenderSlugRoute =
           vite,
           matchingStaticTemplate,
           locale,
-          url.pathname,
+          req.originalUrl,
           projectStructure
         );
         return;
@@ -87,7 +87,7 @@ export const serverRenderSlugRoute =
         templateModuleInternal,
         props,
         vite,
-        `/${slug}`,
+        req.originalUrl,
         projectStructure
       );
     } catch (e: any) {


### PR DESCRIPTION
The locale was not sent through to transformIndexHtml, making the original request remain cached by the dev server. If you used a locale query param in one request and then removed it (or vice versa) you would never see the updated data.