### PR TITLE
fix(upgrade): siteStream conversion now sets specific fields

### DIFF
--- a/packages/pages/src/upgrade/migrateConfig.test.ts
+++ b/packages/pages/src/upgrade/migrateConfig.test.ts
@@ -19,15 +19,26 @@ describe("formatSiteStream", () => {
     expect(formatSiteStream(testJson, siteStreamPath)).toEqual(expectedJson);
   });
 
-  it("returns expected reverseProxyPrefix", () => {
-    const testJson = { reverseProxy: { displayUrlPrefix: "foo" } };
-    const expectedJson = { serving: { reverseProxyPrefix: "foo" } };
-    expect(formatSiteStream(testJson, siteStreamPath)).toEqual(expectedJson);
-  });
-
   it("returns expected id with id first", () => {
     const testJson = { fields: ["meta", "name"], $id: "123" };
     const expectedJson = { id: "123", fields: ["meta", "name"] };
+    expect(formatSiteStream(testJson, siteStreamPath)).toEqual(expectedJson);
+  });
+
+  it("returns expected full config", () => {
+    const testJson = {
+      $id: "123",
+      fields: ["meta", "name"],
+      filter: { entityIds: ["1234"] },
+      source: "foo",
+      localization: ["en"],
+    };
+    const expectedJson = {
+      id: "123",
+      entityId: "1234",
+      fields: ["meta", "name"],
+      localization: ["en"],
+    };
     expect(formatSiteStream(testJson, siteStreamPath)).toEqual(expectedJson);
   });
 });

--- a/packages/pages/src/upgrade/migrateConfig.ts
+++ b/packages/pages/src/upgrade/migrateConfig.ts
@@ -108,22 +108,12 @@ export const formatSiteStream = (sitesJson: any, siteStreamPath: string) => {
     );
   }
 
-  // Replace $id with id and keeps id in the first position
-  const siteStream = {
-    id: sitesJson.$id,
-    ...sitesJson,
+  return {
+    id: sitesJson.$id, // Replace $id with id and keeps id in the first position
     entityId: entityId,
+    localization: sitesJson.localization,
+    fields: sitesJson.fields,
   };
-  if (siteStream.reverseProxy?.displayUrlPrefix) {
-    siteStream.serving = {
-      reverseProxyPrefix: sitesJson.reverseProxy?.displayUrlPrefix,
-    };
-  }
-  delete siteStream.$id;
-  delete siteStream.reverseProxy;
-  delete siteStream.filter;
-
-  return siteStream;
 };
 
 const migrateRedirects = async (source: string, dest: string) => {


### PR DESCRIPTION
`siteStream` in config.yaml only has four fields that we now explicitly set. Before this change we used the spread operator on the old config which brought in things not used in config.yaml, such as `source`.