### PR TITLE
feat: support scope with modules

### DIFF
--- a/packages/pages/src/build/build.ts
+++ b/packages/pages/src/build/build.ts
@@ -13,9 +13,6 @@ export const buildCommand = (program: Command) => {
   program
     .command("build")
     .description("Build site using Vite")
-    .option(
-      "--scope <string>",
-      "The subfolder to scope the served templates from"
-    )
+    .option("--scope <string>", "The subfolder to scope from")
     .action(handler);
 };

--- a/packages/pages/src/common/src/project/structure.ts
+++ b/packages/pages/src/common/src/project/structure.ts
@@ -1,8 +1,10 @@
 import pathLib from "node:path";
 import merge from "lodash/merge.js";
+import fs from "node:fs";
 import { Path } from "./path.js";
 import { determineAssetsFilepath } from "../assets/getAssetsFilepath.js";
 import { determinePublicFilepath } from "../assets/getPublicFilepath.js";
+import { Manifest } from "../template/types.js";
 
 /**
  * All important folders defined at the root of the project.
@@ -127,6 +129,8 @@ export interface ProjectStructureConfig {
    *
    * The subfolder path inside src/templates and sites-config
    * to scope a build to a subset of templates using a specific sites-config folder.
+   *
+   * Modules scoping is also supported.
    */
   scope?: string;
 }
@@ -224,10 +228,11 @@ export class ProjectStructure {
   };
 
   /**
-   * @returns the list of of src/templates, taking scope into account. If a scope is defined then
-   * both the scoped and non-scoped template paths are returned.
+   * @param manifest should only be provided if fs doesn't work in the env.
+   * @returns the list of of src/templates, taking scope into account. If a scope is defined and
+   * the scoped path exists, then both the scoped and non-scoped template paths are returned.
    */
