### PR TITLE
feat(plugin): add support for statusCode to getRedirects

### DIFF
--- a/packages/pages/docs/api/pages.getredirects.md
+++ b/packages/pages/docs/api/pages.getredirects.md
@@ -9,7 +9,9 @@ The type definiton for the template's getRedirects function.
 **Signature:**
 
 ```typescript
-export type GetRedirects<T extends TemplateProps> = (props: T) => string[];
+export type GetRedirects<T extends TemplateProps> = (
+  props: T
+) => (RedirectSource | string)[];
 ```
 
 **References:** [TemplateProps](./pages.templateprops.md)

--- a/packages/pages/etc/pages.api.md
+++ b/packages/pages/etc/pages.api.md
@@ -67,8 +67,12 @@ export const getLang: <T extends TemplateRenderProps<any>>(
 // @public
 export type GetPath<T extends TemplateProps> = (props: T) => string;
 
+// Warning: (ae-forgotten-export) The symbol "RedirectSource" needs to be exported by the entry point index.d.ts
+//
 // @public
-export type GetRedirects<T extends TemplateProps> = (props: T) => string[];
+export type GetRedirects<T extends TemplateProps> = (
+  props: T
+) => (RedirectSource | string)[];
 
 // @public
 export const getRelativePrefixToRootFromPath: (path: string) => string;
@@ -338,7 +342,7 @@ export type TransformProps<T extends TemplateProps> = (props: T) => Promise<T>;
 
 // Warnings were encountered during analysis:
 //
-// dist/types/src/common/src/template/types.d.ts:173:5 - (ae-forgotten-export) The symbol "ProjectStructureConfig" needs to be exported by the entry point index.d.ts
+// dist/types/src/common/src/template/types.d.ts:174:5 - (ae-forgotten-export) The symbol "ProjectStructureConfig" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/pages/src/common/src/redirect/types.ts
+++ b/packages/pages/src/common/src/redirect/types.ts
@@ -1,0 +1,4 @@
+export interface RedirectSource {
+  source: string;
+  statusCode: number;
+}

--- a/packages/pages/src/common/src/template/types.ts
+++ b/packages/pages/src/common/src/template/types.ts
@@ -1,6 +1,7 @@
 import { ProjectStructureConfig } from "../project/structure.js";
 import { HeadConfig } from "./head.js";
 import React from "react";
+import { RedirectSource } from "../redirect/types.js";
 
 /**
  * The type to include in any template file. It defines the available functions and fields that are available
@@ -41,7 +42,9 @@ export interface TemplateModule<
  *
  * @public
  */
-export type GetRedirects<T extends TemplateProps> = (props: T) => string[];
+export type GetRedirects<T extends TemplateProps> = (
+  props: T
+) => (RedirectSource | string)[];
 
 /**
  * The type definition for the template's transformProps function. Can be used

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
@@ -11,6 +11,7 @@ import {
   convertTemplateModuleToTemplateModuleInternal,
   TemplateModuleInternal,
 } from "../../../../common/src/template/internal/types.js";
+import { RedirectSource } from "../../../../common/src/redirect/types.js";
 import { ProjectStructure } from "../../../../common/src/project/structure.js";
 import { validateGetPathValue } from "../../../../common/src/template/internal/validateGetPathValue.js";
 
@@ -97,7 +98,7 @@ const importRenderTemplate = async (
 export type GeneratedPage = {
   path: string;
   content?: string;
-  redirects: string[];
+  redirects: (RedirectSource | string)[];
   authScope?: string;
 };
 


### PR DESCRIPTION
Allows the user to pass in either RedirectSource {source: string, statusCode: int}[] or string[] for GetRedirects

The Yext CLI has not been updated to accept the new type yet, so this currently only works for string[]
