### PR TITLE
fix(plugin): use the user's vite.config

### DIFF
--- a/packages/pages/src/util/viteConfig.ts
+++ b/packages/pages/src/util/viteConfig.ts
@@ -18,9 +18,10 @@ export const scopedViteConfigPath = (scope?: string) => {
 };
 
 export const removePluginFromViteConfig = (config: any) => {
-  if (config?.plugins) {
+  if (config?.plugins?.[0]) {
     config.plugins = config.plugins?.[0]?.filter(
-      (obj: any) => obj.name !== "vite:react-refresh"
+      (obj: any) =>
+        obj.name !== "vite:react-refresh" || obj.name !== "vite:react-babel"
     );
   }
   return config;

--- a/packages/pages/src/util/viteConfig.ts
+++ b/packages/pages/src/util/viteConfig.ts
@@ -18,11 +18,8 @@ export const scopedViteConfigPath = (scope?: string) => {
 };
 
 export const removePluginFromViteConfig = (config: any) => {
-  if (config?.plugins?.[0]) {
-    config.plugins = config.plugins?.[0]?.filter(
-      (obj: any) =>
-        obj.name !== "vite:react-refresh" || obj.name !== "vite:react-babel"
-    );
+  if (config?.plugins) {
+    config.plugins = "";
   }
   return config;
 };

--- a/packages/pages/src/util/viteConfig.ts
+++ b/packages/pages/src/util/viteConfig.ts
@@ -16,3 +16,12 @@ export const scopedViteConfigPath = (scope?: string) => {
     return viteConfigPath;
   }
 };
+
+export const removePluginFromViteConfig = (config: any) => {
+  if (config?.plugins) {
+    config.plugins = config.plugins?.[0]?.filter(
+      (obj: any) => obj.name !== "vite:react-refresh"
+    );
+  }
+  return config;
+};

--- a/packages/pages/src/vite-plugin/modules/plugin.ts
+++ b/packages/pages/src/vite-plugin/modules/plugin.ts
@@ -1,4 +1,4 @@
-import { mergeConfig, Plugin } from "vite";
+import { build, mergeConfig, Plugin } from "vite";
 import { ProjectStructure } from "../../common/src/project/structure.js";
 import { glob } from "glob";
 import path from "node:path";
@@ -15,7 +15,10 @@ import postcss from "postcss";
 import nested from "postcss-nested";
 import { createModuleLogger } from "../../common/src/module/internal/logger.js";
 import { getModuleName } from "../../common/src/module/internal/getModuleConfig.js";
-import { scopedViteConfigPath } from "../../util/viteConfig.js";
+import {
+  removePluginFromViteConfig,
+  scopedViteConfigPath,
+} from "../../util/viteConfig.js";
 
 type FileInfo = {
   path: string;
@@ -74,7 +77,7 @@ export const buildModules = async (
       loggerInfo(msg, options);
     };
 
-    const override = {
+    const moduleBuildConfig = {
       customLogger: logger,
       configFile: false,
       envDir: envVarConfig.envVarDir,
@@ -140,7 +143,13 @@ export const buildModules = async (
         }),
       ],
     };
-    await mergeConfig(viteConfig, override);
+    await build(
+      mergeConfig(
+        removePluginFromViteConfig(viteConfig.default),
+        moduleBuildConfig,
+        false
+      )
+    );
   }
 };
 

--- a/packages/pages/src/vite-plugin/modules/plugin.ts
+++ b/packages/pages/src/vite-plugin/modules/plugin.ts
@@ -15,6 +15,7 @@ import postcss from "postcss";
 import nested from "postcss-nested";
 import { createModuleLogger } from "../../common/src/module/internal/logger.js";
 import { getModuleName } from "../../common/src/module/internal/getModuleConfig.js";
+import { scopedViteConfigPath } from "../../util/viteConfig.js";
 
 type FileInfo = {
   path: string;
@@ -60,6 +61,11 @@ export const buildModules = async (
       `Please be aware that using @tailwind base applies styles globally. This can affect code outside of the widget.`
     );
   }
+
+  const viteConfig = await import(
+    scopedViteConfigPath(projectStructure.config.scope) ?? ""
+  );
+  const rollupOptions = viteConfig?.default?.build?.rollupOptions;
 
   for (const [moduleName, fileInfo] of Object.entries(filepaths)) {
     logger.info = (msg, options) => {
@@ -121,6 +127,7 @@ export const buildModules = async (
             format: "umd",
             entryFileNames: `${moduleName}.umd.js`,
           },
+          ...rollupOptions,
         },
         reportCompressedSize: false,
       },

--- a/packages/pages/src/vite-plugin/modules/plugin.ts
+++ b/packages/pages/src/vite-plugin/modules/plugin.ts
@@ -62,9 +62,8 @@ export const buildModules = async (
     );
   }
 
