### PR TITLE
fix: module asset paths had double slash in production

### DIFF
--- a/packages/pages/src/vite-plugin/modules/plugin.ts
+++ b/packages/pages/src/vite-plugin/modules/plugin.ts
@@ -109,7 +109,7 @@ export const buildModules = async (
               domain = new URL(
                 "https://" +
                   JSON.parse(process.env.YEXT_SITE_ARGUMENT).productionDomain
-              ).toString();
+              ).origin;
             } catch (_) {
               logErrorAndExit("Cannot parse YEXT_SITE_ARGUMENT");
             }


### PR DESCRIPTION
Calling .toString() on a URL results in a slash at the end while using origin does not. 