### PR TITLE
fix: correctly ignore templates marked for in platform page sets

### DIFF
--- a/packages/pages/src/common/src/template/loader/loader.test.ts
+++ b/packages/pages/src/common/src/template/loader/loader.test.ts
@@ -4,7 +4,6 @@ import path from "path";
 import { loadTemplateModules } from "./loader.js";
 import { convertToPosixPath } from "../paths.js";
 import { ProjectStructure } from "../../project/structure.js";
-import fs from "node:fs";
 
 describe("loadTemplateModules", () => {
   it("loads and transpiles raw templates", async () => {
@@ -35,49 +34,5 @@ describe("loadTemplateModules", () => {
     );
 
     expect(templateModules.get("template")?.config.name).toEqual("template");
-  });
-
-  it("ignores in-platform page set templates", async () => {
-    try {
-      const templateFiles = glob.sync([
-        convertToPosixPath(
-          path.join(process.cwd(), "tests/fixtures/inPlatformTemplate.tsx")
-        ),
-        convertToPosixPath(
-          path.join(process.cwd(), "tests/fixtures/template.tsx")
-        ),
-      ]);
-
-      const testTemplateManifest = {
-        templates: [
-          {
-            name: "inPlatformTemplate",
-            description: "test",
-            exampleSiteUrl: "",
-            layoutRequired: true,
-            defaultLayoutData: '{"root":{}, "zones":{}, "content":[]}',
-          },
-        ],
-      };
-
-      fs.writeFileSync(
-        ".template-manifest.json",
-        JSON.stringify(testTemplateManifest)
-      );
-
-      const templateModules = await loadTemplateModules(
-        templateFiles,
-        false,
-        false,
-        new ProjectStructure()
-      );
-
-      expect(templateModules.get("inPlatformTemplate")).toBeUndefined();
-      expect(templateModules.get("template")?.config.name).toEqual("template");
-    } finally {
-      if (fs.existsSync(".template-manifest.json")) {
-        fs.unlinkSync(".template-manifest.json");
-      }
-    }
   });
 });

--- a/packages/pages/src/common/src/template/loader/loader.ts
+++ b/packages/pages/src/common/src/template/loader/loader.ts
@@ -6,8 +6,7 @@ import { ProjectStructure } from "../../project/structure.js";
 import { loadModules } from "../../loader/vite.js";
 import { ViteDevServer } from "vite";
 import { loadViteModule } from "../../../../dev/server/ssr/loadViteModule.js";
-import { TemplateManifest, TemplateModule } from "../types.js";
-import fs from "node:fs";
+import { TemplateModule } from "../types.js";
 
 /**
  * Loads all templates in the project.
@@ -30,21 +29,6 @@ export const loadTemplateModules = async (
     projectStructure
   );
 
-  const templateManifestPath = projectStructure
-    .getTemplateManifestPath()
-    .getAbsolutePath();
-
-  let inPlatformTemplateNames: string[] = [];
-  if (fs.existsSync(templateManifestPath)) {
-    const templateManifest = JSON.parse(
-      fs.readFileSync(templateManifestPath, "utf-8")
-    ) as TemplateManifest;
-
-    inPlatformTemplateNames = templateManifest.templates.map(
-      (templateInfo) => templateInfo.name
-    );
-  }
-
   const importedTemplateModules = [] as TemplateModuleInternal<any, any>[];
   for (const importedModule of importedModules) {
     const templateModuleInternal =
@@ -54,15 +38,10 @@ export const loadTemplateModules = async (
         adjustForFingerprintedAsset
       );
 
-    // ignore templates marked for in-platform page set use by .template-manifest.json
-    if (
-      !inPlatformTemplateNames.includes(templateModuleInternal.templateName)
-    ) {
-      importedTemplateModules.push({
-        ...templateModuleInternal,
-        path: importedModule.path,
-      });
-    }
+    importedTemplateModules.push({
+      ...templateModuleInternal,
+      path: importedModule.path,
+    });
   }
 
   return importedTemplateModules.reduce((prev, module) => {

--- a/packages/pages/src/dev/server/middleware/sendAppHTML.ts
+++ b/packages/pages/src/dev/server/middleware/sendAppHTML.ts
@@ -62,6 +62,7 @@ export default async function sendAppHTML(
     await getTemplateModules(projectStructure);
   const templatesConfig: FeaturesConfig = getTemplatesConfig(
     templateModules,
+    projectStructure,
     redirectModules
   );
 

--- a/packages/pages/src/dev/server/ssr/generateTestData.ts
+++ b/packages/pages/src/dev/server/ssr/generateTestData.ts
@@ -57,7 +57,10 @@ export const generateTestDataForSlug = async (
     }
   }
 
-  const featuresConfig = getTemplatesConfig(templateModuleCollection);
+  const featuresConfig = getTemplatesConfig(
+    templateModuleCollection,
+    projectStructure
+  );
   const featuresConfigForEntityPages: FeaturesConfig = {
     features: featuresConfig.features.filter((f) => "entityPageSet" in f),
     streams: featuresConfig.streams,
@@ -184,7 +187,7 @@ async function spawnTestDataCommand(
       if (testData) {
         try {
           parsedData = JSON.parse(testData.trim());
-        } catch (e) {
+        } catch {
           stdout.write(
             `\nUnable to parse test data from command: \`${command} ${args.join(
               " "

--- a/packages/pages/src/generate/templates/createTemplatesJson.test.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJson.test.ts
@@ -4,144 +4,185 @@ import { TemplateModuleCollection } from "../../common/src/template/loader/loade
 import { getTemplatesConfig } from "./createTemplatesJson.js";
 import { RedirectModuleCollection } from "../../common/src/redirect/loader/loader.js";
 import { RedirectSource } from "../../common/src/redirect/types.js";
+import { ProjectStructure } from "../../common/src/project/structure.js";
+import fs from "node:fs";
 
 describe("createTemplatesJsonFromModule - getFeaturesConfig", () => {
   it("creates the proper default templates structure", async () => {
-    const templateModules: TemplateModuleCollection = new Map();
-    templateModules.set("turtlehead-tacos", {
-      path: "src/templates/static.tsx",
-      filename: "static.tsx",
-      templateName: "turtlehead-tacos",
-      config: {
-        name: "turtlehead-tacos",
-        hydrate: true,
-        templateType: "static",
-      },
-      getPath: () => {
-        return "";
-      },
-    });
-    templateModules.set("location", {
-      path: "src/templates/location.tsx",
-      filename: "location.tsx",
-      templateName: "location",
-      config: {
-        name: "location",
-        hydrate: true,
-        streamId: "location-stream",
-        stream: {
-          $id: "location-stream",
-          fields: ["foo"],
-          filter: {
-            entityIds: ["97807061"],
-          },
-          localization: {
-            locales: ["en"],
-            primary: false,
-          },
-          transform: {
-            replaceOptionValuesWithDisplayNames: ["paymentOptions"],
-          },
-        },
-        templateType: "entity",
-      },
-      getPath: () => {
-        return "";
-      },
-    });
-
-    const redirectModules: RedirectModuleCollection = new Map();
-    redirectModules.set("closed-location", {
-      config: {
-        name: "closed-location",
-        streamId: "closed-location-stream",
-        stream: {
-          $id: "closed-location-stream",
-          fields: ["foo"],
-          filter: {
-            entityIds: ["97807061"],
-          },
-          localization: {
-            locales: ["en"],
-            primary: false,
-          },
-        },
-      },
-      filename: "closed-location.tsx",
-      getDestination(): string {
-        return "";
-      },
-      getSources(): RedirectSource[] {
-        return [
+    try {
+      const testTemplateManifest = {
+        templates: [
           {
-            source: "nomoretacos.com",
-            statusCode: 301,
+            name: "main",
+            description: "test",
+            exampleSiteUrl: "",
+            layoutRequired: true,
+            defaultLayoutData: '{"root":{}, "zones":{}, "content":[]}',
           },
-        ];
-      },
-      path: "src/redirects/closed-location.tsx",
-      redirectName: "closed-location",
-    });
+        ],
+      };
+      fs.writeFileSync(
+        ".template-manifest.json",
+        JSON.stringify(testTemplateManifest)
+      );
 
-    const expected: FeaturesConfig = {
-      features: [
-        {
+      const templateModules: TemplateModuleCollection = new Map();
+      templateModules.set("turtlehead-tacos", {
+        path: "src/templates/static.tsx",
+        filename: "static.tsx",
+        templateName: "turtlehead-tacos",
+        config: {
           name: "turtlehead-tacos",
-          templateType: "JS",
-          staticPage: {},
-          streamId: undefined,
-          alternateLanguageFields: undefined,
+          hydrate: true,
+          templateType: "static",
         },
-        {
+        getPath: () => {
+          return "";
+        },
+      });
+      templateModules.set("main", {
+        path: "src/templates/c.tsx",
+        filename: "main.tsx",
+        templateName: "main",
+        config: {
+          name: "main",
+          hydrate: true,
+          templateType: "static",
+        },
+        getPath: () => {
+          return "";
+        },
+      });
+      templateModules.set("location", {
+        path: "src/templates/location.tsx",
+        filename: "location.tsx",
+        templateName: "location",
+        config: {
           name: "location",
+          hydrate: true,
           streamId: "location-stream",
-          templateType: "JS",
-          entityPageSet: {},
-          alternateLanguageFields: undefined,
+          stream: {
+            $id: "location-stream",
+            fields: ["foo"],
+            filter: {
+              entityIds: ["97807061"],
+            },
+            localization: {
+              locales: ["en"],
+              primary: false,
+            },
+            transform: {
+              replaceOptionValuesWithDisplayNames: ["paymentOptions"],
+            },
+          },
+          templateType: "entity",
         },
-        {
+        getPath: () => {
+          return "";
+        },
+      });
+
+      const redirectModules: RedirectModuleCollection = new Map();
+      redirectModules.set("closed-location", {
+        config: {
           name: "closed-location",
           streamId: "closed-location-stream",
-          templateType: "JS",
-          entityPageSet: {},
-          alternateLanguageFields: undefined,
+          stream: {
+            $id: "closed-location-stream",
+            fields: ["foo"],
+            filter: {
+              entityIds: ["97807061"],
+            },
+            localization: {
+              locales: ["en"],
+              primary: false,
+            },
+          },
         },
-      ],
-      streams: [
-        {
-          $id: "location-stream",
-          filter: {
-            entityIds: ["97807061"],
-          },
-          fields: ["foo"],
-          localization: {
-            locales: ["en"],
-            primary: false,
-          },
-          transform: {
-            replaceOptionValuesWithDisplayNames: ["paymentOptions"],
-          },
-          source: "knowledgeGraph",
-          destination: "pages",
+        filename: "closed-location.tsx",
+        getDestination(): string {
+          return "";
         },
-        {
-          $id: "closed-location-stream",
-          filter: {
-            entityIds: ["97807061"],
-          },
-          fields: ["foo"],
-          localization: {
-            locales: ["en"],
-            primary: false,
-          },
-          source: "knowledgeGraph",
-          destination: "pages",
+        getSources(): RedirectSource[] {
+          return [
+            {
+              source: "nomoretacos.com",
+              statusCode: 301,
+            },
+          ];
         },
-      ],
-    };
+        path: "src/redirects/closed-location.tsx",
+        redirectName: "closed-location",
+      });
 
-    expect(getTemplatesConfig(templateModules, redirectModules)).toEqual(
-      expected
-    );
+      const expected: FeaturesConfig = {
+        features: [
+          {
+            name: "turtlehead-tacos",
+            templateType: "JS",
+            staticPage: {},
+            streamId: undefined,
+            alternateLanguageFields: undefined,
+          },
+          {
+            name: "location",
+            streamId: "location-stream",
+            templateType: "JS",
+            entityPageSet: {},
+            alternateLanguageFields: undefined,
+          },
+          {
+            name: "closed-location",
+            streamId: "closed-location-stream",
+            templateType: "JS",
+            entityPageSet: {},
+            alternateLanguageFields: undefined,
+          },
+        ],
+        streams: [
+          {
+            $id: "location-stream",
+            filter: {
+              entityIds: ["97807061"],
+            },
+            fields: ["foo"],
+            localization: {
+              locales: ["en"],
+              primary: false,
+            },
+            transform: {
+              replaceOptionValuesWithDisplayNames: ["paymentOptions"],
+            },
+            source: "knowledgeGraph",
+            destination: "pages",
+          },
+          {
+            $id: "closed-location-stream",
+            filter: {
+              entityIds: ["97807061"],
+            },
+            fields: ["foo"],
+            localization: {
+              locales: ["en"],
+              primary: false,
+            },
+            source: "knowledgeGraph",
+            destination: "pages",
+          },
+        ],
+      };
+
+      expect(
+        getTemplatesConfig(
+          templateModules,
+          new ProjectStructure(),
+          redirectModules
+        )
+      ).toEqual(expected);
+    } finally {
+      if (fs.existsSync(".template-manifest.json")) {
+        fs.unlinkSync(".template-manifest.json");
+      }
+    }
   });
 });

--- a/packages/pages/src/generate/templates/createTemplatesJson.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJson.ts
@@ -141,23 +141,23 @@ export const getTemplatesConfig = (
 ): FeaturesConfig => {
   const features: FeatureConfig[] = [];
   const streams: StreamConfig[] = [];
+  let inPlatformTemplateNames: string[] = [];
+
+  const templateManifestPath = projectStructure
+    .getTemplateManifestPath()
+    .getAbsolutePath();
+
+  if (fs.existsSync(templateManifestPath)) {
+    const templateManifest = JSON.parse(
+      fs.readFileSync(templateManifestPath, "utf-8")
+    ) as TemplateManifest;
+
+    inPlatformTemplateNames = templateManifest.templates.map(
+      (templateInfo) => templateInfo.name
+    );
+  }
+
   for (const module of templateModules.values()) {
-    let inPlatformTemplateNames: string[] = [];
-
-    const templateManifestPath = projectStructure
-      .getTemplateManifestPath()
-      .getAbsolutePath();
-
-    if (fs.existsSync(templateManifestPath)) {
-      const templateManifest = JSON.parse(
-        fs.readFileSync(templateManifestPath, "utf-8")
-      ) as TemplateManifest;
-
-      inPlatformTemplateNames = templateManifest.templates.map(
-        (templateInfo) => templateInfo.name
-      );
-    }
-
     if (inPlatformTemplateNames.includes(module.config.name)) {
       // skip in-platform page sets
       continue;

--- a/packages/pages/src/generate/templates/createTemplatesJson.ts
+++ b/packages/pages/src/generate/templates/createTemplatesJson.ts
@@ -23,6 +23,7 @@ import {
 } from "../../common/src/redirect/loader/loader.js";
 import { getTemplateFilepaths } from "../../common/src/template/internal/getTemplateFilepaths.js";
 import { getRedirectFilePaths } from "../../common/src/redirect/internal/getRedirectFilepaths.js";
+import { TemplateManifest } from "../../common/src/template/types.js";
 
 /**
  * Loads the templates as modules and generates a templates.json or
@@ -57,6 +58,7 @@ export const createTemplatesJsonFromModule = async (
   // which is why all of the types have not yet been renamed.
   const { features, streams } = getTemplatesConfig(
     templateModules,
+    projectStructure,
     redirectModules
   );
   let templatesAbsolutePath;
@@ -134,11 +136,33 @@ export const getTemplateModules = async (
 
 export const getTemplatesConfig = (
   templateModules: TemplateModuleCollection,
+  projectStructure: ProjectStructure,
   redirectModules?: RedirectModuleCollection
 ): FeaturesConfig => {
   const features: FeatureConfig[] = [];
   const streams: StreamConfig[] = [];
   for (const module of templateModules.values()) {
+    let inPlatformTemplateNames: string[] = [];
+
+    const templateManifestPath = projectStructure
+      .getTemplateManifestPath()
+      .getAbsolutePath();
+
+    if (fs.existsSync(templateManifestPath)) {
+      const templateManifest = JSON.parse(
+        fs.readFileSync(templateManifestPath, "utf-8")
+      ) as TemplateManifest;
+
+      inPlatformTemplateNames = templateManifest.templates.map(
+        (templateInfo) => templateInfo.name
+      );
+    }
+
+    if (inPlatformTemplateNames.includes(module.config.name)) {
+      // skip in-platform page sets
+      continue;
+    }
+
     const featureConfig = convertTemplateConfigToFeatureConfig(module.config);
     features.push(featureConfig);
     const streamConfig = convertTemplateConfigToStreamConfig(module.config);


### PR DESCRIPTION
In https://github.com/yext/pages/pull/564, the in-platform page sets were filtered in loader.ts, which removed them from both the manifest.json and features.json. They are still needed in manifest.json so page generation was failing. This change only removes them from features.json. 

Tested in-platform and confirmed that in platform page set pages generate successfully and the static pages are no longer generated.