### PR TITLE
perf(dev): optimize loading index page

### DIFF
--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -11,15 +11,13 @@ import path from "path";
 import fs from "fs";
 import { ProjectStructure } from "../../../common/src/project/structure.js";
 import { getTemplateFilepathsFromProjectStructure } from "../../../common/src/template/internal/getTemplateFilepaths.js";
-import {
-  convertTemplateModuleToTemplateModuleInternal,
-  TemplateModuleInternal,
-} from "../../../common/src/template/internal/types.js";
+import { TemplateModuleInternal } from "../../../common/src/template/internal/types.js";
 import { ViteDevServer } from "vite";
-import { loadViteModule } from "./loadViteModule.js";
-import { TemplateModule } from "../../../common/src/template/types.js";
 import { getTemplatesConfig } from "../../../generate/templates/createTemplatesJson.js";
-import { TemplateModuleCollection } from "../../../common/src/template/loader/loader.js";
+import {
+  TemplateModuleCollection,
+  loadTemplateModuleCollectionUsingVite,
+} from "../../../common/src/template/loader/loader.js";
 import runSubprocess from "../../../util/runSubprocess.js";
 import YAML from "yaml";
 
@@ -93,28 +91,6 @@ export const generateTestDataForSlug = async (
     Array.from(slugFields),
     templateModuleCollection
   );
-};
-
-const loadTemplateModuleCollectionUsingVite = async (
-  vite: ViteDevServer,
-  templateFilepaths: string[]
-): Promise<TemplateModuleCollection> => {
-  const templateModules: TemplateModuleInternal<any, any>[] = await Promise.all(
-    templateFilepaths.map(async (templateFilepath) => {
-      const templateModule = await loadViteModule<TemplateModule<any, any>>(
-        vite,
-        templateFilepath
-      );
-      return convertTemplateModuleToTemplateModuleInternal(
-        templateFilepath,
-        templateModule,
-        false
-      );
-    })
-  );
-  return templateModules.reduce((prev, module) => {
-    return prev.set(module.config.name, module);
-  }, new Map());
 };
 
 export const generateTestDataForPage = async (

--- a/packages/pages/src/dev/server/ssr/getLocalData.ts
+++ b/packages/pages/src/dev/server/ssr/getLocalData.ts
@@ -1,10 +1,10 @@
 import path from "path";
 import fs from "fs";
 import { readdir } from "fs/promises";
-import { findTemplateModuleInternal } from "./findTemplateModuleInternal.js";
 import { ViteDevServer } from "vite";
 import { validateGetPathValue } from "../../../common/src/template/internal/validateGetPathValue.js";
 import { logWarning } from "../../../util/logError.js";
+import { loadTemplateModuleCollectionUsingVite } from "../../../common/src/template/loader/loader.js";
 
 const LOCAL_DATA_PATH = "localData";
 
@@ -61,6 +61,11 @@ export const getLocalDataManifest = async (
     }
   }
 
+  const templateModuleCollection = await loadTemplateModuleCollectionUsingVite(
+    vite,
+    templateFilepaths
+  );
+
   const staticPaths: string[] = [];
   for (const fileName of dir) {
     const data = JSON.parse(
@@ -78,11 +83,7 @@ export const getLocalDataManifest = async (
       continue;
     }
 
-    const templateModuleInternal = await findTemplateModuleInternal(
-      vite,
-      async (t) => featureName === t.config.name,
-      templateFilepaths
-    );
+    const templateModuleInternal = templateModuleCollection.get(featureName);
 
     const uid = data.uid?.toString();
     const entityId = data.id?.toString();


### PR DESCRIPTION
The template modules were all being loaded for each localData file. For repos with many templates/documents this was extremely slow. We now only load the template modules once.