### PR TITLE
set ts morph lib

### DIFF
--- a/packages/pages/src/common/src/parsers/sourceFileParser.ts
+++ b/packages/pages/src/common/src/parsers/sourceFileParser.ts
@@ -13,6 +13,7 @@ export function createTsMorphProject() {
   return new Project({
     compilerOptions: {
       jsx: typescript.JsxEmit.ReactJSX,
+      lib: ["ES2023", "DOM"],
     },
   });
 }


### PR DESCRIPTION
Was running into an issue where using ES6's `Map` in a template would be replaced with the `pages-components` `Map` during the build due to the `fixMissingImports()` call in this file