### PR TITLE
fix(dev): cache bust client

### DIFF
--- a/packages/pages/src/dev/server/middleware/sendAppHTML.ts
+++ b/packages/pages/src/dev/server/middleware/sendAppHTML.ts
@@ -61,9 +61,11 @@ export default async function sendAppHTML(
   );
 
   const transformedIndexHtml = await vite.transformIndexHtml(
-    // vite decodes request urls when caching proxy requests so we have to
-    // load the transform request with a decoded uri
-    decodeURIComponent(pathname),
+    // Vite decodes request urls when caching proxy requests so we have to
+    // load the transform request with a decoded uri. Additionally we add
+    // a date to cache bust the module path so that props are updated upon
+    // page refresh, otherwise Vite caches it.
+    decodeURIComponent(pathname) + Date.now(),
     clientInjectedIndexHtml
   );
 


### PR DESCRIPTION
transformIndexHtml results in the client module imports looking like this:
`<script type="module" src="/@id/__x00__/location?html-proxy&amp;index=0.js"></script>`

Upon page refresh, because the client path is the same, the browser caches the response. This meant that when props changed, they weren't actually reflected. We now append a time to unique-ify the request to ensure that the latest props are always used.

The import now looks like this:
`<script type="module" src="/@id/__x00__/location61707256037383?html-proxy&amp;index=0.js"></script>`