### PR TITLE
fix(dev): don't lookup mime type unless there's an extension

### DIFF
--- a/packages/pages/src/dev/server/middleware/getContentType.ts
+++ b/packages/pages/src/dev/server/middleware/getContentType.ts
@@ -13,5 +13,10 @@ export const getContentType = (
   // with a fallback to the current logic.
   const path = templateModuleInternal.getPath(props);
 
-  return lookup(path) || "text/html";
+  // There is a bug in mime-types where "map" returns "application/json" instead of false
+  // https://github.com/jshttp/mime-types/issues/125
+  // Instead, only get the mime type if there's an extension, otherwise fallback to "text/html"
+  const pathExtention = path.includes(".") ? path.split(".").pop() : "";
+
+  return pathExtention ? lookup(pathExtention) || "text/html" : "text/html";
 };


### PR DESCRIPTION
The mime-type library returns "application/json" when passed a value of "map" (also true for "json"). Don't use the library if there is no extension and instead default to "text/html".

This bug presented itself when someone used a slug value of "map" and the page rendered as raw html.