### PR TITLE
fix(dev)!: rework _server.tsx

### DIFF
--- a/packages/pages/etc/pages.api.md
+++ b/packages/pages/etc/pages.api.md
@@ -10,6 +10,11 @@ import { default as React_2 } from "react";
 export type Attributes = Record<string, string>;
 
 // @internal
+export interface ClientRenderTemplate {
+  render(pageContext: PageContext<any>): Promise<string>;
+}
+
+// @internal
 export interface ClientServerRenderTemplates {
   clientRenderTemplatePath: string;
   isCustomRenderTemplate: boolean;
@@ -153,8 +158,10 @@ export type Render<T extends TemplateRenderProps<T>> = (props: T) => string;
 export const renderHeadConfigToString: (headConfig: HeadConfig) => string;
 
 // @internal
-export interface RenderTemplate {
+export interface ServerRenderTemplate {
+  indexHtml: string;
   render(pageContext: PageContext<any>): Promise<string>;
+  replacementTag: string;
 }
 
 // @public

--- a/packages/pages/src/common/src/template/internal/_server.tsx
+++ b/packages/pages/src/common/src/template/internal/_server.tsx
@@ -4,17 +4,18 @@ import * as ReactDOMServer from "react-dom/server";
 import * as React from "react";
 import { PageContext } from "../types.js";
 
-export { render };
-
-const render = async (pageContext: PageContext<any>) => {
+export const render = async (pageContext: PageContext<any>) => {
   const { Page, pageProps } = pageContext;
-  const viewHtml = ReactDOMServer.renderToString(<Page {...pageProps} />);
 
-  return `<!DOCTYPE html>
+  return ReactDOMServer.renderToString(<Page {...pageProps} />);
+};
+
+export const replacementTag = "<!--YEXT-SERVER-->";
+
+export const indexHtml = `<!DOCTYPE html>
     <html lang="<!--app-lang-->">
       <head></head>
       <body>
-        <div id="reactele">${viewHtml}</div>
+        <div id="reactele">${replacementTag}</div>
       </body>
     </html>`;
-};

--- a/packages/pages/src/common/src/template/types.ts
+++ b/packages/pages/src/common/src/template/types.ts
@@ -247,11 +247,27 @@ export interface ClientServerRenderTemplates {
 }
 
 /**
- * The type of the client/server render templates.
+ * The type of the server render template.
  *
  * @internal
  */
-export interface RenderTemplate {
+export interface ServerRenderTemplate {
+  /** The render function required by the render templates */
+  render(pageContext: PageContext<any>): Promise<string>;
+
+  /** The index.html entrypoint for your template */
+  indexHtml: string;
+
+  /** The tag in indexHtml to replace with the contents of render */
+  replacementTag: string;
+}
+
+/**
+ * The type of the client render template.
+ *
+ * @internal
+ */
+export interface ClientRenderTemplate {
   /** The render function required by the render templates */
   render(pageContext: PageContext<any>): Promise<string>;
 }

--- a/packages/pages/src/dev/server/middleware/sendAppHTML.ts
+++ b/packages/pages/src/dev/server/middleware/sendAppHTML.ts
@@ -53,18 +53,18 @@ export default async function sendAppHTML(
     clientServerRenderTemplates.serverRenderTemplatePath
   )) as ServerRenderTemplate;
 
+  const clientInjectedIndexHtml = getIndexTemplateDev(
+    clientHydrationString,
+    serverRenderTemplateModule.indexHtml,
+    getLang(headConfig, props),
+    headConfig
+  );
+
   const transformedIndexHtml = await vite.transformIndexHtml(
     // vite decodes request urls when caching proxy requests so we have to
     // load the transform request with a decoded uri
     decodeURIComponent(pathname),
-    serverRenderTemplateModule.indexHtml
-  );
-
-  const clientInjectedIndexHtml = getIndexTemplateDev(
-    clientHydrationString,
-    transformedIndexHtml,
-    getLang(headConfig, props),
-    headConfig
+    clientInjectedIndexHtml
   );
 
   const getServerHtml = async () => {
@@ -76,7 +76,7 @@ export default async function sendAppHTML(
     });
   };
 
-  const html = clientInjectedIndexHtml.replace(
+  const html = transformedIndexHtml.replace(
     serverRenderTemplateModule.replacementTag,
     await getServerHtml()
   );

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.test.tsx
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import React from "react";
 import { TemplateModuleInternal } from "../../../../common/src/template/internal/types.js";
 import {
-  RenderTemplate,
+  ServerRenderTemplate,
   TemplateProps,
   Manifest,
 } from "../../../../common/src/template/types.js";
@@ -40,18 +40,18 @@ const baseProps: TemplateProps = {
   },
 };
 
-const serverRenderTemplate: RenderTemplate = {
+const serverRenderTemplate: ServerRenderTemplate = {
   render: () => {
-    return Promise.resolve(
-      `<!DOCTYPE html>
-        <html lang="<!--app-lang-->">
-          <head></head>
-          <body>
-            <div id="reactele"></div>
-          </body>
-        </html>`
-    );
+    return Promise.resolve("");
   },
+  indexHtml: `<!DOCTYPE html>
+  <html lang="<!--app-lang-->">
+    <head></head>
+    <body>
+      <div id="reactele"><!--REPLACE-ME></div>
+    </body>
+  </html>`,
+  replacementTag: "<!--REPLACE-ME>",
 };
 
 describe("generateResponses", () => {

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
@@ -3,7 +3,7 @@ import {
   TemplateRenderProps,
   Manifest,
   TemplateModule,
-  RenderTemplate,
+  ServerRenderTemplate,
 } from "../../../../common/src/template/types.js";
 import { getRelativePrefixToRootFromPath } from "../../../../common/src/template/paths.js";
 import { reactWrapper } from "./wrapper.js";
@@ -49,7 +49,7 @@ export const readTemplateModules = async (
 /** The render template information needed by the plugin execution */
 export interface PluginRenderTemplates {
   /** The server render module */
-  server: RenderTemplate;
+  server: ServerRenderTemplate;
   /** The client render relative path */
   client: string;
 }
@@ -80,12 +80,14 @@ export const getPluginRenderTemplates = async (
 // caches dynamically imported plugin render template modules. Without this, dynamically imported
 // modules will leak some memory during generation. This can cause issues on a publish with a large
 // number of generations.
-const pluginRenderTemplatesCache = new Map<string, RenderTemplate>();
+const pluginRenderTemplatesCache = new Map<string, ServerRenderTemplate>();
 
-const importRenderTemplate = async (path: string): Promise<RenderTemplate> => {
+const importRenderTemplate = async (
+  path: string
+): Promise<ServerRenderTemplate> => {
   let module = pluginRenderTemplatesCache.get(path);
   if (!module) {
-    module = (await import(path)) as RenderTemplate;
+    module = (await import(path)) as ServerRenderTemplate;
     pluginRenderTemplatesCache.set(path, module);
   }
   return module;

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
@@ -32,11 +32,6 @@ export const reactWrapper = async <T extends TemplateRenderProps>(
     `${templateModuleInternal.templateName}.tsx`
   );
 
-  const serverHtml = await pluginRenderTemplates.server.render({
-    Page: templateModuleInternal.default!,
-    pageProps: props,
-  });
-
   let clientHydrationString;
   if (hydrate) {
     clientHydrationString = getHydrationTemplate(
@@ -46,9 +41,19 @@ export const reactWrapper = async <T extends TemplateRenderProps>(
     );
   }
 
+  const serverHtml = await pluginRenderTemplates.server.render({
+    Page: templateModuleInternal.default!,
+    pageProps: props,
+  });
+
+  const html = pluginRenderTemplates.server.indexHtml.replace(
+    pluginRenderTemplates.server.replacementTag,
+    serverHtml
+  );
+
   const clientInjectedServerHtml = getServerTemplatePlugin(
     clientHydrationString,
-    serverHtml,
+    html,
     templateFilepath,
     manifest.bundlerManifest,
     getLang(headConfig, props),


### PR DESCRIPTION
This reworks the exports of _server.tsx. According to [this](https://github.com/vitejs/vite/pull/15345#issuecomment-1855550194) transformIndexHtml should be called on the index.html (which is provided automatically) and not the entire result of calling render (after the server code is injected). It hasn’t actually posed a problem but I’d like to get ahead of it and make sure we’re doing it the right way. It really only affects local dev but it’s breaking since what’s exported from _server.tsx has changed.

_server.tsx is now expected to export 3 things:
```
export const render = async (pageContext: PageContext<any>) => {
  const { Page, pageProps } = pageContext;

  return ReactDOMServer.renderToString(<Page {...pageProps} />);
};

export const replacementTag = "<!--YEXT-SERVER-->";

export const indexHtml = `<!DOCTYPE html>
    <html lang="<!--app-lang-->">
      <head></head>
      <body>
        <div id="reactele">${replacementTag}</div>
      </body>
    </html>`;
```

Specifically, `indexHtml` is now split out from the server `render`. It also requires a `replacementTag` to know where the server html should be injected into the indexHtml.