### PR TITLE
fix(plugin): don't merge the entire user vite.config.js

### DIFF
--- a/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
+++ b/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
@@ -8,10 +8,7 @@ import { processEnvVariables } from "../../util/processEnvVariables.js";
 import { FunctionMetadataParser } from "../../common/src/function/internal/functionMetadataParser.js";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import pc from "picocolors";
-import {
-  removePluginFromViteConfig,
-  scopedViteConfigPath,
-} from "../../util/viteConfig.js";
+import { scopedViteConfigPath } from "../../util/viteConfig.js";
 
 export const buildServerlessFunctions = async (
   projectStructure: ProjectStructure
@@ -98,7 +95,13 @@ export const buildServerlessFunctions = async (
     };
     await build(
       mergeConfig(
-        removePluginFromViteConfig(viteConfig.default),
+        {
+          build: {
+            rollupOptions: {
+              external: viteConfig.default.build.rollupOptions.external,
+            },
+          },
+        },
         serverlessFunctionBuildConfig
       )
     );

--- a/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
+++ b/packages/pages/src/vite-plugin/serverless-functions/plugin.ts
@@ -1,4 +1,4 @@
-import { build, createLogger, mergeConfig } from "vite";
+import { build, createLogger, InlineConfig, mergeConfig } from "vite";
 import { ProjectStructure } from "../../common/src/project/structure.js";
 import { glob } from "glob";
 import path from "node:path";
@@ -57,7 +57,7 @@ export const buildServerlessFunctions = async (
       loggerInfo(msg, options);
     };
 
-    const serverlessFunctionBuildConfig = {
+    const serverlessFunctionBuildConfig: InlineConfig = {
       customLogger: logger,
       configFile: false,
       envDir: envVarConfig.envVarDir,
@@ -93,18 +93,21 @@ export const buildServerlessFunctions = async (
         }),
       ],
     };
-    await build(
-      mergeConfig(
-        {
-          build: {
-            rollupOptions: {
-              external: viteConfig.default.build.rollupOptions.external,
+
+    const mergedConfig = viteConfig.default.build.rollupOptions.external
+      ? mergeConfig(
+          {
+            build: {
+              rollupOptions: {
+                external: viteConfig.default.build.rollupOptions.external,
+              },
             },
           },
-        },
-        serverlessFunctionBuildConfig
-      )
-    );
+          serverlessFunctionBuildConfig
+        )
+      : serverlessFunctionBuildConfig;
+
+    await build(mergedConfig);
   }
 };
 


### PR DESCRIPTION
https://github.com/yext/pages/pull/524 added support for merging a user's vite.config.js during the serverless function build process. However, other items in the config can cause the build to fail. Limit serverless functions to be merged **only** with  the build.rollupOptions.external option.