-  getTemplatePaths = () => {
+  getTemplatePaths = (manifest?: Manifest) => {
     // src/templates
     const templatesRoot = pathLib.join(
       this.config.rootFolders.source,
@@ -235,34 +240,23 @@ export class ProjectStructure {
     );
 
     if (this.config.scope) {
-      return [
-        new Path(pathLib.join(templatesRoot, this.config.scope)),
-        new Path(templatesRoot),
-      ];
+      // src/templates/[scope]
+      const scopedPath: string = pathLib.join(templatesRoot, this.config.scope);
+      if (fs && fs.existsSync(scopedPath)) {
+        return [new Path(scopedPath), new Path(templatesRoot)];
+      } else if (
+        manifest &&
+        Object.keys(manifest.bundlerManifest).some((key) =>
+          key.includes(scopedPath)
+        )
+      ) {
+        // manifest is used instead of fs during render code due to fs not working.
+        // Specifically in pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
+        return [new Path(scopedPath), new Path(templatesRoot)];
+      }
     }
 
     return [new Path(templatesRoot)];
-  };
-
-  /**
-   * @returns the list of of src/modules, taking scope into account. If a scope is defined then
-   * both the scoped and non-scoped module paths are returned.
-   */
-  getModulePaths = () => {
-    // src/modules
-    const modulesRoot = pathLib.join(
-      this.config.rootFolders.source,
-      this.config.subfolders.modules
-    );
-
-    if (this.config.scope) {
-      return [
-        new Path(pathLib.join(modulesRoot, this.config.scope)),
-        new Path(modulesRoot),
-      ];
-    }
-
-    return [new Path(modulesRoot)];
   };
 
   /**
@@ -294,15 +288,26 @@ export class ProjectStructure {
 
   /**
    * @returns the {@link Path} to the modules folder, taking scope into account.
-   * If moduleName is provided, returns the path to that modules folder.
+   * If moduleName is provided, returns the path to that modules folder. If a scope is
+   * defined and scoped path exists, then both the scoped and non-scoped module paths are returned.
    */
-  getModulePath = (moduleName: string | undefined) => {
+  getModulePaths = (moduleName?: string) => {
     const modulesPath = pathLib.join(
+      this.config.rootFolders.source,
+      this.config.subfolders.modules,
+      moduleName ?? ""
+    );
+    const scopedPath = pathLib.join(
       this.config.rootFolders.source,
       this.config.subfolders.modules,
       this.config.scope ?? "",
       moduleName ?? ""
     );
-    return new Path(modulesPath);
+
+    if (this.config.scope && fs.existsSync(scopedPath)) {
+      return [new Path(scopedPath), new Path(modulesPath)];
+    }
+
+    return [new Path(modulesPath)];
   };
 }

--- a/packages/pages/src/common/src/project/structure.ts
+++ b/packages/pages/src/common/src/project/structure.ts
@@ -242,7 +242,7 @@ export class ProjectStructure {
     if (this.config.scope) {
       // src/templates/[scope]
       const scopedPath: string = pathLib.join(templatesRoot, this.config.scope);
-      if (fs && fs.existsSync(scopedPath)) {
+      if (fs?.existsSync(scopedPath)) {
         return [new Path(scopedPath), new Path(templatesRoot)];
       } else if (
         manifest &&

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -87,10 +87,7 @@ export const devCommand = (program: Command) => {
       "Creates features.json, generates test data, " +
         "and runs a custom local development server that is backed by Vite."
     )
-    .option(
-      "--scope <string>",
-      "The subfolder to scope the served templates from"
-    )
+    .option("--scope <string>", "The subfolder to scope from")
     .option("--local", "Disables dynamically generated test data")
     .option(
       "--prod-url",

--- a/packages/pages/src/generate/artifacts/artifacts.ts
+++ b/packages/pages/src/generate/artifacts/artifacts.ts
@@ -21,9 +21,6 @@ export const artifactsCommand = (program: Command) => {
   program
     .command("artifacts")
     .description("Generatesartifacts.json file")
-    .option(
-      "--scope <string>",
-      "The subfolder to scope the served templates from"
-    )
+    .option("--scope <string>", "The subfolder to scope from")
     .action(artifactsHandler);
 };

--- a/packages/pages/src/generate/ci/ci.ts
+++ b/packages/pages/src/generate/ci/ci.ts
@@ -24,10 +24,7 @@ export const ciCommand = (program: Command) => {
   program
     .command("ci")
     .description("Generates ci.json file")
-    .option(
-      "--scope <string>",
-      "The subfolder to scope the served templates from"
-    )
+    .option("--scope <string>", "The subfolder to scope from")
     .action(handler);
 };
 

--- a/packages/pages/src/generate/features/features.ts
+++ b/packages/pages/src/generate/features/features.ts
@@ -21,9 +21,6 @@ export const featureCommand = (program: Command) => {
   program
     .command("features")
     .description("Generates features.json file")
-    .option(
-      "--scope <string>",
-      "The subfolder to scope the served templates from"
-    )
+    .option("--scope <string>", "The subfolder to scope from")
     .action(handler);
 };

--- a/packages/pages/src/prod/prod.ts
+++ b/packages/pages/src/prod/prod.ts
@@ -25,9 +25,6 @@ export const prodCommand = (program: Command) => {
     .description("Runs a custom local production server")
     .option("--noBuild", "Disable build step")
     .option("--noRender", "Disable render step")
-    .option(
-      "--scope  <string>",
-      "The subfolder to scope the served templates from"
-    )
+    .option("--scope  <string>", "The subfolder to scope from")
     .action(handler);
 };

--- a/packages/pages/src/scaffold/modules/generate.ts
+++ b/packages/pages/src/scaffold/modules/generate.ts
@@ -40,7 +40,10 @@ export const generateModule = async (
   ];
   const response = await prompts(questions);
 
-  const modulePath = projectStructure.getModulePath(response.moduleName).path;
+  const modulePath = path.join(
+    projectStructure.getModulePaths()[0].path,
+    response.moduleName
+  );
 
   // Handle interruption signal (Ctrl+C)
   process.on("SIGINT", () =>
@@ -82,7 +85,10 @@ const validateModuleName = (
   moduleName: string,
   projectStructure: ProjectStructure
 ): boolean => {
-  const modulePath = projectStructure.getModulePath(moduleName).path;
+  const modulePath = path.join(
+    projectStructure.getModulePaths()[0].path,
+    moduleName
+  );
   if (fs.existsSync(modulePath)) {
     return false;
   }
@@ -90,7 +96,7 @@ const validateModuleName = (
 };
 
 function handleCancel(moduleName: string, projectStructure: ProjectStructure) {
-  const modulePath = projectStructure.getModulePath(moduleName).path;
+  const modulePath = projectStructure.getModulePaths(moduleName)[0].path;
   if (fs.existsSync(modulePath)) {
     const moduleFiles = glob.sync("**/*", { cwd: modulePath, nodir: true });
     moduleFiles.forEach((file) => {

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
@@ -28,7 +28,7 @@ export const reactWrapper = async <T extends TemplateRenderProps>(
     : undefined;
 
   const templateFilepath = path.join(
-    projectStructure.getTemplatePaths()[0].path,
+    projectStructure.getTemplatePaths(manifest)[0].path,
     `${templateModuleInternal.templateName}.tsx`
   );
 

--- a/packages/pages/src/vite-plugin/modules/plugin.ts
+++ b/packages/pages/src/vite-plugin/modules/plugin.ts
@@ -7,7 +7,6 @@ import { convertToPosixPath } from "../../common/src/template/paths.js";
 import { processEnvVariables } from "../../util/processEnvVariables.js";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import pc from "picocolors";
-import { addResponseHeadersToConfigYaml } from "../../util/editConfigYaml.js";
 import SourceFileParser, {
   createTsMorphProject,
 } from "../../common/src/parsers/sourceFileParser.js";
@@ -16,11 +15,6 @@ import postcss from "postcss";
 import nested from "postcss-nested";
 import { createModuleLogger } from "../../common/src/module/internal/logger.js";
 import { getModuleName } from "../../common/src/module/internal/getModuleName.js";
-
-const moduleResponseHeaderProps = {
-  headerKey: "Access-Control-Allow-Origin",
-  headerValues: ["*"],
-};
 
 type FileInfo = {
   path: string;
@@ -34,8 +28,7 @@ export const buildModules = async (
     return;
   }
 
-  const { rootFolders, subfolders, envVarConfig, scope } =
-    projectStructure.config;
+  const { rootFolders, subfolders, envVarConfig } = projectStructure.config;
   const outdir = path.join(rootFolders.dist, subfolders.modules);
 
   const filepaths: { [s: string]: FileInfo } = {};
@@ -76,20 +69,6 @@ export const buildModules = async (
       }
       loggerInfo(msg, options);
     };
-
-    // For each module, add response header to config.yaml.
-    // Users can manually adjust headerKey and headerValue in their config.yaml.
-    // As long as pathPattern matches, it won't be overwitten.
-    addResponseHeadersToConfigYaml(
-      projectStructure,
-      {
-        pathPattern: scope
-          ? `^modules/${scope}/${moduleName}.*`
-          : `^modules/${moduleName}.*`,
-        ...moduleResponseHeaderProps,
-      },
-      "# The ^modules/ header allows access to your modules from other sites\n"
-    );
 
     await build({
       customLogger: logger,

--- a/packages/yext-function/manifest.ts
+++ b/packages/yext-function/manifest.ts
@@ -128,6 +128,8 @@ export interface ProjectStructureConfig {
    *
    * The subfolder path inside src/templates and sites-config
    * to scope a build to a subset of templates using a specific sites-config folder.
+   *
+   * Modules scoping is also supported.
    */
   scope?: string;
 }


### PR DESCRIPTION
`npm run prod -- --scope myScope` works w/ myScope in templates, modules, and both. npm run build and dev work as expected as well. Double checked scaffolding supported scope still too. 

scope means files in both myScope and src/... are built and used. Without the scope being set, the files in myScope are not used. If a file is in myScope and in src/... (with same config name), the one in myScope should be used (if scope is set).