### PR TITLE
feat: add reverseProxyPrefix flag to build

### DIFF
--- a/packages/pages/src/build/build.test.ts
+++ b/packages/pages/src/build/build.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { build } from "vite";
+import { buildHandler } from "./build.js";
+import { REVERSE_PROXY_PREFIX_ENV_VAR } from "../util/reverseProxyOverride.js";
+
+vi.mock("vite", () => ({
+  build: vi.fn(),
+}));
+
+vi.mock("../util/viteConfig.js", () => ({
+  scopedViteConfigPath: vi.fn(() => "vite.config.js"),
+}));
+
+describe("buildHandler", () => {
+  afterEach(() => {
+    delete process.env[REVERSE_PROXY_PREFIX_ENV_VAR];
+    vi.clearAllMocks();
+  });
+
+  it("sets the reverse proxy env var when the flag is provided", async () => {
+    await buildHandler({
+      pluginFilesizeLimit: 10,
+      pluginTotalFilesizeLimit: 20,
+      reverseProxyPrefix: "www.brand.com/locations",
+    });
+
+    expect(process.env[REVERSE_PROXY_PREFIX_ENV_VAR]).toEqual("www.brand.com/locations");
+    expect(build).toHaveBeenCalledWith({
+      configFile: "vite.config.js",
+    });
+  });
+
+  it("clears the reverse proxy env var when the flag is absent", async () => {
+    process.env[REVERSE_PROXY_PREFIX_ENV_VAR] = "www.brand.com/legacy";
+
+    await buildHandler({
+      pluginFilesizeLimit: 10,
+      pluginTotalFilesizeLimit: 20,
+    });
+
+    expect(process.env[REVERSE_PROXY_PREFIX_ENV_VAR]).toBeUndefined();
+  });
+});

--- a/packages/pages/src/build/build.ts
+++ b/packages/pages/src/build/build.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { build } from "vite";
 import { scopedViteConfigPath } from "../util/viteConfig.js";
