### PR TITLE
chore: prevent shell injection in github action (vuln-44057)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,9 +40,13 @@ jobs:
 
       - name: Verify package version and get npm tag
         id: get_npm_tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          TAG=$(pnpm run ci-verify-publish ${{ github.ref_name }} | tail -n 1)
-          echo "npm_tag=$TAG" >> $GITHUB_OUTPUT
+          TAG=$(pnpm run ci-verify-publish "$REF_NAME" | tail -n 1)
+          echo "npm_tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Publish
-        run: cd packages/pages && pnpm publish --access public --tag ${{ steps.get_npm_tag.outputs.npm_tag }} --no-git-checks
+        env:
+          NPM_TAG: ${{ steps.get_npm_tag.outputs.npm_tag }}
+        run: cd packages/pages && pnpm publish --access public --tag "$NPM_TAG" --no-git-checks


### PR DESCRIPTION
> Summary
> Using variable interpolation $... with github context data in a run: step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. github context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with env: to store the data and use the environment variable in the run: script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".