### PR TITLE
fix: revert filtering of static templates from template manifest

### DIFF
--- a/packages/pages/src/common/src/template/loader/loader.test.ts
+++ b/packages/pages/src/common/src/template/loader/loader.test.ts
@@ -4,7 +4,6 @@ import path from "path";
 import { loadTemplateModules } from "./loader.js";
 import { convertToPosixPath } from "../paths.js";
 import { ProjectStructure } from "../../project/structure.js";
-import fs from "node:fs";
 
 describe("loadTemplateModules", () => {
   it("loads and transpiles raw templates", async () => {
@@ -35,49 +34,5 @@ describe("loadTemplateModules", () => {
     );
 
     expect(templateModules.get("template")?.config.name).toEqual("template");
-  });
-
-  it("ignores in-platform page set templates", async () => {
-    try {
-      const templateFiles = glob.sync([
-        convertToPosixPath(
-          path.join(process.cwd(), "tests/fixtures/inPlatformTemplate.tsx")
-        ),
-        convertToPosixPath(
-          path.join(process.cwd(), "tests/fixtures/template.tsx")
-        ),
-      ]);
-
-      const testTemplateManifest = {
-        templates: [
-          {
-            name: "inPlatformTemplate",
-            description: "test",
-            exampleSiteUrl: "",
-            layoutRequired: true,
-            defaultLayoutData: '{"root":{}, "zones":{}, "content":[]}',
-          },
-        ],
-      };
-
-      fs.writeFileSync(
-        ".template-manifest.json",
-        JSON.stringify(testTemplateManifest)
-      );
-
-      const templateModules = await loadTemplateModules(
-        templateFiles,
-        false,
-        false,
-        new ProjectStructure()
-      );
-
-      expect(templateModules.get("inPlatformTemplate")).toBeUndefined();
-      expect(templateModules.get("template")?.config.name).toEqual("template");
-    } finally {
-      if (fs.existsSync(".template-manifest.json")) {
-        fs.unlinkSync(".template-manifest.json");
-      }
-    }
   });
 });

--- a/packages/pages/src/common/src/template/loader/loader.ts
+++ b/packages/pages/src/common/src/template/loader/loader.ts
@@ -6,8 +6,7 @@ import { ProjectStructure } from "../../project/structure.js";
 import { loadModules } from "../../loader/vite.js";
 import { ViteDevServer } from "vite";
 import { loadViteModule } from "../../../../dev/server/ssr/loadViteModule.js";
-import { TemplateManifest, TemplateModule } from "../types.js";
-import fs from "node:fs";
+import { TemplateModule } from "../types.js";
 
 /**
  * Loads all templates in the project.
@@ -30,21 +29,6 @@ export const loadTemplateModules = async (
     projectStructure
   );
 
-  const templateManifestPath = projectStructure
-    .getTemplateManifestPath()
-    .getAbsolutePath();
-
-  let inPlatformTemplateNames: string[] = [];
-  if (fs.existsSync(templateManifestPath)) {
-    const templateManifest = JSON.parse(
-      fs.readFileSync(templateManifestPath, "utf-8")
-    ) as TemplateManifest;
-
-    inPlatformTemplateNames = templateManifest.templates.map(
-      (templateInfo) => templateInfo.name
-    );
-  }
-
   const importedTemplateModules = [] as TemplateModuleInternal<any, any>[];
   for (const importedModule of importedModules) {
     const templateModuleInternal =
@@ -54,15 +38,10 @@ export const loadTemplateModules = async (
         adjustForFingerprintedAsset
       );
 
-    // ignore templates marked for in-platform page set use by .template-manifest.json
-    if (
-      !inPlatformTemplateNames.includes(templateModuleInternal.templateName)
-    ) {
-      importedTemplateModules.push({
-        ...templateModuleInternal,
-        path: importedModule.path,
-      });
-    }
+    importedTemplateModules.push({
+      ...templateModuleInternal,
+      path: importedModule.path,
+    });
   }
 
   return importedTemplateModules.reduce((prev, module) => {


### PR DESCRIPTION
Partial revert of https://github.com/yext/pages/commit/4fe7b8eb376e2aebf9eacded510781e89ba446c6.

Filtering was causing page generation to fail in platform