### PR TITLE
chore(dev): deprecate alternateLanguageFields

### DIFF
--- a/packages/pages/docs/api/pages.templateconfig.alternatelanguagefields.md
+++ b/packages/pages/docs/api/pages.templateconfig.alternatelanguagefields.md
@@ -4,7 +4,11 @@
 
 ## TemplateConfig.alternateLanguageFields property
 
-The specific fields to add additional language options to based on the stream's localization
+> Warning: This API is now obsolete.
+>
+> field will be unsupported in the future
+
+The specific fields to add additional language options to based on the stream's localization.
 
 **Signature:**
 

--- a/packages/pages/docs/api/pages.templateconfig.md
+++ b/packages/pages/docs/api/pages.templateconfig.md
@@ -16,7 +16,7 @@ export interface TemplateConfig
 
 | Property                                                                      | Modifiers | Type                        | Description                                                                                                  |
 | ----------------------------------------------------------------------------- | --------- | --------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| [alternateLanguageFields?](./pages.templateconfig.alternatelanguagefields.md) |           | string\[\]                  | _(Optional)_ The specific fields to add additional language options to based on the stream's localization    |
+| [alternateLanguageFields?](./pages.templateconfig.alternatelanguagefields.md) |           | string\[\]                  | _(Optional)_ The specific fields to add additional language options to based on the stream's localization.   |
 | [hydrate?](./pages.templateconfig.hydrate.md)                                 |           | boolean                     | _(Optional)_ Determines if hydration is allowed or not for webpages                                          |
 | [name?](./pages.templateconfig.name.md)                                       |           | string                      | _(Optional)_ The name of the template feature. If not defined uses the template filename (without extension) |
 | [onUrlChange?](./pages.templateconfig.onurlchange.md)                         |           | string                      | _(Optional)_ The name of the onUrlChange function to use.                                                    |