-  const viteConfig = await import(
-    scopedViteConfigPath(projectStructure.config.scope) ?? ""
-  );
+  const viteConfigPath = scopedViteConfigPath(projectStructure.config.scope);
+  const viteConfig = viteConfigPath ? await import(viteConfigPath) : "";
 
   for (const [moduleName, fileInfo] of Object.entries(filepaths)) {
     logger.info = (msg, options) => {

--- a/packages/pages/src/vite-plugin/modules/plugin.ts
+++ b/packages/pages/src/vite-plugin/modules/plugin.ts
@@ -146,8 +146,7 @@ export const buildModules = async (
     await build(
       mergeConfig(
         removePluginFromViteConfig(viteConfig.default),
-        moduleBuildConfig,
-        false
+        moduleBuildConfig
       )
     );
   }

--- a/packages/pages/src/vite-plugin/modules/plugin.ts
+++ b/packages/pages/src/vite-plugin/modules/plugin.ts
@@ -99,7 +99,10 @@ export const buildModules = async (
         },
       },
       experimental: {
-        renderBuiltUrl(filename: any, { type }: any) {
+        renderBuiltUrl(
+          filename: string,
+          { type }: { type: "asset" | "public" }
+        ) {
           let domain = `http://localhost:8000`;
           if (typeof process.env.YEXT_SITE_ARGUMENT !== "undefined") {
             try {

--- a/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
+++ b/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
@@ -1,4 +1,4 @@
-import { createLogger, mergeConfig } from "vite";
+import { build, createLogger, mergeConfig } from "vite";
 import { ProjectStructure } from "../../common/src/project/structure.js";
 import { glob } from "glob";
 import path from "node:path";
@@ -8,7 +8,10 @@ import { processEnvVariables } from "../../util/processEnvVariables.js";
 import { FunctionMetadataParser } from "../../common/src/function/internal/functionMetadataParser.js";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import pc from "picocolors";
-import { scopedViteConfigPath } from "../../util/viteConfig.js";
+import {
+  removePluginFromViteConfig,
+  scopedViteConfigPath,
+} from "../../util/viteConfig.js";
 
 export const buildServerlessFunctions = async (
   projectStructure: ProjectStructure
@@ -57,7 +60,7 @@ export const buildServerlessFunctions = async (
       loggerInfo(msg, options);
     };
 
-    const override = {
+    const serverlessFunctionBuildConfig = {
       customLogger: logger,
       configFile: false,
       envDir: envVarConfig.envVarDir,
@@ -93,7 +96,13 @@ export const buildServerlessFunctions = async (
         }),
       ],
     };
-    await mergeConfig(viteConfig, override);
+    await build(
+      mergeConfig(
+        removePluginFromViteConfig(viteConfig.default),
+        serverlessFunctionBuildConfig,
+        false
+      )
+    );
   }
 };
 

--- a/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
+++ b/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
@@ -42,9 +42,8 @@ export const buildServerlessFunctions = async (
   const logger = createLogger();
   const loggerInfo = logger.info;
 
-  const viteConfig = await import(
-    scopedViteConfigPath(projectStructure.config.scope) ?? ""
-  );
+  const viteConfigPath = scopedViteConfigPath(projectStructure.config.scope);
+  const viteConfig = viteConfigPath ? await import(viteConfigPath) : "";
 
   for (const [name, filepath] of Object.entries(filepaths)) {
     logger.info = (msg, options) => {

--- a/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
+++ b/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
@@ -99,8 +99,7 @@ export const buildServerlessFunctions = async (
     await build(
       mergeConfig(
         removePluginFromViteConfig(viteConfig.default),
-        serverlessFunctionBuildConfig,
-        false
+        serverlessFunctionBuildConfig
       )
     );
   }

--- a/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
+++ b/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
@@ -8,6 +8,7 @@ import { processEnvVariables } from "../../util/processEnvVariables.js";
 import { FunctionMetadataParser } from "../../common/src/function/internal/functionMetadataParser.js";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import pc from "picocolors";
+import { scopedViteConfigPath } from "../../util/viteConfig.js";
 
 export const buildServerlessFunctions = async (
   projectStructure: ProjectStructure
@@ -40,6 +41,11 @@ export const buildServerlessFunctions = async (
 
   const logger = createLogger();
   const loggerInfo = logger.info;
+
+  const viteConfig = await import(
+    scopedViteConfigPath(projectStructure.config.scope) ?? ""
+  );
+  const rollupOptions = viteConfig?.default?.build?.rollupOptions;
 
   for (const [name, filepath] of Object.entries(filepaths)) {
     logger.info = (msg, options) => {
@@ -75,6 +81,7 @@ export const buildServerlessFunctions = async (
             // must use this over lib.fileName otherwise it always ends in .js
             entryFileNames: `[name]/mod.ts`,
           },
+          ...rollupOptions,
         },
         reportCompressedSize: false,
       },


### PR DESCRIPTION
Tested and confirmed it does use the user's build.rollupOptions.external when I add that to the `vite.config.js`
Tested w/ both the problem build (a serverless func repo) and a modules repo.

`configFile: false` should remain or else it'll get stuck in infinite loop of yext plugin.