### PR TITLE
fix: additional workflow change

### DIFF
--- a/.github/workflows/generate_markdown_files.yml
+++ b/.github/workflows/generate_markdown_files.yml
@@ -25,6 +25,8 @@ jobs:
           push: true
           pull: --rebase --autostash
           default_author: github_actions
-      - name: Fail on push
-        run: |
-          if [[ ${{ steps.generate-markdown.outputs.pushed }} == true ]]; then exit 1; else exit 0; fi
+      -  name: Fail on push
+         env:
+          PUSHED: ${{ steps.generate-markdown.outputs.pushed }}
+         run: |
+          if [[ $PUSHED == true ]]; then exit 1; else exit 0; fi


### PR DESCRIPTION
Required fix for vulnerability in addition to #573. Did not realize it was required because: 
> Semgrep updated their run-shell-injection rule a while back to treat {{steps. ... .outputs. ...}}  — e.g. this file's outputs.pushed — as untrusted inputs that should be loaded in as Environment Variables through the env: option. Unfortunately, they did not update the description of their rule, so our ticket description was incomplete. 

