### PR TITLE
fix(upgrade): check for Markdown before updating imports

### DIFF
--- a/packages/pages/src/upgrade/upgrade.ts
+++ b/packages/pages/src/upgrade/upgrade.ts
@@ -28,6 +28,9 @@ const handler = async (args: UpgradeArgs) => {
   // check proper Node version first
   checkNodeVersion();
 
+  // log warnings
+  checkLegacyMarkdown(source);
+
   // update deps, scripts, engines
   await updateDevDependencies();
   updatePackageScripts();
@@ -40,9 +43,6 @@ const handler = async (args: UpgradeArgs) => {
   updateServerlessFunctionTypeReferences(
     path.resolve(source, projectStructure.config.subfolders.serverlessFunctions)
   );
-
-  // log warnings
-  checkLegacyMarkdown(source);
 
   // install deps
   await installDependencies();


### PR DESCRIPTION
The markdown warning check was never happening because we rewrote the imports that it's looking for before this check was executed.