### PR TITLE
refactor(dev): generate templates.json after vite initialization

### DIFF
--- a/packages/pages/etc/pages.api.md
+++ b/packages/pages/etc/pages.api.md
@@ -31,14 +31,33 @@ export const convertToPosixPath: (p: string) => string;
 
 // @internal (undocumented)
 export const createDevServer: (
-  dynamicGenerateData: boolean,
-  useProdURLs: boolean,
   devServerPort: number,
-  openBrowser: boolean,
-  scope?: string,
-  module?: string,
-  siteId?: number
+  devArgs: DevArgs
 ) => Promise<void>;
+
+// @internal
+export interface DevArgs {
+  // (undocumented)
+  local?: boolean;
+  // (undocumented)
+  module?: string;
+  // (undocumented)
+  noGenFeatures?: boolean;
+  // (undocumented)
+  noGenTestData?: boolean;
+  // (undocumented)
+  noInit?: boolean;
+  // (undocumented)
+  openBrowser: boolean;
+  // (undocumented)
+  port?: number;
+  // (undocumented)
+  prodUrl?: boolean;
+  // (undocumented)
+  scope?: string;
+  // (undocumented)
+  siteId?: number;
+}
 
 // @internal (undocumented)
 export const devCommand: (program: Command) => void;

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -7,6 +7,10 @@ import { isUsingConfig } from "../util/config.js";
 import { logWarning } from "../util/logError.js";
 import { ProjectStructure } from "../common/src/project/structure.js";
 
+/**
+ * The arguments passed to the dev CLI command.
+ * @internal
+ */
 export interface DevArgs {
   local?: boolean;
   prodUrl?: boolean;

--- a/packages/pages/src/dev/dev.ts
+++ b/packages/pages/src/dev/dev.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
 import { createServer } from "./server/server.js";
-import runSubProcess from "../util/runSubprocess.js";
 import { autoYextInit } from "./server/autoInit.js";
 import open from "open";
 import getPort, { portNumbers } from "get-port";
@@ -8,7 +7,7 @@ import { isUsingConfig } from "../util/config.js";
 import { logWarning } from "../util/logError.js";
 import { ProjectStructure } from "../common/src/project/structure.js";
 
-interface DevArgs {
+export interface DevArgs {
   local?: boolean;
   prodUrl?: boolean;
   openBrowser: boolean;
@@ -21,17 +20,8 @@ interface DevArgs {
   siteId?: number;
 }
 
-const handler = async ({
-  local,
-  prodUrl,
-  openBrowser,
-  noInit,
-  scope,
-  noGenFeatures,
-  port,
-  module,
-  siteId,
-}: DevArgs) => {
+const handler = async (devArgs: DevArgs) => {
+  const { openBrowser, noInit, scope, port, module } = devArgs;
   const { config } = (await ProjectStructure.init({ scope })).config.rootFiles;
 
   if (!isUsingConfig(config, scope)) {
@@ -46,34 +36,14 @@ const handler = async ({
   if (!noInit) {
     await autoYextInit(scope);
   }
-  if (!noGenFeatures) {
-    if (isUsingConfig(config, scope)) {
-      await runSubProcess(
-        "pages generate templates",
-        scope ? [`--scope ${scope}`] : []
-      );
-    } else {
-      await runSubProcess(
-        "pages generate features",
-        scope ? [`--scope ${scope}`] : []
-      );
-    }
-  }
 
   const devServerPort =
     port ??
     (await getPort({
       port: portNumbers(5173, 6000),
     }));
-  await createServer(
-    !local,
-    !!prodUrl,
-    devServerPort,
-    openBrowser,
-    scope,
-    module,
-    siteId
-  );
+
+  await createServer(devServerPort, devArgs);
 
   if (openBrowser && !module) {
     await open(`http://localhost:${devServerPort}/`);


### PR DESCRIPTION
Runs `pages generate features`/`pages generate templates` after initializing the vite server so that vite plugins run before generation.

Confirmed in the VE starter that the edit static page was generated.
Confirmed in a non-VE starter that entity and static pages were generated and the `--noGenFeatures` flag worked.