### PR TITLE
feat(dev): add pageSets to global variable in header in dev mode

### DIFF
--- a/packages/pages/src/common/src/template/hydration.ts
+++ b/packages/pages/src/common/src/template/hydration.ts
@@ -1,6 +1,7 @@
 import { HeadConfig, renderHeadConfigToString } from "./head.js";
 import { convertToPosixPath } from "./paths.js";
 import { TemplateRenderProps } from "./types.js";
+import { FeaturesConfig } from "../feature/features.js";
 
 /**
  * Imports the custom hydration template and entrypoint template as modules and calls
@@ -134,6 +135,7 @@ const getCommonInjectedIndexHtml = (
  * @param clientHydrationString
  * @param indexHtml
  * @param appLanguage
+ * @param templatesConfig
  * @param headConfig
  * @returns the server template to render in the Vite dev environment
  */
@@ -141,14 +143,21 @@ export const getIndexTemplateDev = (
   clientHydrationString: string | undefined,
   indexHtml: string,
   appLanguage: string,
+  templatesConfig: FeaturesConfig,
   headConfig?: HeadConfig
 ): string => {
-  return getCommonInjectedIndexHtml(
+  let commonIndex = getCommonInjectedIndexHtml(
     clientHydrationString,
     indexHtml,
     appLanguage,
     headConfig
   );
+  commonIndex = injectIntoEndOfHead(
+    commonIndex,
+    `<script id="templatesJsonDev">${JSON.stringify(templatesConfig, null)}</script>`
+  );
+
+  return commonIndex;
 };
 
 /**

--- a/packages/pages/src/common/src/template/hydration.ts
+++ b/packages/pages/src/common/src/template/hydration.ts
@@ -154,7 +154,7 @@ export const getIndexTemplateDev = (
   );
   commonIndex = injectIntoEndOfHead(
     commonIndex,
-    `<script id="templatesJsonDev">${JSON.stringify(templatesConfig, null)}</script>`
+    `<script>const pageSets = ${JSON.stringify(templatesConfig, null)}</script>`
   );
 
   return commonIndex;

--- a/packages/pages/src/dev/server/middleware/sendAppHTML.ts
+++ b/packages/pages/src/dev/server/middleware/sendAppHTML.ts
@@ -13,6 +13,11 @@ import {
   getHydrationTemplateDev,
   getIndexTemplateDev,
 } from "../../../common/src/template/hydration.js";
+import {
+  getTemplateModules,
+  getTemplatesConfig,
+} from "../../../generate/templates/createTemplatesJson.js";
+import { FeaturesConfig } from "../../../common/src/feature/features.js";
 
 /**
  * Renders the HTML for a given {@link TemplateModuleInternal}
@@ -53,6 +58,13 @@ export default async function sendAppHTML(
     clientServerRenderTemplates.serverRenderTemplatePath
   )) as ServerRenderTemplate;
 
+  const { templateModules, redirectModules } =
+    await getTemplateModules(projectStructure);
+  const templatesConfig: FeaturesConfig = getTemplatesConfig(
+    templateModules,
+    redirectModules
+  );
+
   const clientInjectedIndexHtml = getIndexTemplateDev(
     clientHydrationString,
     serverRenderTemplateModule.getIndexHtml
@@ -62,6 +74,7 @@ export default async function sendAppHTML(
         })
       : serverRenderTemplateModule.indexHtml,
     getLang(headConfig, props),
+    templatesConfig,
     headConfig
   );
 

--- a/packages/pages/src/generate/features/features.ts
+++ b/packages/pages/src/generate/features/features.ts
@@ -1,26 +1,13 @@
 import { ProjectStructure } from "../../common/src/project/structure.js";
-import { getTemplateFilepaths } from "../../common/src/template/internal/getTemplateFilepaths.js";
 import { Command } from "commander";
 import { createTemplatesJson } from "../templates/createTemplatesJson.js";
 import { logErrorAndExit } from "../../util/logError.js";
-import { getRedirectFilePaths } from "../../common/src/redirect/internal/getRedirectFilepaths.js";
 
 const handler = async ({ scope }: { scope: string }): Promise<void> => {
   const projectStructure = await ProjectStructure.init({ scope });
-  const templateFilepaths = getTemplateFilepaths(
-    projectStructure.getTemplatePaths()
-  );
-  const redirectFilepaths = getRedirectFilePaths(
-    projectStructure.getRedirectPaths()
-  );
 
   try {
-    await createTemplatesJson(
-      templateFilepaths,
-      redirectFilepaths,
-      projectStructure,
-      "FEATURES"
-    );
+    await createTemplatesJson(projectStructure, "FEATURES");
   } catch (error) {
     logErrorAndExit(error);
   }

--- a/packages/pages/src/generate/templates/createTemplatesJson.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJson.ts
@@ -21,30 +21,19 @@ import {
   loadRedirectModules,
   RedirectModuleCollection,
 } from "../../common/src/redirect/loader/loader.js";
+import { getTemplateFilepaths } from "../../common/src/template/internal/getTemplateFilepaths.js";
+import { getRedirectFilePaths } from "../../common/src/redirect/internal/getRedirectFilepaths.js";
 
 /**
  * Loads the templates as modules and generates a templates.json or
  * features.json from the templates.
  */
 export const createTemplatesJson = async (
-  templateFilepaths: string[],
-  redirectFilepaths: string[],
   projectStructure: ProjectStructure,
   type: "FEATURES" | "TEMPLATES"
 ): Promise<void> => {
-  const templateModules = await loadTemplateModules(
-    templateFilepaths,
-    true,
-    false,
-    projectStructure
-  );
-
-  const redirectModules = await loadRedirectModules(
-    redirectFilepaths,
-    true,
-    false,
-    projectStructure
-  );
+  const { templateModules, redirectModules } =
+    await getTemplateModules(projectStructure);
 
   return createTemplatesJsonFromModule(
     templateModules,
@@ -112,6 +101,35 @@ export const createTemplatesJsonFromModule = async (
     templatesAbsolutePath,
     JSON.stringify(templatesJson, null, "  ")
   );
+};
+
+/**
+ * Helper to get the template modules from the project structure
+ * @param projectStructure
+ */
+export const getTemplateModules = async (
+  projectStructure: ProjectStructure
+) => {
+  const templateFilepaths = getTemplateFilepaths(
+    projectStructure.getTemplatePaths()
+  );
+  const redirectFilepaths = getRedirectFilePaths(
+    projectStructure.getRedirectPaths()
+  );
+  const templateModules = await loadTemplateModules(
+    templateFilepaths,
+    true,
+    false,
+    projectStructure
+  );
+
+  const redirectModules = await loadRedirectModules(
+    redirectFilepaths,
+    true,
+    false,
+    projectStructure
+  );
+  return { templateModules, redirectModules };
 };
 
 export const getTemplatesConfig = (

--- a/packages/pages/src/generate/templates/templates.ts
+++ b/packages/pages/src/generate/templates/templates.ts
@@ -1,8 +1,6 @@
 import { ProjectStructure } from "../../common/src/project/structure.js";
-import { getTemplateFilepaths } from "../../common/src/template/internal/getTemplateFilepaths.js";
 import { createTemplatesJson } from "./createTemplatesJson.js";
 import { Command } from "commander";
-import { getRedirectFilePaths } from "../../common/src/redirect/internal/getRedirectFilepaths.js";
 
 export const templatesHandler = async ({
   scope,
@@ -10,19 +8,8 @@ export const templatesHandler = async ({
   scope: string;
 }): Promise<void> => {
   const projectStructure = await ProjectStructure.init({ scope });
-  const templateFilepaths = getTemplateFilepaths(
-    projectStructure.getTemplatePaths()
-  );
-  const redirectFilepaths = getRedirectFilePaths(
-    projectStructure.getRedirectPaths()
-  );
 
-  await createTemplatesJson(
-    templateFilepaths,
-    redirectFilepaths,
-    projectStructure,
-    "TEMPLATES"
-  );
+  await createTemplatesJson(projectStructure, "TEMPLATES");
 };
 
 export const templatesCommand = (program: Command) => {


### PR DESCRIPTION
Adds the templatesJson to the header so that we can access it in the Visual Editor.

Tested locally and verified that the templatesJson was present in a script tag in the header.

Also verified that `npm run prod` still works as expected and the templatesJson is not present.