### PR TITLE
fix(scaffold): edit puck version

### DIFF
--- a/packages/pages/src/common/src/parsers/puckConfigParser.ts
+++ b/packages/pages/src/common/src/parsers/puckConfigParser.ts
@@ -7,7 +7,7 @@ import { SyntaxKind } from "ts-morph";
  * Adds variables to the puck config file and adds the new config to
  * the exported map.
  * @param fileName template name with invalid chars and spaces removed
- * @param filepath /src/puck/ve.config.ts
+ * @param filepath /src/ve.config.tsx
  */
 export function addDataToPuckConfig(fileName: string, filepath: string) {
   if (!fs.existsSync(filepath)) {

--- a/packages/pages/src/scaffold/template/generate.ts
+++ b/packages/pages/src/scaffold/template/generate.ts
@@ -174,7 +174,7 @@ const addVEDependencies = async () => {
   await updatePackageDependency("@yext/visual-editor", null, true);
   await updatePackageDependency(
     "@measured/puck",
-    "^0.16.0-canary.39e7f40",
+    "0.16.0-canary.39e7f40",
     true
   );
   await installDependencies();

--- a/packages/pages/src/scaffold/template/generate.ts
+++ b/packages/pages/src/scaffold/template/generate.ts
@@ -130,7 +130,7 @@ const formatFileName = (templateName: string): string => {
 };
 
 // Creates a src/templates/ file with a basic template based on provided user responses
-// and adds the new VE template and config to src/ve.config.ts
+// and adds the new VE template and config to src/ve.config.tsx
 const generateVETemplate = async (
   response: any,
   projectStructure: ProjectStructure
@@ -161,7 +161,7 @@ const addVETemplateToConfig = (
 ) => {
   const configPath = path.join(
     projectStructure.config.rootFolders.source,
-    "ve.config.ts"
+    "ve.config.tsx"
   );
   if (fs.existsSync(configPath)) {
     addDataToPuckConfig(fileName, configPath);
@@ -172,7 +172,11 @@ const addVETemplateToConfig = (
 
 const addVEDependencies = async () => {
   await updatePackageDependency("@yext/visual-editor", null, true);
-  await updatePackageDependency("@measured/puck", null, true);
+  await updatePackageDependency(
+    "@measured/puck",
+    "^0.16.0-canary.39e7f40",
+    true
+  );
   await installDependencies();
 };
 


### PR DESCRIPTION
Tested and it works immediately after scaffolding but you do see kinda long list of warnings about conflicting peer dependencies, like: 

npm WARN 
npm WARN Conflicting peer dependency: eslint@8.57.0
npm WARN node_modules/eslint
npm WARN   peer eslint@"^6.0.0 || ^7.0.0 || ^8.0.0" from @typescript-eslint/utils@5.62.0
npm WARN   node_modules/@yext/visual-editor/node_modules/@yext/eslint-config/node_modules/eslint-config-react-app/node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/utils
npm WARN     @typescript-eslint/utils@"^5.58.0" from eslint-plugin-testing-library@5.11.1
npm WARN     node_modules/@yext/visual-editor/node_modules/@yext/eslint-config/node_modules/eslint-config-react-app/node_modules/eslint-plugin-testing-library

