### PR TITLE
fix(plugin): alias imports not output in hydration files

### DIFF
--- a/packages/pages/src/common/src/parsers/sourceFileParser.test.ts
+++ b/packages/pages/src/common/src/parsers/sourceFileParser.test.ts
@@ -83,6 +83,21 @@ describe("getAllImports", () => {
     ]);
   });
 
+  it("handles types", () => {
+    const parser = createParser(`import { type Template } from "@yext/pages";`);
+    const imports = parser.getAllImports();
+    console.log(imports);
+    expect(imports[0].namedImports).toEqual(["Template"]);
+  });
+
+  it("handles aliases", () => {
+    const parser = createParser(
+      `import {Template as Template2} from "@yext/pages";`
+    );
+    const imports = parser.getAllImports();
+    expect(imports[0].namedImports).toEqual(["Template as Template2"]);
+  });
+
   it("handles named imports and default imports from one path", () => {
     const parser = createParser(
       `import Foo, {Template, TemplateConfig, TemplateProps} from "@yext/pages";`

--- a/packages/pages/src/common/src/parsers/sourceFileParser.ts
+++ b/packages/pages/src/common/src/parsers/sourceFileParser.ts
@@ -141,7 +141,12 @@ export default class SourceFileParser {
       const moduleSpecifier: string = importDec.getModuleSpecifierValue();
       const namedImportsAsString: string[] = [];
       importDec.getNamedImports()?.forEach((namedImport) => {
-        namedImportsAsString.push(namedImport.getName());
+        const alias = namedImport.getAliasNode()?.getText();
+        if (alias) {
+          namedImportsAsString.push(`${namedImport.getName()} as ${alias}`);
+        } else {
+          namedImportsAsString.push(namedImport.getName());
+        }
       });
       const attributes: OptionalKind<ImportAttributeStructure>[] = [];
       importDec


### PR DESCRIPTION
It seems there's not a better way to handle imports with ts-morph. I tried straight text copying, which works, but then the output format doesn't match what's expected. While this isn't a huge deal technically it made many test cases fail. I'm open to other ways to move imports over if there's a more robust option.