### PR TITLE
fix: migrate authentication not authorization

### DIFF
--- a/packages/pages/src/common/src/config/types.ts
+++ b/packages/pages/src/common/src/config/types.ts
@@ -55,7 +55,7 @@ export interface ConfigYaml {
   };
 
   /** Auth policy configuration */
-  authorization: {
+  authentication: {
     policyName: string;
   };
 

--- a/packages/pages/src/upgrade/migrateConfig.ts
+++ b/packages/pages/src/upgrade/migrateConfig.ts
@@ -153,7 +153,7 @@ const migrateAuth = (configYamlPath: string, authPath: string) => {
   const authJson = readJsonSync(authPath);
   if (authJson !== null) {
     console.info(`migrating auth info from ${authPath} to ${configYamlPath}`);
-    writeYamlSync(configYamlPath, "authorization", authJson);
+    writeYamlSync(configYamlPath, "authentication", authJson);
   }
 };
 


### PR DESCRIPTION
Tested upgrading an older repo with auth.json to Pages 1.0.0 and confirmed policyName was properly migrated into the config.yaml. 