### PR TITLE
feat: set editor feature name to config name

### DIFF
--- a/packages/pages/src/vite-plugin/build/buildStart/buildStart.test.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/buildStart.test.ts
@@ -1,0 +1,38 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { Path } from "../../../common/src/project/path.js";
+import { ProjectStructure } from "../../../common/src/project/structure.js";
+import { discoverInputs, resolveTemplateEntryName } from "./buildStart.js";
+
+const projectStructure = new ProjectStructure();
+const templateFixturesPath = path.join(process.cwd(), "tests/fixtures/buildStartTemplates");
+
+describe("buildStart", () => {
+  it("uses config.name as the emitted entry name for edit templates", async () => {
+    const actual = await resolveTemplateEntryName(
+      path.join(templateFixturesPath, "edit.tsx"),
+      projectStructure
+    );
+
+    expect(actual).toEqual("edit-template-id");
+  });
+
+  it("uses the sibling edit template config.name for edit.client templates", async () => {
+    const actual = await resolveTemplateEntryName(
+      path.join(templateFixturesPath, "edit.client.tsx"),
+      projectStructure
+    );
+
+    expect(actual).toEqual("edit-template-id");
+  });
+
+  it("keeps non-edit templates filename-based while renaming edit server and client entries", async () => {
+    const actual = await discoverInputs([new Path(templateFixturesPath)], [], projectStructure);
+
+    expect(actual).toMatchObject({
+      "server/edit-template-id": path.join(templateFixturesPath, "edit.tsx"),
+      "client/edit-template-id": path.join(templateFixturesPath, "edit.client.tsx"),
+      "server/location": path.join(templateFixturesPath, "location.tsx"),
+    });
+  });
+});

--- a/packages/pages/src/vite-plugin/build/buildStart/buildStart.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/buildStart.ts
@@ -10,6 +10,9 @@ import { convertToPosixPath } from "../../../common/src/template/paths.js";
 import { getGlobalClientServerRenderTemplates } from "../../../common/src/template/internal/getTemplateFilepaths.js";
 import { readdir } from "fs/promises";
 import { NormalizedInputOptions } from "rollup";
