### PR TITLE
feat(dev/plugin): update isProduction logic

### DIFF
--- a/packages/pages/src/util/env.test.ts
+++ b/packages/pages/src/util/env.test.ts
@@ -1,162 +1,53 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
 import { isProduction } from "./env.js";
-import * as runTime from "./runtime.js";
 
 describe("isProduction", () => {
-  it("returns true when browser and prod domain", async () => {
-    const runtimeSpy = vi.spyOn(runTime, "getRuntime") as unknown as any;
-    runtimeSpy.mockImplementation(() => ({
-      name: "browser",
-    }));
-
-    const domain = "prod.com";
-
+  it("returns true when IS_PRODUCTION is true", async () => {
     const windowSpy = vi.spyOn(window, "window", "get") as unknown as any;
     windowSpy.mockImplementation(() => ({
-      location: {
-        hostname: "prod.com",
-      },
-    }));
-
-    expect(isProduction(domain)).toBeTruthy();
-
-    windowSpy.mockRestore();
-    runtimeSpy.mockRestore();
-  });
-
-  it("returns false when not browser and prod domain", async () => {
-    const runtimeSpy = vi.spyOn(runTime, "getRuntime") as unknown as any;
-    runtimeSpy.mockImplementation(() => ({
-      name: "node",
-    }));
-
-    const domain = "prod.com";
-
-    const windowSpy = vi.spyOn(window, "window", "get") as unknown as any;
-    windowSpy.mockImplementation(() => ({
-      location: {
-        hostname: "prod.com",
-      },
-    }));
-
-    expect(isProduction(domain)).toBeFalsy();
-
-    windowSpy.mockRestore();
-    runtimeSpy.mockRestore();
-  });
-
-  it("returns false when browser and staging domain", async () => {
-    const runtimeSpy = vi.spyOn(runTime, "getRuntime") as unknown as any;
-    runtimeSpy.mockImplementation(() => ({
-      name: "browser",
-    }));
-
-    const windowSpy = vi.spyOn(window, "window", "get") as unknown as any;
-    windowSpy.mockImplementation(() => ({
-      location: {
-        hostname: "staging.com",
-      },
-    }));
-
-    expect(isProduction("prod.com")).toBeFalsy();
-
-    windowSpy.mockRestore();
-    runtimeSpy.mockRestore();
-  });
-
-  it("returns false when browser and staging domain and multiple allowed prod domains", async () => {
-    const runtimeSpy = vi.spyOn(runTime, "getRuntime") as unknown as any;
-    runtimeSpy.mockImplementation(() => ({
-      name: "browser",
-    }));
-
-    const windowSpy = vi.spyOn(window, "window", "get") as unknown as any;
-    windowSpy.mockImplementation(() => ({
-      location: {
-        hostname: "staging.com",
-      },
-    }));
-
-    expect(isProduction("prod1.com", "prod2.com")).toBeFalsy();
-
-    windowSpy.mockRestore();
-    runtimeSpy.mockRestore();
-  });
-
-  it("returns true when browser and prod domain and multiple allowed prod domains", async () => {
-    const runtimeSpy = vi.spyOn(runTime, "getRuntime") as unknown as any;
-    runtimeSpy.mockImplementation(() => ({
-      name: "browser",
-    }));
-
-    const windowSpy = vi.spyOn(window, "window", "get") as unknown as any;
-    windowSpy.mockImplementation(() => ({
-      location: {
-        hostname: "prod1.com",
-      },
-    }));
-
-    expect(isProduction("prod1.com", "prod2.com")).toBeTruthy();
-
-    windowSpy.mockRestore();
-    runtimeSpy.mockRestore();
-  });
-
-  it("returns true when browser and prod domain and no prod domains specified", async () => {
-    const runtimeSpy = vi.spyOn(runTime, "getRuntime") as unknown as any;
-    runtimeSpy.mockImplementation(() => ({
-      name: "browser",
-    }));
-
-    const windowSpy = vi.spyOn(window, "window", "get") as unknown as any;
-    windowSpy.mockImplementation(() => ({
-      location: {
-        hostname: "prod.com",
-      },
+      IS_PRODUCTION: true,
     }));
 
     expect(isProduction()).toBeTruthy();
 
     windowSpy.mockRestore();
-    runtimeSpy.mockRestore();
   });
 
-  it("returns false when browser and localhost and no prod domains specified", async () => {
-    const runtimeSpy = vi.spyOn(runTime, "getRuntime") as unknown as any;
-    runtimeSpy.mockImplementation(() => ({
-      name: "browser",
-    }));
-
+  it("returns true when IS_PRODUCTION is true and domains passed", async () => {
     const windowSpy = vi.spyOn(window, "window", "get") as unknown as any;
     windowSpy.mockImplementation(() => ({
-      location: {
-        hostname: "localhost",
-      },
+      IS_PRODUCTION: true,
+    }));
+
+    expect(isProduction("random")).toBeTruthy();
+
+    windowSpy.mockRestore();
+  });
+
+  it("returns false when IS_PRODUCTION is false", async () => {
+    const windowSpy = vi.spyOn(window, "window", "get") as unknown as any;
+    windowSpy.mockImplementation(() => ({
+      IS_PRODUCTION: false,
     }));
 
     expect(isProduction()).toBeFalsy();
 
     windowSpy.mockRestore();
-    runtimeSpy.mockRestore();
   });
 
-  it("returns false when browser and preview domain and no prod domains specified", async () => {
-    const runtimeSpy = vi.spyOn(runTime, "getRuntime") as unknown as any;
-    runtimeSpy.mockImplementation(() => ({
-      name: "browser",
-    }));
-
+  it("returns false when IS_PRODUCTION is false and domains passed", async () => {
     const windowSpy = vi.spyOn(window, "window", "get") as unknown as any;
     windowSpy.mockImplementation(() => ({
-      location: {
-        hostname: "test.preview.pagescdn.com",
-      },
+      IS_PRODUCTION: false,
     }));
 
-    expect(isProduction()).toBeFalsy();
+    expect(isProduction("random")).toBeFalsy();
 
     windowSpy.mockRestore();
-    runtimeSpy.mockRestore();
+  });
+
+  it("returns false when IS_PRODUCTION is not defined", async () => {
+    expect(isProduction()).toBeFalsy();
   });
 });

--- a/packages/pages/src/util/env.ts
+++ b/packages/pages/src/util/env.ts
@@ -1,32 +1,25 @@
-import { getRuntime } from "./runtime.js";
-
 /**
  * Determines if the code is being executed on the production site on
  * the client. This is useful for things like firing analytics only
  * in production (opposed to dev or staging) and not during server side
- * rendering. If one or more domains are provided, the current hostname
- * must match one of them in order to be considered a production domain.
- * If no domains are provided, all hostnames are considered production
- * domains except for localhost and preview.pagescdn.com.
+ * rendering. The domains list has been deprecated and is no longer used.
+ * A client-side variable, IS_PRODUCTION, is now injected at serving time.
  *
- * @param domains The specified production domains of the site
+ * @param domains - Deprecated: The specified production domains of the site
  *
  * @public
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const isProduction = (...domains: string[]): boolean => {
-  const runtime = getRuntime();
-  if (runtime.name !== "browser") {
-    return false;
+  if (typeof window !== "undefined") {
+    // Previously users would pass in the siteDomain from the document, however this lead
+    // to incorrect cases where a domain is set after the deploy was made. The document
+    // remains the same for the deploy, so then isProduction() would incorrectly evaluate to
+    // false. Now this global var is injected at serving time, so it is always correct.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return window.IS_PRODUCTION || false;
   }
 
-  const currentHostname: string = window?.location?.hostname;
-
-  if (domains.length === 0) {
-    return (
-      currentHostname !== "localhost" &&
-      !currentHostname.includes("preview.pagescdn.com")
-    );
-  }
-
-  return domains.some((domain) => domain?.includes(currentHostname));
+  return false;
 };


### PR DESCRIPTION
Instead of requiring a list of prod domains to check against, isProduction now uses the IS_PRODUCTION global variable which is guaranteed to be correct as it's injected by the serving layer.