### PR TITLE
fix(dev): filtering documents by slug

### DIFF
--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -286,7 +286,7 @@ const getDocumentBySlug = (
   }
 
   // Filter out any non-entity pages
-  const filteredDocuments: any[] = parsedData.map(
+  const filteredDocuments: any[] = parsedData.filter(
     (document) => !!document?.__?.entityPageSet
   );
   if (filteredDocuments.length === 1) {


### PR DESCRIPTION
Documents by slug weren't correctly being found due to a bug using map instead of filter.