### PR TITLE
feat: use template from _pageset.config

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,11 +20,13 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           token: ${{ secrets.BOT_REPO_SCOPED_TOKEN }}
-      - uses: pnpm/action-setup@v4.0.0
-      - uses: actions/setup-node@v4.0.2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.0.0
       - uses: actions/download-artifact@v4.1.7
         with:
           name: ${{ matrix.react-major == 19 && format('build-output-{0}-react-19', matrix.node-version) || format('build-output-{0}', matrix.node-version) }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,13 +20,11 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           token: ${{ secrets.BOT_REPO_SCOPED_TOKEN }}
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4.0.2
+      - uses: pnpm/action-setup@v4.0.0
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4.0.0
       - uses: actions/download-artifact@v4.1.7
         with:
           name: ${{ matrix.react-major == 19 && format('build-output-{0}-react-19', matrix.node-version) || format('build-output-{0}', matrix.node-version) }}

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getDocumentTemplateName, getTemplateIdFromConfigTemplate } from "./resolveTemplateName.js";
+import { getDocumentTemplateName, getVisualEditorTemplateId } from "./resolveTemplateName.js";
 
 const baseDocument = {
   __: {
@@ -86,12 +86,12 @@ describe("getDocumentTemplateName", () => {
   });
 });
 
-describe("getTemplateIdFromConfigTemplate", () => {
+describe("getVisualEditorTemplateId", () => {
   it("extracts the trailing template id from a resource name", () => {
-    expect(getTemplateIdFromConfigTemplate("accounts/123/visualEditorTemplates/main")).toBe("main");
+    expect(getVisualEditorTemplateId("accounts/123/visualEditorTemplates/main")).toBe("main");
   });
 
   it("returns plain template ids unchanged", () => {
-    expect(getTemplateIdFromConfigTemplate("main")).toBe("main");
+    expect(getVisualEditorTemplateId("main")).toBe("main");
   });
 });

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getDocumentTemplateName } from "./resolveTemplateName.js";
+import { getDocumentTemplateName, getTemplateIdFromConfigTemplate } from "./resolveTemplateName.js";
 
 const baseDocument = {
   __: {
@@ -19,7 +19,7 @@ describe("getDocumentTemplateName", () => {
           },
         }),
       })
-    ).toBe("accounts/123/visualEditorTemplates/main");
+    ).toBe("main");
   });
 
   it("supports _pageset when it is already an object", () => {
@@ -32,7 +32,7 @@ describe("getDocumentTemplateName", () => {
           },
         },
       })
-    ).toBe("accounts/123/visualEditorTemplates/main");
+    ).toBe("main");
   });
 
   it("falls back when _pageset cannot be parsed", () => {
@@ -83,5 +83,15 @@ describe("getDocumentTemplateName", () => {
         },
       })
     ).toBe("page-set-name");
+  });
+});
+
+describe("getTemplateIdFromConfigTemplate", () => {
+  it("extracts the trailing template id from a resource name", () => {
+    expect(getTemplateIdFromConfigTemplate("accounts/123/visualEditorTemplates/main")).toBe("main");
+  });
+
+  it("returns plain template ids unchanged", () => {
+    expect(getTemplateIdFromConfigTemplate("main")).toBe("main");
   });
 });

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, it } from "vitest";
 import { getDocumentTemplateName } from "./resolveTemplateName.js";
 