--- a/packages/pages/etc/pages.api.md
+++ b/packages/pages/etc/pages.api.md
@@ -235,6 +235,7 @@ export type Template<T extends TemplateRenderProps> = (
 
 // @public
 export interface TemplateConfig {
+  // @deprecated
   alternateLanguageFields?: string[];
   hydrate?: boolean;
   name?: string;
@@ -279,7 +280,7 @@ export type TransformProps<T extends TemplateProps> = (props: T) => Promise<T>;
 
 // Warnings were encountered during analysis:
 //
-// dist/types/src/common/src/template/types.d.ts:165:5 - (ae-forgotten-export) The symbol "ProjectStructureConfig" needs to be exported by the entry point index.d.ts
+// dist/types/src/common/src/template/types.d.ts:168:5 - (ae-forgotten-export) The symbol "ProjectStructureConfig" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -84,8 +84,8 @@
     "yaml": "^2.3.4"
   },
   "devDependencies": {
-    "@microsoft/api-documenter": "^7.23.14",
-    "@microsoft/api-extractor": "^7.38.5",
+    "@microsoft/api-documenter": "^7.23.17",
+    "@microsoft/api-extractor": "^7.39.1",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",
     "@types/escape-html": "^1.0.4",

--- a/packages/pages/src/common/src/feature/features.ts
+++ b/packages/pages/src/common/src/feature/features.ts
@@ -30,6 +30,7 @@ interface FeatureConfigBase {
   name: string;
   streamId?: string;
   templateType: "JS";
+  /** @deprecated field will be unsupported in the future */
   alternateLanguageFields?: string[];
   onUrlChange?: PluginFunctionSelector;
 }

--- a/packages/pages/src/common/src/template/internal/types.ts
+++ b/packages/pages/src/common/src/template/internal/types.ts
@@ -59,7 +59,10 @@ export interface TemplateConfigInternal {
   streamId?: string;
   /** The stream configuration used by the template */
   stream?: StreamInternal;
-  /** The specific fields to add additional language options to based on the stream's localization */
+  /**
+   * The specific fields to add additional language options to based on the stream's localization.
+   * @deprecated field will be unsupported in the future
+   */
   alternateLanguageFields?: string[];
   /** The name of the onUrlChange function to use. */
   onUrlChange?: string;

--- a/packages/pages/src/common/src/template/types.ts
+++ b/packages/pages/src/common/src/template/types.ts
@@ -97,7 +97,10 @@ export interface TemplateConfig {
   streamId?: string;
   /** The stream configuration used by the template */
   stream?: Stream;
-  /** The specific fields to add additional language options to based on the stream's localization */
+  /**
+   * The specific fields to add additional language options to based on the stream's localization.
+   * @deprecated field will be unsupported in the future
+   */
   alternateLanguageFields?: string[];
   /** The name of the onUrlChange function to use. */
   onUrlChange?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,11 +184,11 @@ importers:
         version: 2.3.4
     devDependencies:
       '@microsoft/api-documenter':
-        specifier: ^7.23.14
-        version: 7.23.14(@types/node@20.10.4)
+        specifier: ^7.23.17
+        version: 7.23.17(@types/node@20.10.4)
       '@microsoft/api-extractor':
-        specifier: ^7.38.5
-        version: 7.38.5(@types/node@20.10.4)
+        specifier: ^7.39.1
+        version: 7.39.1(@types/node@20.10.4)
       '@testing-library/react':
         specifier: ^14.1.2
         version: 14.1.2(react-dom@18.2.0)(react@18.2.0)
@@ -1097,13 +1097,13 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
-  /@microsoft/api-documenter@7.23.14(@types/node@20.10.4):
-    resolution: {integrity: sha512-D9cX3sS/6xN8SFbrR6I1ZTKvGl5UIPFZKYqTLg8YBUKJtFbUSDLrzRLWOcjxwxjnu+gCHAHyaNpG4G//CQivLw==}
+  /@microsoft/api-documenter@7.23.17(@types/node@20.10.4):
+    resolution: {integrity: sha512-9AaEo0LaVdx5qljF4wX1kjZmWRcFDM9OAdW5HXEdapuIyCq8/uAJ4W9q5ee0ntJuJ+Z0g8ynfA3/WEyAuQt/Rw==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.3(@types/node@20.10.4)
+      '@microsoft/api-extractor-model': 7.28.4(@types/node@20.10.4)
       '@microsoft/tsdoc': 0.14.2
-      '@rushstack/node-core-library': 3.62.0(@types/node@20.10.4)
+      '@rushstack/node-core-library': 3.63.0(@types/node@20.10.4)
       '@rushstack/ts-command-line': 4.17.1
       colors: 1.2.5
       js-yaml: 3.13.1
@@ -1112,24 +1112,24 @@ packages:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor-model@7.28.3(@types/node@20.10.4):
-    resolution: {integrity: sha512-wT/kB2oDbdZXITyDh2SQLzaWwTOFbV326fP0pUwNW00WeliARs0qjmXBWmGWardEzp2U3/axkO3Lboqun6vrig==}
+  /@microsoft/api-extractor-model@7.28.4(@types/node@20.10.4):
+    resolution: {integrity: sha512-vucgyPmgHrJ/D4/xQywAmjTmSfxAx2/aDmD6TkIoLu51FdsAfuWRbijWA48AePy60OO+l+mmy9p2P/CEeBZqig==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.1
-      '@rushstack/node-core-library': 3.62.0(@types/node@20.10.4)
+      '@rushstack/node-core-library': 3.63.0(@types/node@20.10.4)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.38.5(@types/node@20.10.4):
-    resolution: {integrity: sha512-c/w2zfqBcBJxaCzpJNvFoouWewcYrUOfeu5ZkWCCIXTF9a/gXM85RGevEzlMAIEGM/kssAAZSXRJIZ3Q5vLFow==}
+  /@microsoft/api-extractor@7.39.1(@types/node@20.10.4):
+    resolution: {integrity: sha512-V0HtCufWa8hZZvSmlEzQZfINcJkHAU/bmpyJQj6w+zpI87EkR8DuBOW6RWrO9c7mUYFZoDaNgUTyKo83ytv+QQ==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.3(@types/node@20.10.4)
+      '@microsoft/api-extractor-model': 7.28.4(@types/node@20.10.4)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.1
-      '@rushstack/node-core-library': 3.62.0(@types/node@20.10.4)
+      '@rushstack/node-core-library': 3.63.0(@types/node@20.10.4)
       '@rushstack/rig-package': 0.5.1
       '@rushstack/ts-command-line': 4.17.1
       colors: 1.2.5
@@ -1137,7 +1137,7 @@ packages:
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.0.4
+      typescript: 5.3.3
     transitivePeerDependencies:
       - '@types/node'
     dev: true
@@ -1496,8 +1496,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rushstack/node-core-library@3.62.0(@types/node@20.10.4):
-    resolution: {integrity: sha512-88aJn2h8UpSvdwuDXBv1/v1heM6GnBf3RjEy6ZPP7UnzHNCqOHA2Ut+ScYUbXcqIdfew9JlTAe3g+cnX9xQ/Aw==}
+  /@rushstack/node-core-library@3.63.0(@types/node@20.10.4):
+    resolution: {integrity: sha512-Q7B3dVpBQF1v+mUfxNcNZh5uHVR8ntcnkN5GYjbBLrxUYHBGKbnCM+OdcN+hzCpFlLBH6Ob0dEHhZ0spQwf24A==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -7454,12 +7454,6 @@ packages:
       call-bind: 1.0.2
       for-each: 0.3.3
       is-typed-array: 1.1.10
-    dev: true
-
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
-    hasBin: true
     dev: true
 
   /typescript@5.1.6:


### PR DESCRIPTION
`alternateLanguageFields` causes page generations to take much longer, so it was deemed as unsupported for new accounts (generations will outright fail). Some accounts are still grandfathered in, but there are alternate solutions that can be used. 