+import { REVERSE_PROXY_PREFIX_ENV_VAR } from "../util/reverseProxyOverride.js";
 
 /**
  * The arguments passed to the build CLI command.
@@ -10,10 +11,14 @@ export interface BuildArgs {
   scope?: string;
   pluginFilesizeLimit: number;
   pluginTotalFilesizeLimit: number;
+  reverseProxyPrefix?: string;
 }
 
-const handler = async (buildArgs: BuildArgs) => {
-  const { scope, pluginFilesizeLimit, pluginTotalFilesizeLimit } = buildArgs;
+/**
+ * Runs the Pages production build with CLI arguments forwarded into the Vite plugin environment.
+ */
+export const buildHandler = async (buildArgs: BuildArgs) => {
+  const { scope, pluginFilesizeLimit, pluginTotalFilesizeLimit, reverseProxyPrefix } = buildArgs;
 
   // Pass CLI arguments as env variables to use in vite-plugin
   if (scope) {
@@ -21,6 +26,11 @@ const handler = async (buildArgs: BuildArgs) => {
   }
   process.env.YEXT_PAGES_PLUGIN_FILESIZE_LIMIT = String(pluginFilesizeLimit);
   process.env.YEXT_PAGES_PLUGIN_TOTAL_FILESIZE_LIMIT = String(pluginTotalFilesizeLimit);
+  if (reverseProxyPrefix) {
+    process.env[REVERSE_PROXY_PREFIX_ENV_VAR] = reverseProxyPrefix;
+  } else {
+    delete process.env[REVERSE_PROXY_PREFIX_ENV_VAR];
+  }
 
   await build({
     configFile: scopedViteConfigPath(scope),
@@ -38,5 +48,6 @@ export const buildCommand = (program: Command) => {
       "The max size of all plugin files combined in MB",
       "10"
     )
-    .action(handler);
+    .option("--reverse-proxy-prefix <string>", "The reverse proxy prefix to apply to the build")
+    .action(buildHandler);
 };

--- a/packages/pages/src/common/src/assets/getAssetsFilepath.test.ts
+++ b/packages/pages/src/common/src/assets/getAssetsFilepath.test.ts
@@ -1,12 +1,25 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { determineAssetsFilepath } from "./getAssetsFilepath.js";
 import * as importHelper from "./import.js";
+import { REVERSE_PROXY_PREFIX_ENV_VAR } from "../../../util/reverseProxyOverride.js";
 
 describe("getAssetsFilepath - determineAssetsFilepath", () => {
+  afterEach(() => {
+    delete process.env[REVERSE_PROXY_PREFIX_ENV_VAR];
+  });
+
   it("returns assets when no files defined", async () => {
     const actual = await determineAssetsFilepath("assets", "");
 
     expect(actual).toEqual("assets");
+  });
+
+  it("returns reverse proxy assets when the env var is present", async () => {
+    process.env[REVERSE_PROXY_PREFIX_ENV_VAR] = "www.brand.com/locations";
+
+    const actual = await determineAssetsFilepath("assets", "");
+
+    expect(actual).toEqual("locations/assets");
   });
 
   it("returns custom assets from vite config", async () => {

--- a/packages/pages/src/common/src/assets/getAssetsFilepath.ts
+++ b/packages/pages/src/common/src/assets/getAssetsFilepath.ts
@@ -1,10 +1,11 @@
 import { pathToFileURL } from "url";
 import { UserConfig } from "vite";
 import { import_ } from "./import.js";
+import { getReverseProxyOverride } from "../../../util/reverseProxyOverride.js";
 
 /**
  * Determines the assets directory to use by checking
- * vite.config.json's assetDir or default to "assets".
+ * the reverse proxy override, then vite.config.json's assetDir, or defaulting to "assets".
  * @param defaultAssetsDir the default directory for assets
  * @param viteConfigPath the path to vite.config.js
  */
@@ -12,6 +13,11 @@ export const determineAssetsFilepath = async (
   defaultAssetsDir: string,
   viteConfigPath: string
 ): Promise<string> => {
+  const reverseProxyOverride = getReverseProxyOverride();
+  if (reverseProxyOverride) {
+    return reverseProxyOverride.assetsDir;
+  }
+
   if (viteConfigPath === "") {
     return defaultAssetsDir;
   }

--- a/packages/pages/src/common/src/config/readConfigYaml.test.ts
+++ b/packages/pages/src/common/src/config/readConfigYaml.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readConfigYaml } from "./readConfigYaml.js";
+import { ProjectStructure } from "../project/structure.js";
+import { processEnvVariables } from "../../../util/processEnvVariables.js";
+import { REVERSE_PROXY_PREFIX_ENV_VAR } from "../../../util/reverseProxyOverride.js";
+
+vi.mock("../../../util/processEnvVariables.js", () => ({
+  processEnvVariables: vi.fn(() => ({})),
+}));
+
+describe("readConfigYaml", () => {
+  const projectStructure = new ProjectStructure({});
+
+  afterEach(() => {
+    if (fs.existsSync("config.yaml")) {
+      fs.rmSync("config.yaml");
+    }
+    delete process.env[REVERSE_PROXY_PREFIX_ENV_VAR];
+    vi.mocked(processEnvVariables).mockReset();
+  });
+
+  it("returns undefined when config.yaml does not exist", () => {
+    expect(readConfigYaml(projectStructure)).toBeUndefined();
+  });
+
+  it("substitutes environment variables from config.yaml", () => {
+    vi.mocked(processEnvVariables).mockReturnValueOnce({
+      PREFIX: "www.brand.com/locations",
+    });
+    fs.writeFileSync(
+      "config.yaml",
+      `serving:
+  reverseProxyPrefix: PREFIX
+`
+    );
+
+    expect(readConfigYaml(projectStructure)).toEqual({
+      serving: {
+        reverseProxyPrefix: "www.brand.com/locations",
+      },
+    });
+  });
+
+  it("overrides reverse proxy config while preserving unrelated config", () => {
+    process.env[REVERSE_PROXY_PREFIX_ENV_VAR] = "www.brand.com/locations";
+    fs.writeFileSync(
+      "config.yaml",
+      `serving:
+  reverseProxyPrefix: old.example.com/legacy
+  customSetting: true
+dynamicRoutes:
+  - from: /health
+    to: /internal/health
+    status: 200
+  - from: /assets/*
+    to: /legacy/assets/:splat
+    status: 302
+sitemap:
+  filename: sitemap.xml
+`
+    );
+
+    expect(readConfigYaml(projectStructure)).toEqual({
+      serving: {
+        reverseProxyPrefix: "www.brand.com/locations",
+        customSetting: true,
+      },
+      dynamicRoutes: [
+        {
+          from: "/health",
+          to: "/internal/health",
+          status: 200,
+        },
+        {
+          from: "/assets/*",
+          to: "/locations/assets/:splat",
+          status: 200,
+        },
+      ],
+      sitemap: {
+        filename: "sitemap.xml",
+      },
+    });
+  });
+
+  it("adds the reverse proxy dynamic route when it is missing", () => {
+    process.env[REVERSE_PROXY_PREFIX_ENV_VAR] = "www.brand.com/locations";
+    fs.writeFileSync(
+      "config.yaml",
+      `serving:
+  customSetting: true
+`
+    );
+
+    expect(readConfigYaml(projectStructure)).toEqual({
+      serving: {
+        customSetting: true,
+        reverseProxyPrefix: "www.brand.com/locations",
+      },
+      dynamicRoutes: [
+        {
+          from: "/assets/*",
+          to: "/locations/assets/:splat",
+          status: 200,
+        },
+      ],
+    });
+  });
+});

--- a/packages/pages/src/common/src/config/readConfigYaml.ts
+++ b/packages/pages/src/common/src/config/readConfigYaml.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import YAML from "yaml";
+import { processEnvVariables } from "../../../util/processEnvVariables.js";
+import { getReverseProxyOverride } from "../../../util/reverseProxyOverride.js";
+import { ProjectStructure } from "../project/structure.js";
+
+export interface ConfigYamlData {
+  siteStream?: {
+    id?: string;
+    entityId?: string | number;
+    fields?: string[];
+    localization?: {
+      locales?: string[];
+      primary?: true;
+    };
+    transform?: {
+      expandOptionFields?: string[];
+      replaceOptionValuesWithDisplayNames?: string[];
+    };
+    [key: string]: unknown;
+  };
+  serving?: {
+    reverseProxyPrefix?: string;
+    [key: string]: unknown;
+  };
+  dynamicRoutes?: Array<{
+    from?: string;
+    to?: string;
+    status?: number;
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+}
+
+/**
+ * Loads config.yaml for the given project structure, substitutes environment variables,
+ * and applies any reverse proxy override from the build environment.
+ */
+export const readConfigYaml = (projectStructure: ProjectStructure): ConfigYamlData | undefined => {
+  const configYamlPath = projectStructure.getConfigYamlPath().getAbsolutePath();
+  if (!fs.existsSync(configYamlPath)) {
+    return;
+  }
+
+  const envVars = processEnvVariables(projectStructure.config.envVarConfig.envVarPrefix);
+  const parsedConfigYaml = substituteEnvVars(
+    YAML.parse(fs.readFileSync(configYamlPath, "utf-8")) ?? {},
+    envVars
+  ) as ConfigYamlData;
+  const reverseProxyOverride = getReverseProxyOverride();
+  if (!reverseProxyOverride) {
+    return parsedConfigYaml;
+  }
+
+  const configYaml = structuredClone(parsedConfigYaml);
+  configYaml.serving = {
+    ...configYaml.serving,
+    reverseProxyPrefix: reverseProxyOverride.reverseProxyPrefix,
+  };
+
+  const dynamicRoutes = configYaml.dynamicRoutes ?? [];
+  const reverseProxyRouteIndex = dynamicRoutes.findIndex((route) => route.from === "/assets/*");
+
+  if (reverseProxyRouteIndex === -1) {
+    configYaml.dynamicRoutes = [...dynamicRoutes, { ...reverseProxyOverride.dynamicRoute }];
+    return configYaml;
+  }
+
+  configYaml.dynamicRoutes = [...dynamicRoutes];
+  configYaml.dynamicRoutes[reverseProxyRouteIndex] = {
+    ...configYaml.dynamicRoutes[reverseProxyRouteIndex],
+    ...reverseProxyOverride.dynamicRoute,
+  };
+
+  return configYaml;
+};
+
+/**
+ * Recursively traverses config.yaml data and substitutes string values that match keys
+ * in the provided environment variable map.
+ */
+const substituteEnvVars = <T>(configData: T, envVars: Record<string, string>): T => {
+  if (typeof configData === "string") {
+    const envValue = envVars[configData];
+    if (envValue !== undefined) {
+      try {
+        return JSON.parse(envValue);
+      } catch {
+        return envValue as T;
+      }
+    }
+    return configData;
+  }
+
+  if (Array.isArray(configData)) {
+    return configData.map((item) => substituteEnvVars(item, envVars)) as T;
+  }
+
+  if (configData && typeof configData === "object") {
+    const newConfig: { [key: string]: unknown } = {};
+    for (const key in configData) {
+      if (Object.prototype.hasOwnProperty.call(configData, key)) {
+        newConfig[key] = substituteEnvVars((configData as Record<string, unknown>)[key], envVars);
+      }
+    }
+    return newConfig as T;
+  }
+
+  return configData;
+};

--- a/packages/pages/src/common/src/feature/stream.ts
+++ b/packages/pages/src/common/src/feature/stream.ts
@@ -1,6 +1,5 @@
 import fs from "fs";
 import path from "path";
-import YAML from "yaml";
 
 import { readJsonSync } from "../../../upgrade/migrateConfig.js";
 import { TemplateConfigInternal } from "../template/internal/types.js";
@@ -8,7 +7,7 @@ import { RedirectConfigInternal } from "../redirect/internal/types.js";
 import { ProjectStructure } from "../project/structure.js";
 import { logErrorAndExit } from "../../../util/logError.js";
 import { Stream } from "../template/types.js";
-import { processEnvVariables } from "../../../util/processEnvVariables.js";
+import { readConfigYaml } from "../config/readConfigYaml.js";
 
 /**
  * The shape of data that represents a stream configuration.
@@ -125,42 +124,6 @@ export const convertRedirectConfigToStreamConfig = (
 };
 
 /**
- * Recursively traverses a configuration object and substitutes
- * string values that match keys in the envVars map. Returns a
- * new object with substituted values.
- */
-const substituteEnvVars = <T>(configData: T, envVars: Record<string, string>): T => {
-  if (typeof configData === "string") {
-    const envValue = envVars[configData];
-    if (envValue !== undefined) {
-      try {
-        return JSON.parse(envValue);
-      } catch {
-        return envValue as T;
-      }
-    }
-    return configData;
-  }
-
-  if (Array.isArray(configData)) {
-    return configData.map((item) => substituteEnvVars(item, envVars)) as T;
-  }
-
-  if (configData && typeof configData === "object") {
-    const newConfig: { [key: string]: any } = {};
-    for (const key in configData) {
-      if (Object.prototype.hasOwnProperty.call(configData, key)) {
-        const value = (configData as any)[key];
-        newConfig[key] = substituteEnvVars(value, envVars);
-      }
-    }
-    return newConfig as T;
-  }
-
-  return configData;
-};
-
-/**
  * Loads the site stream specified in config.yaml or site-stream.json into a {@link SiteStream}.
  */
 export const readSiteStream = (projectStructure: ProjectStructure): SiteStream | undefined => {
@@ -175,16 +138,10 @@ export const readSiteStream = (projectStructure: ProjectStructure): SiteStream |
   }
 
   // read site stream from config.yaml
-  const configYamlPath = projectStructure.getConfigYamlPath().getAbsolutePath();
-  if (fs.existsSync(configYamlPath)) {
-    let yamlDoc = YAML.parse(fs.readFileSync(configYamlPath, "utf-8"));
-    const envVars = processEnvVariables(projectStructure.config.envVarConfig.envVarPrefix);
-    yamlDoc = substituteEnvVars(yamlDoc, envVars);
-
-    if (yamlDoc.siteStream) {
-      yamlDoc.siteStream.entityId = yamlDoc.siteStream?.entityId?.toString();
-      return yamlDoc.siteStream;
-    }
+  const configYaml = readConfigYaml(projectStructure);
+  if (configYaml?.siteStream) {
+    configYaml.siteStream.entityId = configYaml.siteStream?.entityId?.toString();
+    return configYaml.siteStream as SiteStream;
   }
 
   return;

--- a/packages/pages/src/prod/prod.test.ts
+++ b/packages/pages/src/prod/prod.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import runSubprocess from "../util/runSubprocess.js";
+import { prodHandler } from "./prod.js";
+
+vi.mock("../util/runSubprocess.js", () => ({
+  default: vi.fn(async () => 0),
+}));
+
+describe("prodHandler", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards the reverse proxy prefix to the build subprocess", async () => {
+    await prodHandler({
+      scope: "brand",
+      reverseProxyPrefix: "www.brand.com/locations",
+    });
+
+    expect(runSubprocess).toHaveBeenNthCalledWith(1, "yext pages", [
+      "build",
+      "--scope brand",
+      "--reverse-proxy-prefix www.brand.com/locations",
+    ]);
+  });
+});

--- a/packages/pages/src/prod/prod.ts
+++ b/packages/pages/src/prod/prod.ts
@@ -5,16 +5,31 @@ interface ProdArgs {
   noBuild?: boolean;
   noRender?: boolean;
   scope?: string;
+  reverseProxyPrefix?: string;
 }
 
-const handler = async ({ noBuild, noRender, scope }: ProdArgs) => {
+/**
+ * Runs the local production flow by chaining build, render, and serve commands.
+ */
+export const prodHandler = async ({ noBuild, noRender, scope, reverseProxyPrefix }: ProdArgs) => {
   const command = "yext pages";
 
   if (!noBuild) {
-    await runSubprocess(command, ["build", scope ? `--scope ${scope}` : ""]);
+    const buildArgs = ["build"];
+    if (scope) {
+      buildArgs.push(`--scope ${scope}`);
+    }
+    if (reverseProxyPrefix) {
+      buildArgs.push(`--reverse-proxy-prefix ${reverseProxyPrefix}`);
+    }
+    await runSubprocess(command, buildArgs);
   }
   if (!noRender) {
-    await runSubprocess(command, ["render", scope ? `--scope ${scope}` : ""]);
+    const renderArgs = ["render"];
+    if (scope) {
+      renderArgs.push(`--scope ${scope}`);
+    }
+    await runSubprocess(command, renderArgs);
   }
   await runSubprocess(command, ["serve"]);
 };
@@ -26,5 +41,9 @@ export const prodCommand = (program: Command) => {
     .option("--noBuild", "Disable build step")
     .option("--noRender", "Disable render step")
     .option("--scope  <string>", "The subfolder to scope from")
-    .action(handler);
+    .option(
+      "--reverse-proxy-prefix <string>",
+      "The reverse proxy prefix to apply to the build step"
+    )
+    .action(prodHandler);
 };

--- a/packages/pages/src/util/reverseProxyOverride.test.ts
+++ b/packages/pages/src/util/reverseProxyOverride.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getReverseProxyOverride, REVERSE_PROXY_PREFIX_ENV_VAR } from "./reverseProxyOverride.js";
+
+describe("getReverseProxyOverride", () => {
+  afterEach(() => {
+    delete process.env[REVERSE_PROXY_PREFIX_ENV_VAR];
+  });
+
+  it("returns undefined when the env var is not present", () => {
+    expect(getReverseProxyOverride()).toBeUndefined();
+  });
+
+  it("returns the derived assetsDir and dynamic route", () => {
+    process.env[REVERSE_PROXY_PREFIX_ENV_VAR] = "www.brand.com/locations";
+
+    expect(getReverseProxyOverride()).toEqual({
+      reverseProxyPrefix: "www.brand.com/locations",
+      assetsDir: "locations/assets",
+      dynamicRoute: {
+        from: "/assets/*",
+        to: "/locations/assets/:splat",
+        status: 200,
+      },
+    });
+  });
+
+  it("supports nested subpaths", () => {
+    process.env[REVERSE_PROXY_PREFIX_ENV_VAR] = "www.brand.com/foo/bar";
+
+    expect(getReverseProxyOverride()?.assetsDir).toEqual("foo/bar/assets");
+    expect(getReverseProxyOverride()?.dynamicRoute.to).toEqual("/foo/bar/assets/:splat");
+  });
+
+  it("throws when the env var does not include a slash", () => {
+    process.env[REVERSE_PROXY_PREFIX_ENV_VAR] = "www.brand.com";
+
+    expect(() => getReverseProxyOverride()).toThrow(/Expected a host and subpath/);
+  });
+
+  it("throws when the env var has an empty subpath", () => {
+    process.env[REVERSE_PROXY_PREFIX_ENV_VAR] = "www.brand.com/";
+
+    expect(() => getReverseProxyOverride()).toThrow(/Expected a non-empty subpath/);
+  });
+});

--- a/packages/pages/src/util/reverseProxyOverride.ts
+++ b/packages/pages/src/util/reverseProxyOverride.ts
@@ -1,0 +1,49 @@
+export const REVERSE_PROXY_PREFIX_ENV_VAR = "YEXT_PAGES_REVERSE_PROXY_PREFIX";
+
+export interface ReverseProxyOverride {
+  reverseProxyPrefix: string;
+  assetsDir: string;
+  dynamicRoute: {
+    from: string;
+    to: string;
+    status: number;
+  };
+}
+
+/**
+ * Reads and validates the reverse proxy prefix override from the build environment.
+ *
+ * The expected format is a host followed by a slash-delimited subpath such as
+ * "www.brand.com/locations". When present, the subpath is used to derive both
+ * the build assets directory and the reverse-proxy asset rewrite route.
+ */
+export const getReverseProxyOverride = (): ReverseProxyOverride | undefined => {
+  const reverseProxyPrefix = process.env[REVERSE_PROXY_PREFIX_ENV_VAR];
+  if (!reverseProxyPrefix) {
+    return;
+  }
+
+  const firstSlashIndex = reverseProxyPrefix.indexOf("/");
+  if (firstSlashIndex === -1) {
+    throw new Error(
+      `Invalid reverseProxyPrefix "${reverseProxyPrefix}". Expected a host and subpath like "www.brand.com/locations".`
+    );
+  }
+
+  const subpath = reverseProxyPrefix.substring(firstSlashIndex + 1);
+  if (!subpath) {
+    throw new Error(
+      `Invalid reverseProxyPrefix "${reverseProxyPrefix}". Expected a non-empty subpath after the first slash.`
+    );
+  }
+
+  return {
+    reverseProxyPrefix,
+    assetsDir: `${subpath}/assets`,
+    dynamicRoute: {
+      from: "/assets/*",
+      to: `/${subpath}/assets/:splat`,
+      status: 200,
+    },
+  };
+};


### PR DESCRIPTION
Adds a new flag "--reverse-proxy-prefix" to "pages build" command.

This flag is also available for "npm run prod" wherein it will be passed to the build step.