### PR TITLE
feat(dev/plugin): add support for src/redirects

### DIFF
--- a/packages/pages/.gitignore
+++ b/packages/pages/.gitignore
@@ -1,1 +1,2 @@
 .env
+tsdoc-metadata.json

--- a/packages/pages/docs/api/pages.manifest.md
+++ b/packages/pages/docs/api/pages.manifest.md
@@ -13,6 +13,9 @@ export type Manifest = {
   serverPaths: {
     [key: string]: string;
   };
+  redirectPaths: {
+    [key: string]: string;
+  };
   clientPaths: {
     [key: string]: string;
   };

--- a/packages/pages/etc/pages.api.md
+++ b/packages/pages/etc/pages.api.md
@@ -95,6 +95,9 @@ export type Manifest = {
   serverPaths: {
     [key: string]: string;
   };
+  redirectPaths: {
+    [key: string]: string;
+  };
   clientPaths: {
     [key: string]: string;
   };
@@ -342,7 +345,7 @@ export type TransformProps<T extends TemplateProps> = (props: T) => Promise<T>;
 
 // Warnings were encountered during analysis:
 //
-// dist/types/src/common/src/template/types.d.ts:174:5 - (ae-forgotten-export) The symbol "ProjectStructureConfig" needs to be exported by the entry point index.d.ts
+// dist/types/src/common/src/template/types.d.ts:178:5 - (ae-forgotten-export) The symbol "ProjectStructureConfig" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/pages/src/common/src/feature/features.ts
+++ b/packages/pages/src/common/src/feature/features.ts
@@ -1,5 +1,6 @@
 import { TemplateConfigInternal } from "../template/internal/types.js";
-import { convertConfigToStreamConfig, StreamConfig } from "./stream.js";
+import { RedirectConfigInternal } from "../redirect/internal/types.js";
+import { convertTemplateConfigToStreamConfig, StreamConfig } from "./stream.js";
 
 /**
  * The shape of data that represents a features.json file, used by Yext Pages.
@@ -18,7 +19,7 @@ export const convertTemplateConfigInternalToFeaturesConfig = (
   config: TemplateConfigInternal
 ): FeaturesConfig => {
   const featureConfig = convertTemplateConfigToFeatureConfig(config);
-  const streamConfig = convertConfigToStreamConfig(config);
+  const streamConfig = convertTemplateConfigToStreamConfig(config);
 
   return {
     features: [featureConfig],
@@ -91,6 +92,37 @@ export const convertTemplateConfigToFeatureConfig = (
       entityPageSet: {
         pageUrlField: config.pageUrlField,
       },
+    };
+  }
+
+  return featureConfig;
+};
+
+/**
+ * Converts a {@link RedirectConfigInternal} into a valid single {@link FeatureConfig}.
+ */
+export const convertRedirectConfigToFeatureConfig = (
+  config: RedirectConfigInternal
+): FeatureConfig => {
+  const streamConfig = config.stream || null;
+
+  const featureConfigBase: FeatureConfigBase = {
+    name: config.name,
+    streamId: streamConfig?.$id ?? config.streamId,
+    templateType: "JS",
+  };
+
+  let featureConfig: FeatureConfig;
+  // If the redirectConfig does not reference a stream, assume it's a static feature.
+  if (config.redirectType === "static") {
+    featureConfig = {
+      ...featureConfigBase,
+      staticPage: {},
+    };
+  } else {
+    featureConfig = {
+      ...featureConfigBase,
+      entityPageSet: {},
     };
   }
 

--- a/packages/pages/src/common/src/feature/features.ts
+++ b/packages/pages/src/common/src/feature/features.ts
@@ -1,5 +1,5 @@
 import { TemplateConfigInternal } from "../template/internal/types.js";
-import { convertTemplateConfigToStreamConfig, StreamConfig } from "./stream.js";
+import { convertConfigToStreamConfig, StreamConfig } from "./stream.js";
 
 /**
  * The shape of data that represents a features.json file, used by Yext Pages.
@@ -18,7 +18,7 @@ export const convertTemplateConfigInternalToFeaturesConfig = (
   config: TemplateConfigInternal
 ): FeaturesConfig => {
   const featureConfig = convertTemplateConfigToFeatureConfig(config);
-  const streamConfig = convertTemplateConfigToStreamConfig(config);
+  const streamConfig = convertConfigToStreamConfig(config);
 
   return {
     features: [featureConfig],

--- a/packages/pages/src/common/src/feature/features.ts
+++ b/packages/pages/src/common/src/feature/features.ts
@@ -112,19 +112,8 @@ export const convertRedirectConfigToFeatureConfig = (
     templateType: "JS",
   };
 
-  let featureConfig: FeatureConfig;
-  // If the redirectConfig does not reference a stream, assume it's a static feature.
-  if (config.redirectType === "static") {
-    featureConfig = {
-      ...featureConfigBase,
-      staticPage: {},
-    };
-  } else {
-    featureConfig = {
-      ...featureConfigBase,
-      entityPageSet: {},
-    };
-  }
-
-  return featureConfig;
+  return {
+    ...featureConfigBase,
+    entityPageSet: {},
+  };
 };

--- a/packages/pages/src/common/src/feature/stream.test.ts
+++ b/packages/pages/src/common/src/feature/stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { convertConfigToStreamConfig, StreamConfig } from "./stream.js";
+import { convertTemplateConfigToStreamConfig, StreamConfig } from "./stream.js";
 import { TemplateConfigInternal } from "../template/internal/types.js";
 
 describe("stream", () => {
@@ -10,7 +10,7 @@ describe("stream", () => {
       templateType: "static",
     };
 
-    const streamConfig = convertConfigToStreamConfig(templateConfig);
+    const streamConfig = convertTemplateConfigToStreamConfig(templateConfig);
 
     expect(streamConfig).toEqual(void 0);
   });
@@ -30,7 +30,7 @@ describe("stream", () => {
       templateType: "entity",
     };
 
-    const streamConfig = convertConfigToStreamConfig(templateConfig);
+    const streamConfig = convertTemplateConfigToStreamConfig(templateConfig);
     const expectedStreamConfig: StreamConfig = {
       $id: "$id",
       source: "knowledgeGraph",

--- a/packages/pages/src/common/src/feature/stream.test.ts
+++ b/packages/pages/src/common/src/feature/stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { convertTemplateConfigToStreamConfig, StreamConfig } from "./stream.js";
+import { convertConfigToStreamConfig, StreamConfig } from "./stream.js";
 import { TemplateConfigInternal } from "../template/internal/types.js";
 
 describe("stream", () => {
@@ -10,7 +10,7 @@ describe("stream", () => {
       templateType: "static",
     };
 
-    const streamConfig = convertTemplateConfigToStreamConfig(templateConfig);
+    const streamConfig = convertConfigToStreamConfig(templateConfig);
 
     expect(streamConfig).toEqual(void 0);
   });
@@ -30,7 +30,7 @@ describe("stream", () => {
       templateType: "entity",
     };
 
-    const streamConfig = convertTemplateConfigToStreamConfig(templateConfig);
+    const streamConfig = convertConfigToStreamConfig(templateConfig);
     const expectedStreamConfig: StreamConfig = {
       $id: "$id",
       source: "knowledgeGraph",

--- a/packages/pages/src/common/src/feature/stream.ts
+++ b/packages/pages/src/common/src/feature/stream.ts
@@ -1,4 +1,5 @@
 import { TemplateConfigInternal } from "../template/internal/types.js";
+import { RedirectConfigInternal } from "../redirect/internal/types.js";
 
 /**
  * The shape of data that represents a stream configuration.
@@ -40,9 +41,28 @@ export interface StreamConfig {
 /**
  * Converts a {@link TemplateConfig.config.stream} into a valid {@link StreamConfig}.
  */
-export const convertConfigToStreamConfig = (
+export const convertTemplateConfigToStreamConfig = (
   // config is optional for a user to set
   config: TemplateConfigInternal | undefined
+): StreamConfig | void => {
+  if (!config) {
+    return;
+  }
+  if (config.stream) {
+    return {
+      ...config.stream,
+      source: "knowledgeGraph",
+      destination: "pages",
+    };
+  }
+};
+
+/**
+ * Converts a {@link RedirectConfig.config.stream} into a valid {@link StreamConfig}.
+ */
+export const convertRedirectConfigToStreamConfig = (
+  // config is optional for a user to set
+  config: RedirectConfigInternal | undefined
 ): StreamConfig | void => {
   if (!config) {
     return;

--- a/packages/pages/src/common/src/feature/stream.ts
+++ b/packages/pages/src/common/src/feature/stream.ts
@@ -40,7 +40,7 @@ export interface StreamConfig {
 /**
  * Converts a {@link TemplateConfig.config.stream} into a valid {@link StreamConfig}.
  */
-export const convertTemplateConfigToStreamConfig = (
+export const convertConfigToStreamConfig = (
   // config is optional for a user to set
   config: TemplateConfigInternal | undefined
 ): StreamConfig | void => {

--- a/packages/pages/src/common/src/project/structure.ts
+++ b/packages/pages/src/common/src/project/structure.ts
@@ -275,6 +275,9 @@ export class ProjectStructure {
       this.config.rootFolders.source,
       this.config.subfolders.redirects
     );
+    if (!fs?.existsSync(redirectsRoot)) {
+      return [];
+    }
 
     if (this.config.scope) {
       // src/redirects/[scope]

--- a/packages/pages/src/common/src/project/structure.ts
+++ b/packages/pages/src/common/src/project/structure.ts
@@ -263,11 +263,10 @@ export class ProjectStructure {
   };
 
   /**
-   * @param manifest should only be provided if fs doesn't work in the env.
-   * @returns the list of of src/redirects, taking scope into account. If a scope is defined and
+   * @returns the list of src/redirects, taking scope into account. If a scope is defined and
    * the scoped path exists, then both the scoped and non-scoped redirect paths are returned.
    */
-  getRedirectPaths = (manifest?: Manifest) => {
+  getRedirectPaths = () => {
     // src/redirects
     const redirectsRoot = pathLib.join(
       this.config.rootFolders.source,
@@ -278,15 +277,6 @@ export class ProjectStructure {
       // src/redirects/[scope]
       const scopedPath: string = pathLib.join(redirectsRoot, this.config.scope);
       if (fs?.existsSync(scopedPath)) {
-        return [new Path(scopedPath), new Path(redirectsRoot)];
-      } else if (
-        manifest &&
-        Object.keys(manifest.bundlerManifest).some((key) =>
-          key.includes(scopedPath)
-        )
-      ) {
-        // manifest is used instead of fs during render code due to fs not working.
-        // Specifically in pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
         return [new Path(scopedPath), new Path(redirectsRoot)];
       }
     }

--- a/packages/pages/src/common/src/project/structure.ts
+++ b/packages/pages/src/common/src/project/structure.ts
@@ -40,6 +40,8 @@ export interface Subfolders {
   clientBundle: string;
   /** Where to output the server bundles */
   serverBundle: string;
+  /** Where to output the redirect bundles */
+  redirectBundle: string;
   /** Where to output the render bundles */
   renderBundle: string; // _client and _server
   /** Where to output the renderer bundle */
@@ -157,6 +159,7 @@ const defaultProjectStructureConfig: ProjectStructureConfig = {
     public: DEFAULT_PUBLIC_DIR,
     clientBundle: "client",
     serverBundle: "server",
+    redirectBundle: "redirect",
     renderBundle: "render",
     renderer: "renderer",
     static: "static",

--- a/packages/pages/src/common/src/redirect/internal/getRedirectFilepaths.ts
+++ b/packages/pages/src/common/src/redirect/internal/getRedirectFilepaths.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+import { Path } from "../../project/path.js";
+import { ProjectStructure } from "../../project/structure.js";
+import { convertToPosixPath } from "../../template/paths.js";
+import { globSync } from "glob";
+
+/**
+ * Get all the redirect files in the provided redirect folder path(s).
+ *
+ * If there are files that share the same name between the provided
+ * redirect folder paths, only the file found in the first visited path
+ * from the list is included.
+ *
+ * @param paths a list of paths to collect redirect files from
+ * @returns a list of redirect filepaths
+ */
+export const getRedirectFilePaths = (paths: Path[]): string[] => {
+  const redirectFilepaths: string[] = [];
+  const addedFilenames: Set<string> = new Set();
+  paths.forEach((p) => {
+    const filepaths = globSync(
+      convertToPosixPath(`${p.getAbsolutePath()}/*.{tsx,jsx,js,ts}`)
+    );
+    filepaths.forEach((f) => {
+      const fileName = path.basename(f);
+      if (!addedFilenames.has(fileName)) {
+        addedFilenames.add(fileName);
+        redirectFilepaths.push(f);
+      }
+    });
+  });
+
+  return redirectFilepaths;
+};
+
+export const getRedirectFilePathsFromProjectStructure = (
+  projectStructure: ProjectStructure
+): string[] => {
+  return getRedirectFilePaths(projectStructure.getRedirectPaths());
+};

--- a/packages/pages/src/common/src/redirect/internal/types.ts
+++ b/packages/pages/src/common/src/redirect/internal/types.ts
@@ -1,7 +1,6 @@
 import { TemplateProps } from "../../template/types.js";
 import {
   convertStreamToStreamInternal,
-  isStaticTemplateConfig,
   parse,
   StreamInternal,
 } from "../../template/internal/types.js";
@@ -45,10 +44,6 @@ export interface RedirectConfigInternal {
   streamId?: string;
   /** The stream configuration used by the redirect */
   stream?: StreamInternal;
-  /** The field to use as the slug for dynamic dev mode */
-  slugField?: string;
-  /** The type of redirect */
-  redirectType: "entity" | "static";
 }
 
 export const convertRedirectModuleToRedirectModuleInternal = (
@@ -84,8 +79,5 @@ export const convertRedirectConfigToRedirectConfigInternal = (
     name: redirectConfig?.name ?? redirectName,
     ...redirectConfig,
     stream: stream,
-    redirectType: isStaticTemplateConfig(redirectConfig?.streamId, stream)
-      ? "static"
-      : "entity",
   };
 };

--- a/packages/pages/src/common/src/redirect/internal/types.ts
+++ b/packages/pages/src/common/src/redirect/internal/types.ts
@@ -1,0 +1,53 @@
+import { TemplateProps } from "../../template/types.js";
+import {
+  convertTemplateConfigToTemplateConfigInternal,
+  parse,
+  TemplateConfigInternal,
+} from "../../template/internal/types.js";
+import { GetDestination, GetSources, RedirectModule } from "../types.js";
+import { validateRedirectModuleInternal } from "./validateRedirectModuleInternal.js";
+
+/**
+ * A domain representation of a redirect module. Contains all fields from an imported module as well
+ * as metadata about the module used in downstream processing.
+ */
+export interface RedirectModuleInternal<T extends TemplateProps> {
+  /**
+   * The filepath to the redirect file. This can be the raw TSX file when used during dev mode or
+   * the path to the server bundle this module was imported from during prod build.
+   */
+  path: string;
+  /** The name of the file (with extension) */
+  filename: string;
+  /** The name of the file (without extension) */
+  redirectName: string;
+  /** The exported config function */
+  config: TemplateConfigInternal;
+  /** The exported getDestination function **/
+  getDestination: GetDestination<T>;
+  /** The exported getSources function **/
+  getSources: GetSources<T>;
+}
+
+export const convertRedirectModuleToRedirectModuleInternal = (
+  redirectFilepath: string,
+  redirectModule: RedirectModule<any>,
+  adjustForFingerprintedAsset: boolean
+): RedirectModuleInternal<any> => {
+  const redirectPath = parse(redirectFilepath, adjustForFingerprintedAsset);
+
+  const redirectModuleInternal = {
+    ...redirectModule,
+    config: convertTemplateConfigToTemplateConfigInternal(
+      redirectPath.name,
+      redirectModule.config
+    ),
+    path: redirectFilepath,
+    filename: redirectPath.base,
+    redirectName: redirectPath.name,
+  } as RedirectModuleInternal<any>;
+
+  validateRedirectModuleInternal(redirectModuleInternal);
+
+  return redirectModuleInternal;
+};

--- a/packages/pages/src/common/src/redirect/internal/validateRedirectModuleInternal.ts
+++ b/packages/pages/src/common/src/redirect/internal/validateRedirectModuleInternal.ts
@@ -1,5 +1,4 @@
-import { RedirectModuleInternal } from "./types.js";
-import { TemplateConfigInternal } from "../../template/internal/types.js";
+import { RedirectConfigInternal, RedirectModuleInternal } from "./types.js";
 
 export const validateRedirectModuleInternal = (
   redirectModule: RedirectModuleInternal<any>
@@ -17,22 +16,11 @@ export const validateRedirectModuleInternal = (
       `Redirect ${redirectModule.filename} is missing an exported getSources function.`
     );
   }
-
-  // TODO - make this check work
-  // const sources = redirectModule.getSources({});
-  // for (let i = 0; i < sources.length; i++) {
-  //   if (sources[i].statusCode < 300 || sources[i].statusCode >= 400) {
-  //     throw new Error(
-  //         `Redirect ${redirectModule.filename} has an invalid status code ${sources[i].statusCode}.` +
-  //         `Status code must be in the 3xx range.`
-  //     );
-  //   }
-  // }
 };
 
 export const validateConfig = (
   filename: string,
-  redirectConfigInternal: TemplateConfigInternal
+  redirectConfigInternal: RedirectConfigInternal
 ) => {
   if (!redirectConfigInternal.name) {
     throw new Error(

--- a/packages/pages/src/common/src/redirect/internal/validateRedirectModuleInternal.ts
+++ b/packages/pages/src/common/src/redirect/internal/validateRedirectModuleInternal.ts
@@ -1,0 +1,48 @@
+import { RedirectModuleInternal } from "./types.js";
+import { TemplateConfigInternal } from "../../template/internal/types.js";
+
+export const validateRedirectModuleInternal = (
+  redirectModule: RedirectModuleInternal<any>
+) => {
+  validateConfig(redirectModule.filename, redirectModule.config);
+
+  if (!redirectModule.getDestination) {
+    throw new Error(
+      `Redirect ${redirectModule.filename} is missing an exported getDestination function.`
+    );
+  }
+
+  if (!redirectModule.getSources) {
+    throw new Error(
+      `Redirect ${redirectModule.filename} is missing an exported getSources function.`
+    );
+  }
+
+  // TODO - make this check work
+  // const sources = redirectModule.getSources({});
+  // for (let i = 0; i < sources.length; i++) {
+  //   if (sources[i].statusCode < 300 || sources[i].statusCode >= 400) {
+  //     throw new Error(
+  //         `Redirect ${redirectModule.filename} has an invalid status code ${sources[i].statusCode}.` +
+  //         `Status code must be in the 3xx range.`
+  //     );
+  //   }
+  // }
+};
+
+export const validateConfig = (
+  filename: string,
+  redirectConfigInternal: TemplateConfigInternal
+) => {
+  if (!redirectConfigInternal.name) {
+    throw new Error(
+      `Redirect ${filename} is missing a "name" in the config function.`
+    );
+  }
+
+  if (redirectConfigInternal.streamId && redirectConfigInternal.stream) {
+    throw new Error(
+      `Redirect ${filename} must not define both a "streamId" and a "stream".`
+    );
+  }
+};

--- a/packages/pages/src/common/src/redirect/loader/loader.ts
+++ b/packages/pages/src/common/src/redirect/loader/loader.ts
@@ -1,0 +1,55 @@
+import {
+  convertRedirectModuleToRedirectModuleInternal,
+  RedirectModuleInternal,
+} from "../internal/types.js";
+import { ProjectStructure } from "../../project/structure.js";
+import { loadModules } from "../../loader/vite.js";
+
+/**
+ * Loads all redirects in the project.
+ *
+ * @param redirectModulePaths the redirect filepaths to load as modules
+ * @param transpile set to true if the redirects need to be transpiled (such as when they are in tsx format)
+ * @param adjustForFingerprintedAsset removes the fingerprint portion (for server bundles)
+ * @param projectStructure the structure of the project
+ * @returns Promise<{@link RedirectModuleCollection}>
+ */
+export const loadRedirectModules = async (
+  redirectModulePaths: string[],
+  transpile: boolean,
+  adjustForFingerprintedAsset: boolean,
+  projectStructure: ProjectStructure
+): Promise<RedirectModuleCollection> => {
+  const importedModules = await loadModules(
+    redirectModulePaths,
+    transpile,
+    projectStructure
+  );
+
+  const importedRedirectModules = [] as RedirectModuleInternal<any>[];
+  for (const importedModule of importedModules) {
+    const redirectModuleInternal =
+      convertRedirectModuleToRedirectModuleInternal(
+        importedModule.path,
+        importedModule.module,
+        adjustForFingerprintedAsset
+      );
+
+    importedRedirectModules.push({
+      ...redirectModuleInternal,
+      path: importedModule.path,
+    });
+  }
+
+  return importedRedirectModules.reduce((prev, module) => {
+    if (prev.has(module.config.name)) {
+      throw new Error(
+        `Redirects must have unique feature names. Found multiple redirects with "${module.config.name}"`
+      );
+    }
+    return prev.set(module.config.name, module);
+  }, new Map());
+};
+
+// A RedirectModuleCollection is a collection of redirect modules indexed by feature name.
+export type RedirectModuleCollection = Map<string, RedirectModuleInternal<any>>;

--- a/packages/pages/src/common/src/redirect/loader/loader.ts
+++ b/packages/pages/src/common/src/redirect/loader/loader.ts
@@ -44,7 +44,7 @@ export const loadRedirectModules = async (
   return importedRedirectModules.reduce((prev, module) => {
     if (prev.has(module.config.name)) {
       throw new Error(
-        `Redirects must have unique feature names. Found multiple redirects with "${module.config.name}"`
+        `Redirects must have unique names. Found multiple redirects with name "${module.config.name}"`
       );
     }
     return prev.set(module.config.name, module);

--- a/packages/pages/src/common/src/redirect/types.ts
+++ b/packages/pages/src/common/src/redirect/types.ts
@@ -1,4 +1,4 @@
-import { TemplateConfig, TemplateProps } from "../template/types.js";
+import { TemplateProps, Stream } from "../template/types.js";
 
 export interface RedirectSource {
   source: string;
@@ -13,9 +13,27 @@ export interface RedirectSource {
  */
 export interface RedirectModule<T extends TemplateProps> {
   /** The exported config function */
-  config?: TemplateConfig;
+  config?: RedirectConfig;
+  /** The exported GetDestination function */
   getDestination: GetDestination<T>;
+  /** The exported GetSources function */
   getSources: GetSources<T>;
+}
+
+/**
+ * The exported `config` function's definition.
+ *
+ * @public
+ */
+export interface RedirectConfig {
+  /** The name of the redirect. If not defined uses the redirect filename (without extension) */
+  name?: string;
+  /** The stream that this redirect uses. If a stream is defined the streamId is not required. */
+  streamId?: string;
+  /** The stream configuration used by the redirect */
+  stream?: Stream;
+  /** The field to use as the slug for dynamic dev mode */
+  slugField?: string;
 }
 
 /**

--- a/packages/pages/src/common/src/redirect/types.ts
+++ b/packages/pages/src/common/src/redirect/types.ts
@@ -1,4 +1,38 @@
+import { TemplateConfig, TemplateProps } from "../template/types.js";
+
 export interface RedirectSource {
   source: string;
   statusCode: number;
 }
+
+/**
+ * The type to include in any redirect file. It defines the available functions and fields that are available
+ * to the redirect.
+ *
+ * @public
+ */
+export interface RedirectModule<T extends TemplateProps> {
+  /** The exported config function */
+  config?: TemplateConfig;
+  getDestination: GetDestination<T>;
+  getSources: GetSources<T>;
+}
+
+/**
+ * The type definition for the redirect's getDestination function.
+ *
+ * @public
+ */
+export type GetDestination<T extends TemplateProps> = (props: T) => string;
+
+/**
+ * The type definiton for the redirect's getSources function.
+ *
+ * @returns A list of redirect sources. All paths returned by this function will redirect to the path
+ * defined by the redirect's getDestination function.
+ *
+ * @public
+ */
+export type GetSources<T extends TemplateProps> = (
+  props: T
+) => RedirectSource[];

--- a/packages/pages/src/common/src/redirect/types.ts
+++ b/packages/pages/src/common/src/redirect/types.ts
@@ -32,8 +32,6 @@ export interface RedirectConfig {
   streamId?: string;
   /** The stream configuration used by the redirect */
   stream?: Stream;
-  /** The field to use as the slug for dynamic dev mode */
-  slugField?: string;
 }
 
 /**

--- a/packages/pages/src/common/src/template/internal/types.ts
+++ b/packages/pages/src/common/src/template/internal/types.ts
@@ -189,7 +189,7 @@ export const convertTemplateConfigToTemplateConfigInternal = (
  * Converts a {@link Stream} into a valid {@link StreamInternal}
  * by setting stream.localization.primary: false if a locales array exists.
  */
-const convertStreamToStreamInternal = (
+export const convertStreamToStreamInternal = (
   stream: Stream | undefined
 ): StreamInternal | undefined => {
   if (!stream) return;

--- a/packages/pages/src/common/src/template/loader/loader.ts
+++ b/packages/pages/src/common/src/template/loader/loader.ts
@@ -14,6 +14,7 @@ import { TemplateModule } from "../types.js";
  * @param templateModulePaths the templates filepaths to load as modules
  * @param transpile set to true if the templates need to be transpiled (such as when they are in tsx format)
  * @param adjustForFingerprintedAsset removes the fingerprint portion (for server bundles)
+ * @param projectStructure the structure of the project
  * @returns Promise<{@link TemplateModuleCollection}>
  */
 export const loadTemplateModules = async (

--- a/packages/pages/src/common/src/template/types.ts
+++ b/packages/pages/src/common/src/template/types.ts
@@ -185,6 +185,10 @@ export type Manifest = {
   serverPaths: {
     [key: string]: string;
   };
+  /** A map of feature name to the redirect path of the feature */
+  redirectPaths: {
+    [key: string]: string;
+  };
   /** A map of feature name to the client path of the feature */
   clientPaths: {
     [key: string]: string;

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -59,7 +59,10 @@ export const generateTestDataForSlug = async (
     }
   }
 
-  const featuresConfig = getTemplatesConfig(templateModuleCollection);
+  const featuresConfig = getTemplatesConfig(
+    templateModuleCollection,
+    undefined
+  );
   const featuresConfigForEntityPages: FeaturesConfig = {
     features: featuresConfig.features.filter((f) => "entityPageSet" in f),
     streams: featuresConfig.streams,

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -59,10 +59,7 @@ export const generateTestDataForSlug = async (
     }
   }
 
-  const featuresConfig = getTemplatesConfig(
-    templateModuleCollection,
-    undefined
-  );
+  const featuresConfig = getTemplatesConfig(templateModuleCollection);
   const featuresConfigForEntityPages: FeaturesConfig = {
     features: featuresConfig.features.filter((f) => "entityPageSet" in f),
     streams: featuresConfig.streams,

--- a/packages/pages/src/generate/artifacts/createArtifactsJson.test.ts
+++ b/packages/pages/src/generate/artifacts/createArtifactsJson.test.ts
@@ -34,7 +34,7 @@ describe("createArtifactsJson - getArtifactsConfig", () => {
               {
                 root: "dist",
                 pattern:
-                  "assets/{server,static,renderer,render,client}/**/*{.js,.css}",
+                  "assets/{server,static,renderer,render,client,redirect}/**/*{.js,.css}",
               },
             ],
             event: "ON_PAGE_GENERATE",

--- a/packages/pages/src/generate/artifacts/createArtifactsJson.ts
+++ b/packages/pages/src/generate/artifacts/createArtifactsJson.ts
@@ -110,6 +110,7 @@ const getGeneratorPlugin = (projectStructure: ProjectStructure): Plugin => {
     renderer,
     clientBundle,
     serverBundle,
+    redirectBundle,
     static: _static,
     renderBundle,
     plugin,
@@ -124,7 +125,7 @@ const getGeneratorPlugin = (projectStructure: ProjectStructure): Plugin => {
       },
       {
         root: `${rootFolders.dist}`,
-        pattern: `${assets}/{${serverBundle},${_static},${renderer},${renderBundle},${clientBundle}}/**/*{.js,.css}`,
+        pattern: `${assets}/{${serverBundle},${_static},${renderer},${renderBundle},${clientBundle},${redirectBundle}}/**/*{.js,.css}`,
       },
     ],
     event: "ON_PAGE_GENERATE",

--- a/packages/pages/src/generate/features/features.ts
+++ b/packages/pages/src/generate/features/features.ts
@@ -3,15 +3,24 @@ import { getTemplateFilepaths } from "../../common/src/template/internal/getTemp
 import { Command } from "commander";
 import { createTemplatesJson } from "../templates/createTemplatesJson.js";
 import { logErrorAndExit } from "../../util/logError.js";
+import { getRedirectFilePaths } from "../../common/src/redirect/internal/getRedirectFilepaths.js";
 
 const handler = async ({ scope }: { scope: string }): Promise<void> => {
   const projectStructure = await ProjectStructure.init({ scope });
   const templateFilepaths = getTemplateFilepaths(
     projectStructure.getTemplatePaths()
   );
+  const redirectFilepaths = getRedirectFilePaths(
+    projectStructure.getRedirectPaths()
+  );
 
   try {
-    await createTemplatesJson(templateFilepaths, projectStructure, "FEATURES");
+    await createTemplatesJson(
+      templateFilepaths,
+      redirectFilepaths,
+      projectStructure,
+      "FEATURES"
+    );
   } catch (error) {
     logErrorAndExit(error);
   }

--- a/packages/pages/src/generate/templates/createTemplatesJson.test.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJson.test.ts
@@ -54,7 +54,6 @@ describe("createTemplatesJsonFromModule - getFeaturesConfig", () => {
     redirectModules.set("closed-location", {
       config: {
         name: "closed-location",
-        redirectType: "entity",
         streamId: "closed-location-stream",
         stream: {
           $id: "closed-location-stream",

--- a/packages/pages/src/generate/templates/createTemplatesJson.test.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJson.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { FeaturesConfig } from "../../common/src/feature/features.js";
 import { TemplateModuleCollection } from "../../common/src/template/loader/loader.js";
 import { getTemplatesConfig } from "./createTemplatesJson.js";
+import { RedirectModuleCollection } from "../../common/src/redirect/loader/loader.js";
+import { RedirectSource } from "../../common/src/redirect/types.js";
 
 describe("createTemplatesJsonFromModule - getFeaturesConfig", () => {
   it("creates the proper default templates structure", async () => {
@@ -48,6 +50,41 @@ describe("createTemplatesJsonFromModule - getFeaturesConfig", () => {
       },
     });
 
+    const redirectModules: RedirectModuleCollection = new Map();
+    redirectModules.set("closed-location", {
+      config: {
+        name: "closed-location",
+        hydrate: false,
+        templateType: "entity",
+        streamId: "closed-location-stream",
+        stream: {
+          $id: "closed-location-stream",
+          fields: ["foo"],
+          filter: {
+            entityIds: ["97807061"],
+          },
+          localization: {
+            locales: ["en"],
+            primary: false,
+          },
+        },
+      },
+      filename: "closed-location.tsx",
+      getDestination(): string {
+        return "";
+      },
+      getSources(): RedirectSource[] {
+        return [
+          {
+            source: "nomoretacos.com",
+            statusCode: 301,
+          },
+        ];
+      },
+      path: "src/redirects/closed-location.tsx",
+      redirectName: "closed-location",
+    });
+
     const expected: FeaturesConfig = {
       features: [
         {
@@ -60,6 +97,13 @@ describe("createTemplatesJsonFromModule - getFeaturesConfig", () => {
         {
           name: "location",
           streamId: "location-stream",
+          templateType: "JS",
+          entityPageSet: {},
+          alternateLanguageFields: undefined,
+        },
+        {
+          name: "closed-location",
+          streamId: "closed-location-stream",
           templateType: "JS",
           entityPageSet: {},
           alternateLanguageFields: undefined,
@@ -82,9 +126,24 @@ describe("createTemplatesJsonFromModule - getFeaturesConfig", () => {
           source: "knowledgeGraph",
           destination: "pages",
         },
+        {
+          $id: "closed-location-stream",
+          filter: {
+            entityIds: ["97807061"],
+          },
+          fields: ["foo"],
+          localization: {
+            locales: ["en"],
+            primary: false,
+          },
+          source: "knowledgeGraph",
+          destination: "pages",
+        },
       ],
     };
 
-    expect(getTemplatesConfig(templateModules)).toEqual(expected);
+    expect(getTemplatesConfig(templateModules, redirectModules)).toEqual(
+      expected
+    );
   });
 });

--- a/packages/pages/src/generate/templates/createTemplatesJson.test.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJson.test.ts
@@ -54,8 +54,7 @@ describe("createTemplatesJsonFromModule - getFeaturesConfig", () => {
     redirectModules.set("closed-location", {
       config: {
         name: "closed-location",
-        hydrate: false,
-        templateType: "entity",
+        redirectType: "entity",
         streamId: "closed-location-stream",
         stream: {
           $id: "closed-location-stream",

--- a/packages/pages/src/generate/templates/createTemplatesJson.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJson.ts
@@ -5,11 +5,13 @@ import {
   FeaturesConfig,
   FeatureConfig,
   convertTemplateConfigToFeatureConfig,
+  convertRedirectConfigToFeatureConfig,
 } from "../../common/src/feature/features.js";
 import { ProjectStructure } from "../../common/src/project/structure.js";
 import {
   StreamConfig,
-  convertConfigToStreamConfig,
+  convertTemplateConfigToStreamConfig,
+  convertRedirectConfigToStreamConfig,
 } from "../../common/src/feature/stream.js";
 import {
   TemplateModuleCollection,
@@ -114,23 +116,23 @@ export const createTemplatesJsonFromModule = async (
 
 export const getTemplatesConfig = (
   templateModules: TemplateModuleCollection,
-  redirectModules: RedirectModuleCollection | undefined
+  redirectModules?: RedirectModuleCollection
 ): FeaturesConfig => {
   const features: FeatureConfig[] = [];
   const streams: StreamConfig[] = [];
   for (const module of templateModules.values()) {
     const featureConfig = convertTemplateConfigToFeatureConfig(module.config);
     features.push(featureConfig);
-    const streamConfig = convertConfigToStreamConfig(module.config);
+    const streamConfig = convertTemplateConfigToStreamConfig(module.config);
     if (streamConfig) {
       pushStreamConfigIfValid(streams, streamConfig);
     }
   }
   if (redirectModules) {
     for (const module of redirectModules.values()) {
-      const featureConfig = convertTemplateConfigToFeatureConfig(module.config);
+      const featureConfig = convertRedirectConfigToFeatureConfig(module.config);
       features.push(featureConfig);
-      const streamConfig = convertConfigToStreamConfig(module.config);
+      const streamConfig = convertRedirectConfigToStreamConfig(module.config);
       if (streamConfig) {
         pushStreamConfigIfValid(streams, streamConfig);
       }

--- a/packages/pages/src/generate/templates/templates.ts
+++ b/packages/pages/src/generate/templates/templates.ts
@@ -2,6 +2,7 @@ import { ProjectStructure } from "../../common/src/project/structure.js";
 import { getTemplateFilepaths } from "../../common/src/template/internal/getTemplateFilepaths.js";
 import { createTemplatesJson } from "./createTemplatesJson.js";
 import { Command } from "commander";
+import { getRedirectFilePaths } from "../../common/src/redirect/internal/getRedirectFilepaths.js";
 
 export const templatesHandler = async ({
   scope,
@@ -12,8 +13,16 @@ export const templatesHandler = async ({
   const templateFilepaths = getTemplateFilepaths(
     projectStructure.getTemplatePaths()
   );
+  const redirectFilepaths = getRedirectFilePaths(
+    projectStructure.getRedirectPaths()
+  );
 
-  await createTemplatesJson(templateFilepaths, projectStructure, "TEMPLATES");
+  await createTemplatesJson(
+    templateFilepaths,
+    redirectFilepaths,
+    projectStructure,
+    "TEMPLATES"
+  );
 };
 
 export const templatesCommand = (program: Command) => {

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/redirectUtils.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/redirectUtils.ts
@@ -1,0 +1,67 @@
+import {
+  convertRedirectModuleToRedirectModuleInternal,
+  RedirectModuleInternal,
+} from "../../../../common/src/redirect/internal/types.js";
+import {
+  Manifest,
+  TemplateProps,
+} from "../../../../common/src/template/types.js";
+import { ProjectStructure } from "../../../../common/src/project/structure.js";
+import {
+  RedirectModule,
+  RedirectSource,
+} from "../../../../common/src/redirect/types.js";
+
+const pathToRedirectModule = new Map<string, RedirectModule<any>>();
+
+export type GeneratedRedirect = {
+  sources: RedirectSource[];
+  destination: string;
+};
+
+/**
+ * @returns an array of redirect modules matching the document's feature.
+ */
+export const readRedirectModules = async (
+  feature: string,
+  manifest: Manifest,
+  projectStructure: ProjectStructure
+): Promise<RedirectModuleInternal<any> | undefined> => {
+  if (!manifest.redirectPaths[feature]) {
+    return;
+  }
+  const path = manifest.redirectPaths[feature].replace(
+    projectStructure.config.subfolders.assets,
+    ".."
+  );
+  let importedModule = pathToRedirectModule.get(path) as RedirectModule<any>;
+  if (!importedModule) {
+    importedModule = await import(path);
+    pathToRedirectModule.set(path, importedModule);
+  }
+
+  return convertRedirectModuleToRedirectModuleInternal(
+    path,
+    importedModule,
+    true
+  );
+};
+
+/**
+ * Takes in both a redirect module and its stream document, processes them, and writes them to disk.
+ *
+ * @param redirectModuleInternal
+ * @param templateProps
+ */
+export const generateRedirectResponses = async (
+  redirectModuleInternal: RedirectModuleInternal<any>,
+  templateProps: TemplateProps
+): Promise<GeneratedRedirect> => {
+  const destination = redirectModuleInternal.getDestination(templateProps);
+  const sources = redirectModuleInternal.getSources(templateProps);
+
+  return {
+    sources: sources,
+    destination: destination,
+  };
+};

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
@@ -4,11 +4,16 @@ import {
   TemplateProps,
 } from "../../../../common/src/template/types.js";
 import {
-  generateResponses,
-  readTemplateModules,
   GeneratedPage,
+  generateTemplateResponses,
   getPluginRenderTemplates,
+  readTemplateModules,
 } from "./templateUtils.js";
+import {
+  GeneratedRedirect,
+  generateRedirectResponses,
+  readRedirectModules,
+} from "./redirectUtils.js";
 
 /**
  * This function is the main rendering function which is imported and executed in the Deno runtime
@@ -23,25 +28,37 @@ import {
 export default async (
   props: TemplateProps,
   manifest: Manifest
-): Promise<GeneratedPage> => {
+): Promise<GeneratedPage | GeneratedRedirect> => {
   const projectStructure = new ProjectStructure(manifest.projectStructure);
+  const feature = props.document.__.name;
   const template = await readTemplateModules(
-    props.document.__.name,
+    feature,
     manifest,
     projectStructure
   );
-  const pluginRenderTemplates = await getPluginRenderTemplates(
-    manifest,
-    projectStructure
-  );
-
-  const responses = await generateResponses(
-    template,
-    props,
-    pluginRenderTemplates,
+  const redirect = await readRedirectModules(
+    feature,
     manifest,
     projectStructure
   );
 
-  return responses;
+  if (template) {
+    const pluginRenderTemplates = await getPluginRenderTemplates(
+      manifest,
+      projectStructure
+    );
+    return await generateTemplateResponses(
+      template,
+      props,
+      pluginRenderTemplates,
+      manifest,
+      projectStructure
+    );
+  }
+
+  if (redirect) {
+    return await generateRedirectResponses(redirect, props);
+  }
+
+  throw new Error(`Could not find path for feature ${feature}`);
 };

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
@@ -31,17 +31,12 @@ export default async (
 ): Promise<GeneratedPage | GeneratedRedirect> => {
   const projectStructure = new ProjectStructure(manifest.projectStructure);
   const feature = props.document.__.name;
+
   const template = await readTemplateModules(
     feature,
     manifest,
     projectStructure
   );
-  const redirect = await readRedirectModules(
-    feature,
-    manifest,
-    projectStructure
-  );
-
   if (template) {
     const pluginRenderTemplates = await getPluginRenderTemplates(
       manifest,
@@ -56,6 +51,11 @@ export default async (
     );
   }
 
+  const redirect = await readRedirectModules(
+    feature,
+    manifest,
+    projectStructure
+  );
   if (redirect) {
     return await generateRedirectResponses(redirect, props);
   }

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.test.tsx
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.test.tsx
@@ -6,7 +6,7 @@ import {
   TemplateProps,
   Manifest,
 } from "../../../../common/src/template/types.js";
-import { generateResponses } from "./templateUtils.js";
+import { generateTemplateResponses } from "./templateUtils.js";
 import path from "node:path";
 import { ProjectStructure } from "../../../../common/src/project/structure.js";
 
@@ -27,6 +27,7 @@ const baseTemplateModule: TemplateModuleInternal<any, any> = {
 
 const manifest: Manifest = {
   serverPaths: {},
+  redirectPaths: {},
   clientPaths: {},
   renderPaths: {},
   projectStructure: new ProjectStructure().config,
@@ -59,7 +60,7 @@ describe("generateResponses", () => {
 
   it("calls transformProps when transformProps is defined", async () => {
     const fn = vi.fn((props) => props);
-    await generateResponses(
+    await generateTemplateResponses(
       { ...baseTemplateModule, transformProps: fn },
       baseProps,
       {
@@ -77,7 +78,7 @@ describe("generateResponses", () => {
 
   it("calls getRedirects when getRedirects is defined", async () => {
     const fn = vi.fn();
-    await generateResponses(
+    await generateTemplateResponses(
       { ...baseTemplateModule, getRedirects: fn },
       baseProps,
       {

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
@@ -1,9 +1,9 @@
 import {
+  Manifest,
+  ServerRenderTemplate,
+  TemplateModule,
   TemplateProps,
   TemplateRenderProps,
-  Manifest,
-  TemplateModule,
-  ServerRenderTemplate,
 } from "../../../../common/src/template/types.js";
 import { getRelativePrefixToRootFromPath } from "../../../../common/src/template/paths.js";
 import { reactWrapper } from "./wrapper.js";
@@ -24,27 +24,26 @@ export const readTemplateModules = async (
   feature: string,
   manifest: Manifest,
   projectStructure: ProjectStructure
-): Promise<TemplateModuleInternal<any, any>> => {
+): Promise<TemplateModuleInternal<any, any> | undefined> => {
+  if (!manifest.serverPaths[feature]) {
+    return;
+  }
+
   const path = manifest.serverPaths[feature].replace(
     projectStructure.config.subfolders.assets,
     ".."
   );
-  if (!path) {
-    throw new Error(`Could not find path for feature ${feature}`);
-  }
   let importedModule = pathToModule.get(path) as TemplateModule<any, any>;
   if (!importedModule) {
     importedModule = await import(path);
     pathToModule.set(path, importedModule);
   }
 
-  const templateModuleInternal = convertTemplateModuleToTemplateModuleInternal(
+  return convertTemplateModuleToTemplateModuleInternal(
     path,
     importedModule,
     true
   );
-
-  return templateModuleInternal;
 };
 
 /** The render template information needed by the plugin execution */
@@ -109,8 +108,9 @@ export type GeneratedPage = {
  * @param templateProps
  * @param pluginRenderTemplates
  * @param manifest
+ * @param projectStructure
  */
-export const generateResponses = async (
+export const generateTemplateResponses = async (
   templateModuleInternal: TemplateModuleInternal<any, any>,
   templateProps: TemplateProps,
   pluginRenderTemplates: PluginRenderTemplates,

--- a/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
@@ -23,6 +23,7 @@ import {
   loadRedirectModules,
   RedirectModuleCollection,
 } from "../../../common/src/redirect/loader/loader.js";
+import { getRedirectFilePathsFromProjectStructure } from "../../../common/src/redirect/internal/getRedirectFilepaths.js";
 
 export default (projectStructure: ProjectStructure) => {
   return {
@@ -65,45 +66,19 @@ export default (projectStructure: ProjectStructure) => {
             ],
           }
         );
-        const redirectBundles = glob.sync(
-          convertToPosixPath(
-            path.join(
-              path.resolve(
-                rootFolders.dist,
-                subfolders.assets,
-                subfolders.serverBundle
-              ),
-              "**/*.js"
-            )
-          ),
-          {
-            ignore: [
-              path.join(
-                path.resolve(rootFolders.dist, subfolders.serverlessFunctions),
-                "**"
-              ),
-              path.join(
-                path.resolve(rootFolders.dist, subfolders.modules),
-                "**"
-              ),
-              path.join(
-                path.resolve(rootFolders.dist, subfolders.templates),
-                "**"
-              ),
-            ],
-          }
-        );
-
         templateModules = await loadTemplateModules(
           serverBundles,
           false,
           true,
           projectStructure
         );
+
+        const redirectPaths =
+          getRedirectFilePathsFromProjectStructure(projectStructure);
         redirectModules = await loadRedirectModules(
-          redirectBundles,
-          false,
+          redirectPaths,
           true,
+          false,
           projectStructure
         );
 

--- a/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
+++ b/packages/pages/src/vite-plugin/build/closeBundle/closeBundle.ts
@@ -19,6 +19,10 @@ import { logErrorAndClean } from "../../../util/logError.js";
 import { isUsingConfig } from "../../../util/config.js";
 import { createArtifactsJson } from "../../../generate/artifacts/createArtifactsJson.js";
 import { Path } from "../../../common/src/project/path.js";
+import {
+  loadRedirectModules,
+  RedirectModuleCollection,
+} from "../../../common/src/redirect/loader/loader.js";
 
 export default (projectStructure: ProjectStructure) => {
   return {
@@ -28,6 +32,7 @@ export default (projectStructure: ProjectStructure) => {
         startLog: "Validating template modules",
       });
       let templateModules: TemplateModuleCollection;
+      let redirectModules: RedirectModuleCollection;
 
       const { rootFolders, subfolders } = projectStructure.config;
 
@@ -53,12 +58,50 @@ export default (projectStructure: ProjectStructure) => {
                 path.resolve(rootFolders.dist, subfolders.modules),
                 "**"
               ),
+              path.join(
+                path.resolve(rootFolders.dist, subfolders.redirects),
+                "**"
+              ),
+            ],
+          }
+        );
+        const redirectBundles = glob.sync(
+          convertToPosixPath(
+            path.join(
+              path.resolve(
+                rootFolders.dist,
+                subfolders.assets,
+                subfolders.serverBundle
+              ),
+              "**/*.js"
+            )
+          ),
+          {
+            ignore: [
+              path.join(
+                path.resolve(rootFolders.dist, subfolders.serverlessFunctions),
+                "**"
+              ),
+              path.join(
+                path.resolve(rootFolders.dist, subfolders.modules),
+                "**"
+              ),
+              path.join(
+                path.resolve(rootFolders.dist, subfolders.templates),
+                "**"
+              ),
             ],
           }
         );
 
         templateModules = await loadTemplateModules(
           serverBundles,
+          false,
+          true,
+          projectStructure
+        );
+        redirectModules = await loadRedirectModules(
+          redirectBundles,
           false,
           true,
           projectStructure
@@ -94,6 +137,7 @@ export default (projectStructure: ProjectStructure) => {
         try {
           createTemplatesJsonFromModule(
             templateModules,
+            redirectModules,
             projectStructure,
             "TEMPLATES"
           );
@@ -107,6 +151,7 @@ export default (projectStructure: ProjectStructure) => {
         try {
           createTemplatesJsonFromModule(
             templateModules,
+            redirectModules,
             projectStructure,
             "FEATURES"
           );

--- a/playground/locations-site/src/redirects/closed-locations.tsx
+++ b/playground/locations-site/src/redirects/closed-locations.tsx
@@ -1,0 +1,43 @@
+import {
+  RedirectConfig,
+  TemplateProps,
+  GetDestination,
+  GetSources,
+} from "@yext/pages";
+
+export const config: RedirectConfig = {
+  stream: {
+    $id: "closed-location-redirects",
+    fields: ["slug"],
+    filter: {
+      entityTypes: ["location"],
+    },
+    localization: {
+      locales: ["en"],
+    },
+  },
+};
+
+/**
+ * Defines the URL to redirect the source paths to.
+ */
+export const getDestination: GetDestination<TemplateProps> = ({ document }) => {
+  return document.c_feedbackUrl;
+};
+
+/**
+ * Defines a list of redirect source objects, which will redirect to the URL created by getDestination.
+ */
+
+export const getSources: GetSources<TemplateProps> = ({ document }) => {
+  return [
+    {
+      source: `${document.c_nmlsID}`,
+      status: 301,
+    },
+    {
+      source: `${document.c_temporary_alias}`,
+      status: 302,
+    },
+  ];
+};

--- a/playground/multibrand-site/src/redirects/sunglasses.oakley.com/closed-locations.tsx
+++ b/playground/multibrand-site/src/redirects/sunglasses.oakley.com/closed-locations.tsx
@@ -1,0 +1,43 @@
+import {
+  RedirectConfig,
+  TemplateProps,
+  GetDestination,
+  GetSources,
+} from "@yext/pages";
+
+export const config: RedirectConfig = {
+  stream: {
+    $id: "closed-oakley-redirects",
+    fields: ["slug"],
+    filter: {
+      savedFilterIds: ["1241548641"],
+    },
+    localization: {
+      locales: ["en"],
+    },
+  },
+};
+
+/**
+ * Defines the URL to redirect the source paths to.
+ */
+export const getDestination: GetDestination<TemplateProps> = ({ document }) => {
+  return document.c_feedbackUrl;
+};
+
+/**
+ * Defines a list of redirect source objects, which will redirect to the URL created by getDestination.
+ */
+
+export const getSources: GetSources<TemplateProps> = ({ document }) => {
+  return [
+    {
+      source: `${document.c_nmlsID}`,
+      status: 301,
+    },
+    {
+      source: `${document.c_temporary_alias}`,
+      status: 302,
+    },
+  ];
+};

--- a/playground/multibrand-site/src/redirects/sunglasses.rayban.com/closed-locations.tsx
+++ b/playground/multibrand-site/src/redirects/sunglasses.rayban.com/closed-locations.tsx
@@ -1,0 +1,43 @@
+import {
+  RedirectConfig,
+  TemplateProps,
+  GetDestination,
+  GetSources,
+} from "@yext/pages";
+
+export const config: RedirectConfig = {
+  stream: {
+    $id: "closed-rayban-redirects",
+    fields: ["slug"],
+    filter: {
+      savedFilterIds: ["1241554040"],
+    },
+    localization: {
+      locales: ["en"],
+    },
+  },
+};
+
+/**
+ * Defines the URL to redirect the source paths to.
+ */
+export const getDestination: GetDestination<TemplateProps> = ({ document }) => {
+  return document.c_feedbackUrl;
+};
+
+/**
+ * Defines a list of redirect source objects, which will redirect to the URL created by getDestination.
+ */
+
+export const getSources: GetSources<TemplateProps> = ({ document }) => {
+  return [
+    {
+      source: `${document.c_nmlsID}`,
+      status: 301,
+    },
+    {
+      source: `${document.c_temporary_alias}`,
+      status: 302,
+    },
+  ];
+};


### PR DESCRIPTION
Users can now add redirects through src/redirects, similar to how templates are setup.

Redirect files are validated during npm run dev.

Redirect files should include GetDestination and GetSources functions.

Ran npx pages generate templates and saw that src/redirects files were added to templates.json.

Had similar results for generating features.json.

Tested using scopes.

Using the example here: https://docs.google.com/document/d/1DwfIAGjsrgDejUVBRv0buFlXFxVRCTMrbMfABg4ZrH4 in the locations-starter repo under src/redirects, this snippet is added to templates and features.json: 
```
    {
      "name": "closed-locations",
      "streamId": "closed-location-redirects",
      "templateType": "JS",
      "entityPageSet": {}
    }
```
This stream definition is added to templates.json:
```
    {
      "$id": "closed-location-redirects",
      "fields": [
        "id",
        "name",
        "address",
        "slug"
      ],
      "filter": {
        "entityIds": [
          "location9"
        ]
      },
      "localization": {
        "locales": [
          "en"
        ],
        "primary": false
      },
      "source": "knowledgeGraph",
      "destination": "pages"
    }
```