### PR TITLE
fix(pages-plugins): slugmanager unbounded entity request bug

### DIFF
--- a/packages/plugins/slugManager/manager.ts
+++ b/packages/plugins/slugManager/manager.ts
@@ -53,7 +53,7 @@ export function createManager(config: InternalSlugManagerConfig) {
     }
     const entitiesResponse = await api.listEntities(params);
 
-    if (!entitiesResponse.entities) {
+    if (!entitiesResponse?.entities?.length) {
       return JSON.stringify({
         data: [],
       });


### PR DESCRIPTION
A prior [fix](https://github.com/yext/pages/pull/547) attempted this but had a bug. The fix is to prevent making api requests with unbounded entities. Unfortunately, the previous attempt never checked length so when the array was empty the condition never hit.