### PR TITLE
feat(dev): override document visual configuration

### DIFF
--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -88,9 +88,12 @@ export const serverRenderRoute =
         return;
       }
 
+      const overrides = JSON.parse(req.body.overrides);
+      const documentWithOverrides = overrideDocument(document, overrides.data);
+
       const props = await propsLoader({
         templateModuleInternal,
-        document,
+        document: documentWithOverrides,
       });
       await sendAppHTML(
         res,
@@ -133,4 +136,24 @@ const getDocument = async (
       entityPageCriterion(entityId, templateModuleInternal.config.name, locale)
     )
   )?.document;
+};
+
+const overrideDocument = (document: any, overrideData: any) => {
+  if (!overrideData) {
+    return document;
+  }
+  return {
+    ...document,
+    _site: {
+      ...document._site,
+      c_visualLayouts: [
+        {
+          c_visualConfiguration: {
+            data: JSON.stringify(overrideData),
+            template: document.__.name,
+          },
+        },
+      ],
+    },
+  };
 };

--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -191,9 +191,18 @@ export const createServer = async (
     }
   });
 
+  app.post(
+    /^\/(.+)/,
+    serverRenderRoute({
+      vite,
+      dynamicGenerateData,
+      projectStructure,
+    })
+  );
+
   // When a page is requested that is anything except the root, call our
   // serverRenderRoute middleware.
-  app.use(
+  app.get(
     /^\/(.+)/,
     useProdURLs
       ? serverRenderSlugRoute({


### PR DESCRIPTION
This provides a post request option for `serverRenderRoute` which overrides the c_visualLayouts field of the pulled document with the overrides that are passed in from the request.