### PR TITLE
fix(dev): adjust GTD logic and pass scope

### DIFF
--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -71,6 +71,10 @@ export const generateTestDataForSlug = async (
 
   const slugFields = new Set<string>();
   templateModuleCollection.forEach((templateModule) => {
+    // We don't want to add the default "slug" field when no entity templates need it
+    if (templateModule.config.templateType == "static") {
+      return;
+    }
     const slugField = templateModule?.config?.slugField;
     if (slugField) {
       slugFields.add(slugField);

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -70,22 +70,16 @@ export const generateTestDataForSlug = async (
   args.push("--slug", `"${slug}"`);
 
   const slugFields = new Set<string>();
-  let shouldAddDefaultSlugField = false;
   templateModuleCollection.forEach((templateModule) => {
     const slugField = templateModule?.config?.slugField;
     if (slugField) {
       slugFields.add(slugField);
     } else {
-      shouldAddDefaultSlugField = true;
+      slugFields.add("slug");
     }
   });
 
-  if (slugFields.size !== 0) {
-    if (shouldAddDefaultSlugField) {
-      slugFields.add("slug");
-    }
-    args.push("--slugFields", Array.from(slugFields).toString());
-  }
+  args.push("--slugFields", Array.from(slugFields).toString());
 
   const parsedData = await spawnTestDataCommand(stdout, "yext", args);
 
@@ -270,7 +264,9 @@ const getCommonArgs = (
 
   if (projectStructure.config.scope) {
     args.push("--hostname", projectStructure.config.scope);
+    args.push("--scope", projectStructure.config.scope);
   }
+
   return args;
 };
 
@@ -309,9 +305,17 @@ const getDocumentBySlug = (
     return parsedData;
   }
 
+  // Filter out any non-entity pages
+  const filteredDocuments: any[] = parsedData.map(
+    (document) => !!document?.__?.entityPageSet
+  );
+  if (filteredDocuments.length === 1) {
+    return filteredDocuments[0];
+  }
+
   // Find the slugField where the slug value matches
   const matchingSlugFieldsSet: Set<string> = new Set();
-  for (const document of parsedData) {
+  for (const document of filteredDocuments) {
     for (const slugField of slugFields) {
       if (document[slugField] === slug) {
         matchingSlugFieldsSet.add(slugField);


### PR DESCRIPTION
Fixes the following issues:
1. Not passing the --scope flag to the CLI GTD which is necessary for config v2 (we were only passing --hostname which works the same but only for config v1)
2. `slug` wasn't added to the --slugFields flag if no other alternate slugFields were used
3. Filters out static templates so we can actually find the correct document. Currently, the --featuresConfig flag is not honored by the CLI so static template document data is coming back when it shouldn't. This is a workaround for that.