### PR TITLE
perf(dev): speed up page loads and alleviate memory pressure

### DIFF
--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -37,6 +37,7 @@ export const serverRenderRoute =
       const staticTemplateAndProps = await findStaticTemplateModuleAndDocBySlug(
         vite,
         templateFilepaths,
+        false,
         staticURL,
         locale
       );

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from "express-serve-static-core";
 import { ViteDevServer } from "vite";
 import { propsLoader } from "../ssr/propsLoader.js";
-import { findTemplateModuleInternal } from "../ssr/findTemplateModuleInternal.js";
+import { findTemplateModuleInternalByName } from "../ssr/findTemplateModuleInternal.js";
 import { ProjectStructure } from "../../../common/src/project/structure.js";
 import { getTemplateFilepathsFromProjectStructure } from "../../../common/src/template/internal/getTemplateFilepaths.js";
 import { TemplateRenderProps } from "../../../common/src/template/types.js";
@@ -58,9 +58,9 @@ export const serverRenderSlugRoute =
       }
 
       const feature = document.__.name;
-      const templateModuleInternal = await findTemplateModuleInternal(
+      const templateModuleInternal = await findTemplateModuleInternalByName(
         vite,
-        async (t) => feature === t.config.name,
+        feature,
         templateFilepaths
       );
       if (!templateModuleInternal) {

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -31,6 +31,7 @@ export const serverRenderSlugRoute =
       const staticTemplateAndProps = await findStaticTemplateModuleAndDocBySlug(
         vite,
         templateFilepaths,
+        true,
         slug
       );
 

--- a/packages/pages/src/dev/server/ssr/findTemplateModuleInternal.ts
+++ b/packages/pages/src/dev/server/ssr/findTemplateModuleInternal.ts
@@ -32,6 +32,10 @@ export const findTemplateModuleInternalByName = async (
       templateFilepath
     );
 
+    if (templateModuleInternal.config.templateType !== "entity") {
+      continue;
+    }
+
     templateNameToTemplateFilepath.set(
       templateModuleInternal.config.name,
       templateFilepath

--- a/packages/pages/src/dev/server/ssr/findTemplateModuleInternal.ts
+++ b/packages/pages/src/dev/server/ssr/findTemplateModuleInternal.ts
@@ -6,31 +6,58 @@ import {
 } from "../../../common/src/template/internal/types.js";
 import { TemplateModule } from "../../../common/src/template/types.js";
 
-// Determines the template module to load from a given feature name (from the exported config)
-export const findTemplateModuleInternal = async (
+// A cache of templateName to its filepath. This is an optimization to avoid trying
+// to iterate through all templates on each request. If a templateName changes it is
+// required to restart the dev server.
+const templateNameToTemplateFilepath = new Map<string, string>();
+
+// Determines the template module to load from a given templateName. The module is
+// reloaded upon cache hit to ensure up-to-date data.
+export const findTemplateModuleInternalByName = async (
   devserver: ViteDevServer,
-  criterion: (
-    t: TemplateModuleInternal<any, any>
-  ) => Promise<boolean | undefined>,
+  templateName: string,
   templateFilepaths: string[]
 ): Promise<TemplateModuleInternal<any, any> | null> => {
+  const templateFilepath = templateNameToTemplateFilepath.get(templateName);
+  if (templateFilepath) {
+    return await loadTemplateModuleInternal(devserver, templateFilepath);
+  }
+
+  // Load all templates into the cache until we find the one we're looking for.
+  // We could load all templates but it's a slight optimization to stop once we
+  // find the one we need.
   for (const templateFilepath of templateFilepaths) {
-    const templateModule = await loadViteModule<TemplateModule<any, any>>(
+    const templateModuleInternal = await loadTemplateModuleInternal(
       devserver,
       templateFilepath
     );
 
-    const templateModuleInternal =
-      convertTemplateModuleToTemplateModuleInternal(
-        templateFilepath,
-        templateModule,
-        false
-      );
+    templateNameToTemplateFilepath.set(
+      templateModuleInternal.config.name,
+      templateFilepath
+    );
 
-    if (await criterion(templateModuleInternal)) {
+    if (templateName === templateModuleInternal.config.name) {
       return templateModuleInternal;
     }
   }
 
   return null;
+};
+
+export const loadTemplateModuleInternal = async (
+  devserver: ViteDevServer,
+  templateFilepath: string
+) => {
+  // Freshly load the template as it could have changed
+  const templateModule = await loadViteModule<TemplateModule<any, any>>(
+    devserver,
+    templateFilepath
+  );
+
+  return convertTemplateModuleToTemplateModuleInternal(
+    templateFilepath,
+    templateModule,
+    false
+  );
 };


### PR DESCRIPTION
This change speeds up the dev server page load performance on subsequent page refreshes/HMR changes by caching a mapping of templateName to templateFilepath. This allows us to find the templates much more quickly. Beforehand, we were iterating through and loading every template on each requests.

This caching also has the added benefit of making the Node memory less spikey (and with less GC) because less modules are loaded now.