+const baseDocument = {
+  __: {
+    codeTemplate: "legacy-template",
+    name: "page-set-name",
+  },
+};
+
 describe("getDocumentTemplateName", () => {
   it("prefers _pageset.config.template over codeTemplate", () => {
     expect(
       getDocumentTemplateName({
+        ...baseDocument,
         _pageset: JSON.stringify({
           config: {
             template: "accounts/123/visualEditorTemplates/main",
           },
         }),
-        __: {
-          codeTemplate: "legacy-template",
-          name: "page-set-name",
-        },
       })
     ).toBe("accounts/123/visualEditorTemplates/main");
   });
@@ -21,14 +25,11 @@ describe("getDocumentTemplateName", () => {
   it("supports _pageset when it is already an object", () => {
     expect(
       getDocumentTemplateName({
+        ...baseDocument,
         _pageset: {
           config: {
             template: "accounts/123/visualEditorTemplates/main",
           },
-        },
-        __: {
-          codeTemplate: "legacy-template",
-          name: "page-set-name",
         },
       })
     ).toBe("accounts/123/visualEditorTemplates/main");
@@ -37,38 +38,25 @@ describe("getDocumentTemplateName", () => {
   it("falls back when _pageset cannot be parsed", () => {
     expect(
       getDocumentTemplateName({
+        ...baseDocument,
         _pageset: "{not-json",
-        __: {
-          codeTemplate: "legacy-template",
-          name: "page-set-name",
-        },
       })
     ).toBe("legacy-template");
   });
 
   it("falls back to document.__.codeTemplate", () => {
-    expect(
-      getDocumentTemplateName({
-        __: {
-          codeTemplate: "legacy-template",
-          name: "page-set-name",
-        },
-      })
-    ).toBe("legacy-template");
+    expect(getDocumentTemplateName(baseDocument)).toBe("legacy-template");
   });
 
   it("falls back to codeTemplate when _pageset.config.template is blank", () => {
     expect(
       getDocumentTemplateName({
+        ...baseDocument,
         _pageset: JSON.stringify({
           config: {
             template: "   ",
           },
         }),
-        __: {
-          codeTemplate: "legacy-template",
-          name: "page-set-name",
-        },
       })
     ).toBe("legacy-template");
   });
@@ -76,9 +64,10 @@ describe("getDocumentTemplateName", () => {
   it("falls back to document.__.name when codeTemplate is blank", () => {
     expect(
       getDocumentTemplateName({
+        ...baseDocument,
         __: {
+          ...baseDocument.__,
           codeTemplate: "   ",
-          name: "page-set-name",
         },
       })
     ).toBe("page-set-name");
@@ -87,8 +76,10 @@ describe("getDocumentTemplateName", () => {
   it("falls back to document.__.name", () => {
     expect(
       getDocumentTemplateName({
+        ...baseDocument,
         __: {
-          name: "page-set-name",
+          ...baseDocument.__,
+          codeTemplate: undefined,
         },
       })
     ).toBe("page-set-name");

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getDocumentTemplateName, hasDocumentTemplateMetadata } from "./resolveTemplateName.js";
+import { getDocumentTemplateName } from "./resolveTemplateName.js";
 
 describe("getDocumentTemplateName", () => {
   it("prefers _pageset.config.template over codeTemplate", () => {
@@ -57,6 +57,33 @@ describe("getDocumentTemplateName", () => {
     ).toBe("legacy-template");
   });
 
+  it("falls back to codeTemplate when _pageset.config.template is blank", () => {
+    expect(
+      getDocumentTemplateName({
+        _pageset: JSON.stringify({
+          config: {
+            template: "   ",
+          },
+        }),
+        __: {
+          codeTemplate: "legacy-template",
+          name: "page-set-name",
+        },
+      })
+    ).toBe("legacy-template");
+  });
+
+  it("falls back to document.__.name when codeTemplate is blank", () => {
+    expect(
+      getDocumentTemplateName({
+        __: {
+          codeTemplate: "   ",
+          name: "page-set-name",
+        },
+      })
+    ).toBe("page-set-name");
+  });
+
   it("falls back to document.__.name", () => {
     expect(
       getDocumentTemplateName({
@@ -65,39 +92,5 @@ describe("getDocumentTemplateName", () => {
         },
       })
     ).toBe("page-set-name");
-  });
-});
-
-describe("hasDocumentTemplateMetadata", () => {
-  it("is true when _pageset.config.template exists", () => {
-    expect(
-      hasDocumentTemplateMetadata({
-        _pageset: JSON.stringify({
-          config: {
-            template: "accounts/123/visualEditorTemplates/main",
-          },
-        }),
-      })
-    ).toBe(true);
-  });
-
-  it("falls back to codeTemplate metadata", () => {
-    expect(
-      hasDocumentTemplateMetadata({
-        __: {
-          codeTemplate: "legacy-template",
-        },
-      })
-    ).toBe(true);
-  });
-
-  it("is false when neither source exists", () => {
-    expect(
-      hasDocumentTemplateMetadata({
-        __: {
-          name: "page-set-name",
-        },
-      })
-    ).toBe(false);
   });
 });

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { getDocumentTemplateName, hasDocumentTemplateMetadata } from "./resolveTemplateName.js";
+
+describe("getDocumentTemplateName", () => {
+  it("prefers _pageset.config.template over codeTemplate", () => {
+    expect(
+      getDocumentTemplateName({
+        _pageset: JSON.stringify({
+          config: {
+            template: "accounts/123/visualEditorTemplates/main",
+          },
+        }),
+        __: {
+          codeTemplate: "legacy-template",
+          name: "page-set-name",
+        },
+      })
+    ).toBe("accounts/123/visualEditorTemplates/main");
+  });
+
+  it("supports _pageset when it is already an object", () => {
+    expect(
+      getDocumentTemplateName({
+        _pageset: {
+          config: {
+            template: "accounts/123/visualEditorTemplates/main",
+          },
+        },
+        __: {
+          codeTemplate: "legacy-template",
+          name: "page-set-name",
+        },
+      })
+    ).toBe("accounts/123/visualEditorTemplates/main");
+  });
+
+  it("falls back when _pageset cannot be parsed", () => {
+    expect(
+      getDocumentTemplateName({
+        _pageset: "{not-json",
+        __: {
+          codeTemplate: "legacy-template",
+          name: "page-set-name",
+        },
+      })
+    ).toBe("legacy-template");
+  });
+
+  it("falls back to document.__.codeTemplate", () => {
+    expect(
+      getDocumentTemplateName({
+        __: {
+          codeTemplate: "legacy-template",
+          name: "page-set-name",
+        },
+      })
+    ).toBe("legacy-template");
+  });
+
+  it("falls back to document.__.name", () => {
+    expect(
+      getDocumentTemplateName({
+        __: {
+          name: "page-set-name",
+        },
+      })
+    ).toBe("page-set-name");
+  });
+});
+
+describe("hasDocumentTemplateMetadata", () => {
+  it("is true when _pageset.config.template exists", () => {
+    expect(
+      hasDocumentTemplateMetadata({
+        _pageset: JSON.stringify({
+          config: {
+            template: "accounts/123/visualEditorTemplates/main",
+          },
+        }),
+      })
+    ).toBe(true);
+  });
+
+  it("falls back to codeTemplate metadata", () => {
+    expect(
+      hasDocumentTemplateMetadata({
+        __: {
+          codeTemplate: "legacy-template",
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("is false when neither source exists", () => {
+    expect(
+      hasDocumentTemplateMetadata({
+        __: {
+          name: "page-set-name",
+        },
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
@@ -1,0 +1,29 @@
+const getPageSetTemplateNameFromDocument = (document: Record<string, any>): string | undefined => {
+  const pageSet = document._pageset;
+  if (!pageSet) {
+    return undefined;
+  }
+
+  const parsedPageSet =
+    typeof pageSet === "string"
+      ? (() => {
+          try {
+            return JSON.parse(pageSet);
+          } catch {
+            return undefined;
+          }
+        })()
+      : pageSet;
+
+  return parsedPageSet?.config?.template;
+};
+
+export const getDocumentTemplateName = (document: Record<string, any>): string | undefined => {
+  return (
+    getPageSetTemplateNameFromDocument(document) ?? document.__?.codeTemplate ?? document.__?.name
+  );
+};
+
+export const hasDocumentTemplateMetadata = (document: Record<string, any>): boolean => {
+  return Boolean(getPageSetTemplateNameFromDocument(document) ?? document.__?.codeTemplate);
+};

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
@@ -5,21 +5,6 @@ export const normalizeTemplateName = (value: unknown): string | undefined => {
   return value.trim() || undefined;
 };
 
-export const getTemplateIdFromConfigTemplate = (value: unknown): string | undefined => {
-  const normalizedTemplateName = normalizeTemplateName(value);
-  if (!normalizedTemplateName) {
-    return undefined;
-  }
-
-  const prefix = "visualEditorTemplates/";
-  const prefixIndex = normalizedTemplateName.lastIndexOf(prefix);
-  if (prefixIndex === -1) {
-    return normalizedTemplateName;
-  }
-
-  return normalizeTemplateName(normalizedTemplateName.slice(prefixIndex + prefix.length));
-};
-
 export const getDocumentTemplateName = (document: Record<string, any>): string | undefined => {
   const pageSet = document._pageset;
   const parsedPageSet =
@@ -34,8 +19,25 @@ export const getDocumentTemplateName = (document: Record<string, any>): string |
       : pageSet;
 
   return (
-    getTemplateIdFromConfigTemplate(parsedPageSet?.config?.template) ??
+    getVisualEditorTemplateId(parsedPageSet?.config?.template) ??
     normalizeTemplateName(document.__?.codeTemplate) ??
     normalizeTemplateName(document.__?.name)
   );
+};
+
+// getVisualEditorTemplateId extracts the template ID from the visualEditorTemplate
+// which comes in the format of "accounts/{accountId}/visualEditorTemplates/{templateId}"
+const getVisualEditorTemplateId = (value: unknown): string | undefined => {
+  const normalizedTemplateName = normalizeTemplateName(value);
+  if (!normalizedTemplateName) {
+    return undefined;
+  }
+
+  const prefix = "visualEditorTemplates/";
+  const prefixIndex = normalizedTemplateName.lastIndexOf(prefix);
+  if (prefixIndex === -1) {
+    return normalizedTemplateName;
+  }
+
+  return normalizeTemplateName(normalizedTemplateName.slice(prefixIndex + prefix.length));
 };

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
@@ -27,7 +27,7 @@ export const getDocumentTemplateName = (document: Record<string, any>): string |
 
 // getVisualEditorTemplateId extracts the template ID from the visualEditorTemplate
 // which comes in the format of "accounts/{accountId}/visualEditorTemplates/{templateId}"
-const getVisualEditorTemplateId = (value: unknown): string | undefined => {
+export const getVisualEditorTemplateId = (value: unknown): string | undefined => {
   const normalizedTemplateName = normalizeTemplateName(value);
   if (!normalizedTemplateName) {
     return undefined;

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
@@ -1,4 +1,4 @@
-const normalizeTemplateName = (value: unknown): string | undefined => {
+export const normalizeTemplateName = (value: unknown): string | undefined => {
   if (typeof value !== "string") {
     return undefined;
   }

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
@@ -1,9 +1,12 @@
-const getPageSetTemplateNameFromDocument = (document: Record<string, any>): string | undefined => {
-  const pageSet = document._pageset;
-  if (!pageSet) {
+const normalizeTemplateName = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
     return undefined;
   }
+  return value.trim() || undefined;
+};
 
+export const getDocumentTemplateName = (document: Record<string, any>): string | undefined => {
+  const pageSet = document._pageset;
   const parsedPageSet =
     typeof pageSet === "string"
       ? (() => {
@@ -15,15 +18,9 @@ const getPageSetTemplateNameFromDocument = (document: Record<string, any>): stri
         })()
       : pageSet;
 
-  return parsedPageSet?.config?.template;
-};
-
-export const getDocumentTemplateName = (document: Record<string, any>): string | undefined => {
   return (
-    getPageSetTemplateNameFromDocument(document) ?? document.__?.codeTemplate ?? document.__?.name
+    normalizeTemplateName(parsedPageSet?.config?.template) ??
+    normalizeTemplateName(document.__?.codeTemplate) ??
+    normalizeTemplateName(document.__?.name)
   );
-};
-
-export const hasDocumentTemplateMetadata = (document: Record<string, any>): boolean => {
-  return Boolean(getPageSetTemplateNameFromDocument(document) ?? document.__?.codeTemplate);
 };

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
@@ -5,6 +5,21 @@ export const normalizeTemplateName = (value: unknown): string | undefined => {
   return value.trim() || undefined;
 };
 
+export const getTemplateIdFromConfigTemplate = (value: unknown): string | undefined => {
+  const normalizedTemplateName = normalizeTemplateName(value);
+  if (!normalizedTemplateName) {
+    return undefined;
+  }
+
+  const prefix = "visualEditorTemplates/";
+  const prefixIndex = normalizedTemplateName.lastIndexOf(prefix);
+  if (prefixIndex === -1) {
+    return normalizedTemplateName;
+  }
+
+  return normalizeTemplateName(normalizedTemplateName.slice(prefixIndex + prefix.length));
+};
+
 export const getDocumentTemplateName = (document: Record<string, any>): string | undefined => {
   const pageSet = document._pageset;
   const parsedPageSet =
@@ -19,7 +34,7 @@ export const getDocumentTemplateName = (document: Record<string, any>): string |
       : pageSet;
 
   return (
-    normalizeTemplateName(parsedPageSet?.config?.template) ??
+    getTemplateIdFromConfigTemplate(parsedPageSet?.config?.template) ??
     normalizeTemplateName(document.__?.codeTemplate) ??
     normalizeTemplateName(document.__?.name)
   );

--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -21,7 +21,11 @@ import { getPartition } from "../../../util/partition.js";
 import { getYextUrlForPartition } from "../../../util/url.js";
 import path from "node:path";
 import { logWarning } from "../../../util/logError.js";
-import { getInPlatformPageSetDocuments, PageSetConfig } from "../ssr/inPlatformPageSets.js";
+import {
+  getInPlatformPageSetDocuments,
+  getPageSetTemplateName,
+  PageSetConfig,
+} from "../ssr/inPlatformPageSets.js";
 
 type Props = {
   vite: ViteDevServer;
@@ -161,7 +165,7 @@ export const indexPage =
               (await pageSetAccumulator) +
               `<h4>
                 ${pageSetConfig.display_name}
-                pages [template: ${pageSetConfig.code_template}] (${
+                pages [template: ${getPageSetTemplateName(pageSetConfig)}] (${
                   (documents?.filter((d) => !useProdURLs || d.slug) || []).length
                 }):
               </h4>

--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -165,7 +165,7 @@ export const indexPage =
               (await pageSetAccumulator) +
               `<h4>
                 ${pageSetConfig.display_name}
-                pages [template: ${getPageSetTemplateName(pageSetConfig)}] (${
+                pages [template: ${getPageSetTemplateName(pageSetConfig) ?? "unknown"}] (${
                   (documents?.filter((d) => !useProdURLs || d.slug) || []).length
                 }):
               </h4>

--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -83,25 +83,29 @@ export const serverRenderRoute =
 
       // Look up the template by the in-platform configured template if present, otherwise
       // fall back to the legacy code_template value.
-      const pageSetTemplateName = pageSet ? getPageSetTemplateName(pageSet) : undefined;
-      if (siteId && pageSet && !pageSetTemplateName) {
+      const isInPlatformPageSet = Boolean(siteId && pageSet);
+      let templateName = feature;
+      if (isInPlatformPageSet && pageSet) {
+        templateName = getPageSetTemplateName(pageSet);
+      }
+
+      if (!templateName && pageSet) {
         send404(res, `Cannot determine template for in-platform page set: ${pageSet.id}`);
         return;
       }
-      const templateModuleInternal =
-        siteId && pageSet
-          ? await findTemplateModuleInternalByName(
-              vite,
-              pageSetTemplateName,
-              templateFilepaths,
-              true
-            )
-          : await findTemplateModuleInternalByName(vite, feature, templateFilepaths, false);
+
+      const templateModuleInternal = await findTemplateModuleInternalByName(
+        vite,
+        templateName,
+        templateFilepaths,
+        isInPlatformPageSet
+      );
+
       if (!templateModuleInternal) {
         send404(
           res,
-          pageSet
-            ? `Cannot find template: ${pageSetTemplateName}`
+          isInPlatformPageSet
+            ? `Cannot find template: ${templateName}`
             : `Cannot find template corresponding to feature: ${feature}`
         );
         return;

--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -83,12 +83,16 @@ export const serverRenderRoute =
 
       // Look up the template by the in-platform configured template if present, otherwise
       // fall back to the legacy code_template value.
-      const pageSetTemplateName = pageSet && getPageSetTemplateName(pageSet);
+      const pageSetTemplateName = pageSet ? getPageSetTemplateName(pageSet) : undefined;
+      if (siteId && pageSet && !pageSetTemplateName) {
+        send404(res, `Cannot determine template for in-platform page set: ${pageSet.id}`);
+        return;
+      }
       const templateModuleInternal =
         siteId && pageSet
           ? await findTemplateModuleInternalByName(
               vite,
-              pageSetTemplateName ?? "",
+              pageSetTemplateName,
               templateFilepaths,
               true
             )

--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -86,12 +86,12 @@ export const serverRenderRoute =
       const isInPlatformPageSet = Boolean(siteId && pageSet);
       let templateName = feature;
       if (isInPlatformPageSet && pageSet) {
-        templateName = getPageSetTemplateName(pageSet);
-      }
-
-      if (!templateName && pageSet) {
-        send404(res, `Cannot determine template for in-platform page set: ${pageSet.id}`);
-        return;
+        const pageSetTemplateName = getPageSetTemplateName(pageSet);
+        if (!pageSetTemplateName) {
+          send404(res, `Cannot find template for in-platform page set: ${pageSet.id}`);
+          return;
+        }
+        templateName = pageSetTemplateName;
       }
 
       const templateModuleInternal = await findTemplateModuleInternalByName(

--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -13,7 +13,11 @@ import { generateTestDataForPage } from "../ssr/generateTestData.js";
 import { entityPageCriterion, getLocalData } from "../ssr/getLocalData.js";
 import send404 from "./send404.js";
 import { findStaticTemplateModuleAndDocBySlug } from "../ssr/findMatchingStaticTemplate.js";
-import { getInPlatformPageSetDocuments, PageSetConfig } from "../ssr/inPlatformPageSets.js";
+import {
+  getInPlatformPageSetDocuments,
+  getPageSetTemplateName,
+  PageSetConfig,
+} from "../ssr/inPlatformPageSets.js";
 
 type Props = {
   vite: ViteDevServer;
@@ -77,12 +81,14 @@ export const serverRenderRoute =
         return;
       }
 
-      // Look up the template by code_template if in-platform or feature if in-repo
+      // Look up the template by the in-platform configured template if present, otherwise
+      // fall back to the legacy code_template value.
+      const pageSetTemplateName = pageSet && getPageSetTemplateName(pageSet);
       const templateModuleInternal =
         siteId && pageSet
           ? await findTemplateModuleInternalByName(
               vite,
-              pageSet.code_template,
+              pageSetTemplateName ?? "",
               templateFilepaths,
               true
             )
@@ -91,7 +97,7 @@ export const serverRenderRoute =
         send404(
           res,
           pageSet
-            ? `Cannot find template: ${pageSet.code_template}`
+            ? `Cannot find template: ${pageSetTemplateName}`
             : `Cannot find template corresponding to feature: ${feature}`
         );
         return;

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -5,10 +5,7 @@ import { findTemplateModuleInternalByName } from "../ssr/findTemplateModuleInter
 import { ProjectStructure } from "../../../common/src/project/structure.js";
 import { getTemplateFilepathsFromProjectStructure } from "../../../common/src/template/internal/getTemplateFilepaths.js";
 import { TemplateRenderProps } from "../../../common/src/template/types.js";
-import {
-  getDocumentTemplateName,
-  hasDocumentTemplateMetadata,
-} from "../../../common/src/template/internal/resolveTemplateName.js";
+import { getDocumentTemplateName } from "../../../common/src/template/internal/resolveTemplateName.js";
 import sendAppHTML from "./sendAppHTML.js";
 import { generateTestDataForSlug } from "../ssr/generateTestData.js";
 import { getLocalEntityPageDataForSlug } from "../ssr/getLocalData.js";
@@ -93,7 +90,7 @@ export const serverRenderSlugRoute =
         vite,
         feature,
         templateFilepaths,
-        hasDocumentTemplateMetadata(document)
+        Boolean(document._pageset || document.__?.codeTemplate)
       );
       if (!templateModuleInternal) {
         send404(res, `Cannot find template corresponding to feature: ${feature}`);

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -81,19 +81,19 @@ export const serverRenderSlugRoute =
         return;
       }
 
-      const feature = getDocumentTemplateName(document);
-      if (!feature) {
+      const templateName = getDocumentTemplateName(document);
+      if (!templateName) {
         send404(res, `Cannot find template corresponding to slug: ${slug}`);
         return;
       }
       const templateModuleInternal = await findTemplateModuleInternalByName(
         vite,
-        feature,
+        templateName,
         templateFilepaths,
         Boolean(document._pageset || document.__?.codeTemplate)
       );
       if (!templateModuleInternal) {
-        send404(res, `Cannot find template corresponding to feature: ${feature}`);
+        send404(res, `Cannot find template corresponding to feature: ${templateName}`);
         return;
       }
 

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -58,6 +58,7 @@ export const serverRenderSlugRoute =
 
       // If in-platform page sets exist, try to match the slug to a page set
       let document;
+      let isInPlatformDocument = false;
       if (siteId && inPlatformPageSets.length) {
         for (const ps of inPlatformPageSets) {
           document = (
@@ -66,6 +67,7 @@ export const serverRenderSlugRoute =
             })
           )?.[0];
           if (document) {
+            isInPlatformDocument = true;
             break;
           }
         }
@@ -90,7 +92,7 @@ export const serverRenderSlugRoute =
         vite,
         templateName,
         templateFilepaths,
-        Boolean(document._pageset || document.__?.codeTemplate)
+        isInPlatformDocument
       );
       if (!templateModuleInternal) {
         send404(res, `Cannot find template corresponding to feature: ${templateName}`);

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -5,6 +5,10 @@ import { findTemplateModuleInternalByName } from "../ssr/findTemplateModuleInter
 import { ProjectStructure } from "../../../common/src/project/structure.js";
 import { getTemplateFilepathsFromProjectStructure } from "../../../common/src/template/internal/getTemplateFilepaths.js";
 import { TemplateRenderProps } from "../../../common/src/template/types.js";
+import {
+  getDocumentTemplateName,
+  hasDocumentTemplateMetadata,
+} from "../../../common/src/template/internal/resolveTemplateName.js";
 import sendAppHTML from "./sendAppHTML.js";
 import { generateTestDataForSlug } from "../ssr/generateTestData.js";
 import { getLocalEntityPageDataForSlug } from "../ssr/getLocalData.js";
@@ -80,12 +84,16 @@ export const serverRenderSlugRoute =
         return;
       }
 
-      const feature = document.__.codeTemplate || document.__.name;
+      const feature = getDocumentTemplateName(document);
+      if (!feature) {
+        send404(res, `Cannot find template corresponding to slug: ${slug}`);
+        return;
+      }
       const templateModuleInternal = await findTemplateModuleInternalByName(
         vite,
         feature,
         templateFilepaths,
-        Boolean(document.__.codeTemplate)
+        hasDocumentTemplateMetadata(document)
       );
       if (!templateModuleInternal) {
         send404(res, `Cannot find template corresponding to feature: ${feature}`);

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getPageSetTemplateName, PageSetConfig } from "./inPlatformPageSets.js";
+
+const pageSet = {
+  id: "locations",
+  name: "sites/test/pagesets/locations",
+  display_name: "Locations",
+  code_template: "legacy-template",
+  config: {
+    template: "new-template",
+  },
+  scope: {
+    locales: ["en"],
+    saved_filters: [],
+    entity_types: ["location"],
+  },
+} satisfies PageSetConfig;
+
+describe("getPageSetTemplateName", () => {
+  it("prefers config.template over code_template", () => {
+    expect(getPageSetTemplateName(pageSet)).toBe("new-template");
+  });
+
+  it("falls back to code_template", () => {
+    expect(
+      getPageSetTemplateName({
+        ...pageSet,
+        config: undefined,
+      })
+    ).toBe("legacy-template");
+  });
+});

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
@@ -7,7 +7,7 @@ const pageSet = {
   display_name: "Locations",
   code_template: "legacy-template",
   config: {
-    template: "new-template",
+    template: "accounts/123/visualEditorTemplates/new-template",
   },
   scope: {
     locales: ["en"],
@@ -19,6 +19,17 @@ const pageSet = {
 describe("getPageSetTemplateName", () => {
   it("prefers config.template over code_template", () => {
     expect(getPageSetTemplateName(pageSet)).toBe("new-template");
+  });
+
+  it("supports plain template ids in config.template", () => {
+    expect(
+      getPageSetTemplateName({
+        ...pageSet,
+        config: {
+          template: "new-template",
+        },
+      })
+    ).toBe("new-template");
   });
 
   it("falls back to code_template when config.template is blank", () => {

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
@@ -21,6 +21,17 @@ describe("getPageSetTemplateName", () => {
     expect(getPageSetTemplateName(pageSet)).toBe("new-template");
   });
 
+  it("falls back to code_template when config.template is blank", () => {
+    expect(
+      getPageSetTemplateName({
+        ...pageSet,
+        config: {
+          template: "   ",
+        },
+      })
+    ).toBe("legacy-template");
+  });
+
   it("falls back to code_template", () => {
     expect(
       getPageSetTemplateName({

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
@@ -40,4 +40,14 @@ describe("getPageSetTemplateName", () => {
       })
     ).toBe("legacy-template");
   });
+
+  it("returns undefined when no template metadata exists", () => {
+    expect(
+      getPageSetTemplateName({
+        ...pageSet,
+        code_template: undefined,
+        config: undefined,
+      })
+    ).toBeUndefined();
+  });
 });

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
@@ -1,6 +1,6 @@
 import { spawn } from "child_process";
 import {
-  getTemplateIdFromConfigTemplate,
+  getVisualEditorTemplateId,
   normalizeTemplateName,
 } from "../../../common/src/template/internal/resolveTemplateName.js";
 
@@ -24,7 +24,7 @@ export type PageSetConfig = {
  */
 export const getPageSetTemplateName = (pageSet: PageSetConfig): string | undefined => {
   return (
-    getTemplateIdFromConfigTemplate(pageSet.config?.template) ??
+    getVisualEditorTemplateId(pageSet.config?.template) ??
     normalizeTemplateName(pageSet.code_template)
   );
 };

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
@@ -1,4 +1,5 @@
 import { spawn } from "child_process";
+import { normalizeTemplateName } from "../../../common/src/template/internal/resolveTemplateName.js";
 
 export type PageSetConfig = {
   name: string;
@@ -13,13 +14,6 @@ export type PageSetConfig = {
     entity_types: string[];
   };
   display_name: string;
-};
-
-const normalizeTemplateName = (value: unknown): string | undefined => {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  return value.trim() || undefined;
 };
 
 export const getPageSetTemplateName = (pageSet: PageSetConfig): string | undefined => {

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
@@ -19,11 +19,9 @@ export type PageSetConfig = {
 /*
  * getPageSetTemplateName gets the template name for a fetched pageset, as opposed to the pageset on the document.
  */
-export const getPageSetTemplateName = (pageSet: PageSetConfig): string => {
+export const getPageSetTemplateName = (pageSet: PageSetConfig): string | undefined => {
   return (
-    normalizeTemplateName(pageSet.config?.template) ??
-    normalizeTemplateName(pageSet.code_template) ??
-    "unknown"
+    normalizeTemplateName(pageSet.config?.template) ?? normalizeTemplateName(pageSet.code_template)
   );
 };
 

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
@@ -1,5 +1,8 @@
 import { spawn } from "child_process";
-import { normalizeTemplateName } from "../../../common/src/template/internal/resolveTemplateName.js";
+import {
+  getTemplateIdFromConfigTemplate,
+  normalizeTemplateName,
+} from "../../../common/src/template/internal/resolveTemplateName.js";
 
 export type PageSetConfig = {
   name: string;
@@ -21,7 +24,8 @@ export type PageSetConfig = {
  */
 export const getPageSetTemplateName = (pageSet: PageSetConfig): string | undefined => {
   return (
-    normalizeTemplateName(pageSet.config?.template) ?? normalizeTemplateName(pageSet.code_template)
+    getTemplateIdFromConfigTemplate(pageSet.config?.template) ??
+    normalizeTemplateName(pageSet.code_template)
   );
 };
 

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
@@ -3,13 +3,20 @@ import { spawn } from "child_process";
 export type PageSetConfig = {
   name: string;
   id: string;
-  code_template: string;
+  code_template?: string;
+  config?: {
+    template?: string;
+  };
   scope: {
     locales: string[];
     saved_filters: string[];
     entity_types: string[];
   };
   display_name: string;
+};
+
+export const getPageSetTemplateName = (pageSet: PageSetConfig): string | undefined => {
+  return pageSet.config?.template ?? pageSet.code_template;
 };
 
 export const getInPlatformPageSets = async (siteId: number): Promise<PageSetConfig[]> => {
@@ -51,12 +58,14 @@ export const getInPlatformPageSetDocuments = async (
     args.push("--slug", filters.slug);
   }
 
-  return await spawnPageSetCommands(
+  const documents = await spawnPageSetCommands(
     process.stdout,
     "yext",
     ["pages", "visual-editor", "document", ...args],
     "["
   );
+
+  return documents;
 };
 
 async function spawnPageSetCommands(

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
@@ -16,9 +16,14 @@ export type PageSetConfig = {
   display_name: string;
 };
 
-export const getPageSetTemplateName = (pageSet: PageSetConfig): string | undefined => {
+/*
+ * getPageSetTemplateName gets the template name for a fetched pageset, as opposed to the pageset on the document.
+ */
+export const getPageSetTemplateName = (pageSet: PageSetConfig): string => {
   return (
-    normalizeTemplateName(pageSet.config?.template) ?? normalizeTemplateName(pageSet.code_template)
+    normalizeTemplateName(pageSet.config?.template) ??
+    normalizeTemplateName(pageSet.code_template) ??
+    "unknown"
   );
 };
 

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
@@ -15,8 +15,17 @@ export type PageSetConfig = {
   display_name: string;
 };
 
+const normalizeTemplateName = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return value.trim() || undefined;
+};
+
 export const getPageSetTemplateName = (pageSet: PageSetConfig): string | undefined => {
-  return pageSet.config?.template ?? pageSet.code_template;
+  return (
+    normalizeTemplateName(pageSet.config?.template) ?? normalizeTemplateName(pageSet.code_template)
+  );
 };
 
 export const getInPlatformPageSets = async (siteId: number): Promise<PageSetConfig[]> => {
@@ -58,14 +67,12 @@ export const getInPlatformPageSetDocuments = async (
     args.push("--slug", filters.slug);
   }
 
-  const documents = await spawnPageSetCommands(
+  return await spawnPageSetCommands(
     process.stdout,
     "yext",
     ["pages", "visual-editor", "document", ...args],
     "["
   );
-
-  return documents;
 };
 
 async function spawnPageSetCommands(

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
@@ -51,5 +51,5 @@ export default async (
     return await generateRedirectResponses(redirect, props);
   }
 
-  throw new Error(`Could not find path for feature ${templateName}`);
+  throw new Error(`Could not find path for template ${templateName}`);
 };

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
@@ -28,13 +28,13 @@ export default async (
   manifest: Manifest
 ): Promise<GeneratedPage | GeneratedRedirect> => {
   const projectStructure = new ProjectStructure(manifest.projectStructure);
-  const feature = getDocumentTemplateName(props.document);
+  const templateName = getDocumentTemplateName(props.document);
 
-  if (!feature) {
+  if (!templateName) {
     throw new Error("Could not determine template name from document metadata");
   }
 
-  const template = await readTemplateModules(feature, manifest, projectStructure);
+  const template = await readTemplateModules(templateName, manifest, projectStructure);
   if (template) {
     const pluginRenderTemplates = await getPluginRenderTemplates(manifest, projectStructure);
     return await generateTemplateResponses(
@@ -46,10 +46,10 @@ export default async (
     );
   }
 
-  const redirect = await readRedirectModules(feature, manifest, projectStructure);
+  const redirect = await readRedirectModules(templateName, manifest, projectStructure);
   if (redirect) {
     return await generateRedirectResponses(redirect, props);
   }
 
-  throw new Error(`Could not find path for feature ${feature}`);
+  throw new Error(`Could not find path for feature ${templateName}`);
 };

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
@@ -28,13 +28,13 @@ export default async (
   manifest: Manifest
 ): Promise<GeneratedPage | GeneratedRedirect> => {
   const projectStructure = new ProjectStructure(manifest.projectStructure);
-  const templateName = getDocumentTemplateName(props.document);
+  const feature = getDocumentTemplateName(props.document);
 
-  if (!templateName) {
+  if (!feature) {
     throw new Error("Could not determine template name from document metadata");
   }
 
-  const template = await readTemplateModules(templateName, manifest, projectStructure);
+  const template = await readTemplateModules(feature, manifest, projectStructure);
   if (template) {
     const pluginRenderTemplates = await getPluginRenderTemplates(manifest, projectStructure);
     return await generateTemplateResponses(
@@ -46,10 +46,10 @@ export default async (
     );
   }
 
-  const redirect = await readRedirectModules(templateName, manifest, projectStructure);
+  const redirect = await readRedirectModules(feature, manifest, projectStructure);
   if (redirect) {
     return await generateRedirectResponses(redirect, props);
   }
 
-  throw new Error(`Could not find path for template ${templateName}`);
+  throw new Error(`Could not find path for feature ${feature}`);
 };

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
@@ -1,4 +1,5 @@
 import { ProjectStructure } from "../../../../common/src/project/structure.js";
+import { getDocumentTemplateName } from "../../../../common/src/template/internal/resolveTemplateName.js";
 import { Manifest, TemplateProps } from "../../../../common/src/template/types.js";
 import {
   GeneratedPage,
@@ -27,7 +28,11 @@ export default async (
   manifest: Manifest
 ): Promise<GeneratedPage | GeneratedRedirect> => {
   const projectStructure = new ProjectStructure(manifest.projectStructure);
-  const feature = props.document.__.codeTemplate ?? props.document.__.name;
+  const feature = getDocumentTemplateName(props.document);
+
+  if (!feature) {
+    throw new Error("Could not determine template name from document metadata");
+  }
 
   const template = await readTemplateModules(feature, manifest, projectStructure);
   if (template) {


### PR DESCRIPTION
Updates to use the template found in _pageset.config.template

Implements fallback logic to use the old behavior if _pageset.config.template is missing

_pageset.config.template comes through in a resource_name format, so we extract the template_id to match the current patterns