### PR TITLE
fix(dev): include siteStream from config.yaml in GTD

### DIFF
--- a/packages/pages/src/common/src/project/structure.ts
+++ b/packages/pages/src/common/src/project/structure.ts
@@ -258,4 +258,13 @@ export class ProjectStructure {
       pathLib.join(this.config.rootFolders.dist, this.config.scope ?? "")
     );
   };
+
+  /**
+   * @returns the {@link Path} to the config.yaml file, taking scope into account.
+   */
+  getConfigYamlPath = () => {
+    return new Path(
+      pathLib.join(this.config.scope ?? "", this.config.rootFiles.config)
+    );
+  };
 }

--- a/packages/pages/src/upgrade/migrateConfig.ts
+++ b/packages/pages/src/upgrade/migrateConfig.ts
@@ -191,10 +191,7 @@ export const migrateConfigs = async (projectStructure: ProjectStructure) => {
       fs.mkdirSync(scopeFolder, { recursive: true });
     }
   }
-  const configYamlPath = path.resolve(
-    scopeFolder,
-    projectStructure.config.rootFiles.config
-  );
+  const configYamlPath = projectStructure.getConfigYamlPath().getAbsolutePath();
   if (!fs.existsSync(configYamlPath)) {
     console.info(`${configYamlPath} does not exist, creating it`);
     fs.writeFileSync(configYamlPath, "");


### PR DESCRIPTION
siteStream was only being passed through to generate-test-data when there was a sites-config/site-stream.json file. This ensures the same functionality when using config.yaml.

Fixes https://github.com/yext/pages/issues/483