+import { loadModules } from "../../../common/src/loader/vite.js";
+import { convertTemplateModuleToTemplateModuleInternal } from "../../../common/src/template/internal/types.js";
+import { TemplateModule } from "../../../common/src/template/types.js";
 
 export default (projectStructure: ProjectStructure) => {
   return async function (this: PluginContext, inputOptions: NormalizedInputOptions): Promise<void> {
@@ -114,6 +117,10 @@ const yextBanner = `
       Built with the Yext SSG Plugin
 `;
 
+const EDIT_TEMPLATE_NAME = "edit";
+const EDIT_TEMPLATE_SERVER_EXTENSIONS = [".tsx", ".jsx", ".js", ".ts"];
+const editTemplateEntryNames = new Map<string, string>();
+
 /**
  * Produces a {@link InputOption} by adding all templates at {@link rootTemplateDir} and
  * {@link scopedTemplateDir} to be output at {@code server/}. If there are two files
@@ -126,30 +133,43 @@ const yextBanner = `
  * @param projectStructure
  * @returns
  */
-const discoverInputs = async (
+export const discoverInputs = async (
   templatePaths: Path[],
   redirectPaths: Path[],
   projectStructure: ProjectStructure
 ): Promise<{ [entryAlias: string]: string }> => {
   const entryPoints: Record<string, string> = {};
-  const updateEntryPoints = async (dir: string, isRedirect: boolean) =>
-    (await readdir(dir, { withFileTypes: true }))
+  const addedTemplateFilenames = new Set<string>();
+  const updateEntryPoints = async (dir: string, isRedirect: boolean) => {
+    const templates = (await readdir(dir, { withFileTypes: true }))
       .filter((dirent) => !dirent.isDirectory())
       .map((file) => file.name)
-      .filter((f) => f !== "_client17.tsx" && f !== "_client.tsx" && f !== "_server.tsx")
-      .forEach((template) => {
-        const parsedPath = parse(template);
-        const bundlePath = isRedirect
-          ? projectStructure.config.subfolders.redirectBundle
-          : template.includes(".client")
-            ? projectStructure.config.subfolders.clientBundle
-            : projectStructure.config.subfolders.serverBundle;
-        const outputPath = `${bundlePath}/${parsedPath.name.replace(".client", "")}`;
-        if (entryPoints[outputPath]) {
-          return;
-        }
-        entryPoints[outputPath] = path.join(dir, template);
-      });
+      .filter((f) => f !== "_client17.tsx" && f !== "_client.tsx" && f !== "_server.tsx");
+
+    for (const template of templates) {
+      const parsedPath = parse(template);
+      const bundlePath = isRedirect
+        ? projectStructure.config.subfolders.redirectBundle
+        : template.includes(".client")
+          ? projectStructure.config.subfolders.clientBundle
+          : projectStructure.config.subfolders.serverBundle;
+      const templateFilepath = path.join(dir, template);
+      const duplicateTemplateKey = `${bundlePath}:${template}`;
+      if (addedTemplateFilenames.has(duplicateTemplateKey)) {
+        continue;
+      }
+
+      const entryName = isRedirect
+        ? parsedPath.name.replace(".client", "")
+        : await resolveTemplateEntryName(templateFilepath, projectStructure);
+      const outputPath = `${bundlePath}/${entryName}`;
+      if (entryPoints[outputPath]) {
+        continue;
+      }
+      addedTemplateFilenames.add(duplicateTemplateKey);
+      entryPoints[outputPath] = templateFilepath;
+    }
+  };
 
   for (const templatePath of templatePaths) {
     await updateEntryPoints(templatePath.getAbsolutePath(), false);
@@ -159,6 +179,55 @@ const discoverInputs = async (
   }
 
   return { ...entryPoints, ...discoverRenderTemplates(projectStructure) };
+};
+
+export const resolveTemplateEntryName = async (
+  templateFilepath: string,
+  projectStructure: ProjectStructure
+): Promise<string> => {
+  const parsedPath = parse(templateFilepath);
+  const templateName = parsedPath.name.replace(".client", "");
+  if (templateName !== EDIT_TEMPLATE_NAME) {
+    return templateName;
+  }
+
+  const editTemplateFilepath = findEditServerTemplateFilepath(templateFilepath);
+  const cachedEntryName = editTemplateEntryNames.get(editTemplateFilepath);
+  if (cachedEntryName) {
+    return cachedEntryName;
+  }
+
+  const [importedTemplateModule] = await loadModules(
+    [editTemplateFilepath],
+    true,
+    projectStructure
+  );
+  const templateModuleInternal = convertTemplateModuleToTemplateModuleInternal(
+    editTemplateFilepath,
+    importedTemplateModule.module as TemplateModule<any, any>,
+    false
+  );
+
+  editTemplateEntryNames.set(editTemplateFilepath, templateModuleInternal.config.name);
+  return templateModuleInternal.config.name;
+};
+
+const findEditServerTemplateFilepath = (templateFilepath: string): string => {
+  if (!templateFilepath.includes(`${EDIT_TEMPLATE_NAME}.client.`)) {
+    return templateFilepath;
+  }
+
+  const templateDir = path.dirname(templateFilepath);
+  for (const extension of EDIT_TEMPLATE_SERVER_EXTENSIONS) {
+    const serverTemplateFilepath = path.join(templateDir, `${EDIT_TEMPLATE_NAME}${extension}`);
+    if (fs.existsSync(serverTemplateFilepath)) {
+      return serverTemplateFilepath;
+    }
+  }
+
+  throw new Error(
+    `Could not find a sibling ${EDIT_TEMPLATE_NAME} template for ${templateFilepath}`
+  );
 };
 
 /**x

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
@@ -37,13 +37,7 @@ export default async (
   const template = await readTemplateModules(feature, manifest, projectStructure);
   if (template) {
     const pluginRenderTemplates = await getPluginRenderTemplates(manifest, projectStructure);
-    return await generateTemplateResponses(
-      template,
-      props,
-      pluginRenderTemplates,
-      manifest,
-      projectStructure
-    );
+    return await generateTemplateResponses(template, props, pluginRenderTemplates, manifest);
   }
 
   const redirect = await readRedirectModules(feature, manifest, projectStructure);

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.test.tsx
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.test.tsx
@@ -8,7 +8,6 @@ import {
 } from "../../../../common/src/template/types.js";
 import { generateTemplateResponses } from "./templateUtils.js";
 import path from "node:path";
-import { ProjectStructure } from "../../../../common/src/project/structure.js";
 
 const baseTemplateModule: TemplateModuleInternal<any, any> = {
   path: "path",
@@ -30,7 +29,51 @@ const manifest: Manifest = {
   redirectPaths: {},
   clientPaths: {},
   renderPaths: {},
-  projectStructure: new ProjectStructure().config,
+  projectStructure: {
+    rootFolders: {
+      source: "src",
+      dist: "dist",
+      sitesConfig: "sites-config",
+      functions: "functions",
+    },
+    subfolders: {
+      templates: "templates",
+      modules: "modules",
+      redirects: "redirects",
+      serverlessFunctions: "functions",
+      assets: "assets",
+      public: "public",
+      clientBundle: "client",
+      serverBundle: "server",
+      redirectBundle: "redirect",
+      renderBundle: "render",
+      renderer: "renderer",
+      static: "static",
+      plugin: "plugin",
+    },
+    sitesConfigFiles: {
+      ci: "ci.json",
+      features: "features.json",
+      siteStream: "site-stream.json",
+      serving: "serving.json",
+      sitemap: "sitemap.json",
+      redirects: "redirects.csv",
+      auth: "auth.json",
+    },
+    distConfigFiles: {
+      templates: "templates.json",
+      artifacts: "artifacts.json",
+      functionMetadata: "functionMetadata.json",
+    },
+    rootFiles: {
+      config: "config.yaml",
+      templateManifest: ".template-manifest.json",
+    },
+    envVarConfig: {
+      envVarDir: "",
+      envVarPrefix: "YEXT_PUBLIC",
+    },
+  },
   bundlerManifest: {},
 };
 
@@ -62,8 +105,6 @@ const serverRenderTemplate: ServerRenderTemplate = {
 };
 
 describe("generateResponses", () => {
-  const projectStructure = new ProjectStructure();
-
   it("calls transformProps when transformProps is defined", async () => {
     const fn = vi.fn((props) => props);
     await generateTemplateResponses(
@@ -73,8 +114,7 @@ describe("generateResponses", () => {
         client: path.join(process.cwd(), "src/common/src/template/internal/_client.tsx"),
         server: serverRenderTemplate,
       },
-      manifest,
-      projectStructure
+      manifest
     );
     expect(fn).toHaveBeenCalled();
   });
@@ -88,8 +128,7 @@ describe("generateResponses", () => {
         client: path.join(process.cwd(), "src/common/src/template/internal/_client.tsx"),
         server: serverRenderTemplate,
       },
-      manifest,
-      projectStructure
+      manifest
     );
     expect(fn).toHaveBeenCalled();
   });

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/templateUtils.ts
@@ -107,8 +107,7 @@ export const generateTemplateResponses = async (
   templateModuleInternal: TemplateModuleInternal<any, any>,
   templateProps: TemplateProps,
   pluginRenderTemplates: PluginRenderTemplates,
-  manifest: Manifest,
-  projectStructure: ProjectStructure
+  manifest: Manifest
 ): Promise<GeneratedPage> => {
   if (templateModuleInternal.transformProps) {
     templateProps = await templateModuleInternal.transformProps(templateProps);
@@ -129,8 +128,7 @@ export const generateTemplateResponses = async (
     templateModuleInternal,
     templateRenderProps,
     pluginRenderTemplates,
-    manifest,
-    projectStructure
+    manifest
   );
 
   return {
@@ -152,8 +150,7 @@ const renderHtml = async (
   templateModuleInternal: TemplateModuleInternal<any, any>,
   props: TemplateRenderProps,
   pluginRenderTemplates: PluginRenderTemplates,
-  manifest: Manifest,
-  projectStructure: ProjectStructure
+  manifest: Manifest
 ) => {
   const { default: component, render, getHeadConfig } = templateModuleInternal;
   if (!component && !render) {
@@ -177,7 +174,6 @@ const renderHtml = async (
     templateModuleInternal,
     templateModuleInternal.config.hydrate,
     pluginRenderTemplates,
-    manifest,
-    projectStructure
+    manifest
   );
 };

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.test.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { ProjectStructure } from "../../../../common/src/project/structure.js";
+import { Manifest } from "../../../../common/src/template/types.js";
+import { findOriginalTemplatePathInManifest } from "./wrapper.js";
+
+describe("findOriginalTemplatePathInManifest", () => {
+  it("finds the source template path from the emitted server bundle path", () => {
+    const manifest: Manifest = {
+      serverPaths: {
+        "edit-template-id": "assets/server/edit-template-id.abc123.js",
+      },
+      redirectPaths: {},
+      clientPaths: {},
+      renderPaths: {},
+      projectStructure: new ProjectStructure().config,
+      bundlerManifest: {
+        "src/templates/edit.tsx": {
+          file: "assets/server/edit-template-id.abc123.js",
+          src: "src/templates/edit.tsx",
+          isEntry: true,
+          css: ["assets/static/edit.css"],
+        },
+      },
+    };
+
+    expect(
+      findOriginalTemplatePathInManifest(manifest, manifest.serverPaths["edit-template-id"])
+    ).toEqual("src/templates/edit.tsx");
+  });
+});

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/wrapper.ts
@@ -5,17 +5,14 @@ import {
   getHydrationTemplate,
   getServerTemplatePlugin,
 } from "../../../../common/src/template/hydration.js";
-import path from "node:path";
 import { PluginRenderTemplates } from "./templateUtils.js";
-import { ProjectStructure } from "../../../../common/src/project/structure.js";
 
 export const reactWrapper = async <T extends TemplateRenderProps>(
   props: T,
   templateModuleInternal: TemplateModuleInternal<any, any>,
   hydrate: boolean,
   pluginRenderTemplates: PluginRenderTemplates,
-  manifest: Manifest,
-  projectStructure: ProjectStructure
+  manifest: Manifest
 ): Promise<string | undefined> => {
   if (!manifest) {
     throw new Error("Manifest is undefined");
@@ -25,9 +22,8 @@ export const reactWrapper = async <T extends TemplateRenderProps>(
     : undefined;
 
   const templateFilepath = findOriginalTemplatePathInManifest(
-    projectStructure,
     manifest,
-    `${templateModuleInternal.templateName}.tsx`
+    manifest.serverPaths[templateModuleInternal.config.name]
   );
   if (!templateFilepath) {
     return;
@@ -74,37 +70,26 @@ export const reactWrapper = async <T extends TemplateRenderProps>(
 };
 
 /**
- * Finds the original template path based on the template name and scope. If a scope is set it
- * first tries to find the scoped template, otherwise falls back to the root templates. Note that
- * a template of the same name cannot exist in the scoped folder and the root. The scope overrides
- * it.
- *
- * @param templateName
- * @param manifest
+ * Finds the original template path by matching the emitted server bundle back to the Vite manifest.
  */
 export const findOriginalTemplatePathInManifest = (
-  projectStructure: ProjectStructure,
   manifest: Manifest,
-  templateName: string // with extension
+  serverBundlePath: string | undefined
 ) => {
-  // src/templates
-  const templatesRoot = path.join(
-    projectStructure.config.rootFolders.source,
-    projectStructure.config.subfolders.templates
-  );
-
-  if (projectStructure.config.scope) {
-    const scopedFilepath = path.join(templatesRoot, projectStructure.config.scope, templateName);
-
-    if (Object.keys(manifest.bundlerManifest).some((key) => key.includes(scopedFilepath))) {
-      return scopedFilepath;
-    }
+  if (!serverBundlePath) {
+    console.error("Template server bundle path was not found in manifest");
+    return;
   }
 
-  const filepath = path.join(templatesRoot, templateName);
-  if (Object.keys(manifest.bundlerManifest).some((key) => key.includes(filepath))) {
-    return filepath;
+  const matchingEntry = Object.entries(manifest.bundlerManifest ?? {}).find(([, info]) => {
+    return (
+      typeof info === "object" && info !== null && "file" in info && info.file === serverBundlePath
+    );
+  });
+
+  if (matchingEntry) {
+    return matchingEntry[0];
   }
 
-  console.error(`Template ${templateName} not found in manifest`);
+  console.error(`Template bundle ${serverBundlePath} not found in manifest`);
 };

--- a/packages/pages/tests/fixtures/buildStartTemplates/edit.client.tsx
+++ b/packages/pages/tests/fixtures/buildStartTemplates/edit.client.tsx
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/pages/tests/fixtures/buildStartTemplates/edit.tsx
+++ b/packages/pages/tests/fixtures/buildStartTemplates/edit.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { GetPath, Template, TemplateConfig, TemplateProps, TemplateRenderProps } from "@yext/pages";
+
+export const config: TemplateConfig = {
+  name: "edit-template-id",
+  streamId: "$id",
+};
+
+export const getPath: GetPath<TemplateProps> = () => {
+  return "edit";
+};
+
+const EditTemplate: Template<TemplateRenderProps> = () => {
+  return <>Edit</>;
+};
+
+export default EditTemplate;

--- a/packages/pages/tests/fixtures/buildStartTemplates/location.tsx
+++ b/packages/pages/tests/fixtures/buildStartTemplates/location.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { GetPath, Template, TemplateProps, TemplateRenderProps } from "@yext/pages";
+
+export const getPath: GetPath<TemplateProps> = () => {
+  return "location";
+};
+
+const LocationTemplate: Template<TemplateRenderProps> = () => {
+  return <>Location</>;
+};
+
+export default LocationTemplate;


### PR DESCRIPTION
This updates the feature name for templates with filename `edit` to use the config.name rather than the filename.