### PR TITLE
fix: workflow vulnerability

### DIFF
--- a/.github/workflows/generate_markdown_files.yml
+++ b/.github/workflows/generate_markdown_files.yml
@@ -8,11 +8,8 @@ jobs:
     steps:    
       - name: "Checkout"
         uses: actions/checkout@v4.1.6
-        env:
-          HEAD_REF: ${{ github.head_ref }}
         with:
           token: ${{ secrets.BOT_REPO_SCOPED_TOKEN }}
-      - run: git checkout "$HEAD_REF"
       - name: Install pnpm
         uses: pnpm/action-setup@v4.0.0
       - name: Install deps

--- a/.github/workflows/generate_markdown_files.yml
+++ b/.github/workflows/generate_markdown_files.yml
@@ -8,9 +8,11 @@ jobs:
     steps:    
       - name: "Checkout"
         uses: actions/checkout@v4.1.6
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         with:
-          ref: ${{ github.head_ref }}
           token: ${{ secrets.BOT_REPO_SCOPED_TOKEN }}
+      - run: git checkout "$HEAD_REF"
       - name: Install pnpm
         uses: pnpm/action-setup@v4.0.0
       - name: Install deps


### PR DESCRIPTION
So `github.head_ref` is only populated on pull workflows, generate_markdown is a push workflow, so ref was always empty anyways. 

The vulnerability was worried about:

> Using variable interpolation `$...` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

which is valid and their suggested solution would've worked if we had ref or need the ref

