### PR TITLE
chore: ensure vite's dev server is loopback bound

### DIFF
--- a/packages/pages/src/dev/server/server.ts
+++ b/packages/pages/src/dev/server/server.ts
@@ -28,6 +28,7 @@ import { DevArgs } from "../dev.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVERLESS_FUNCTION_POST_REQUEST_LIMIT = "50mb";
+const DEV_SERVER_HOST = "localhost";
 
 /**
  * @internal
@@ -76,9 +77,11 @@ export const createServer = async (devServerPort: number, devArgs: DevArgs) => {
           modulePath: moduleInfo.modulePath,
         })
       );
-      app.listen(devServerPort, () => process.stdout.write(`listening on :${devServerPort}\n`));
+      app.listen(devServerPort, DEV_SERVER_HOST, () =>
+        process.stdout.write(`listening on http://${DEV_SERVER_HOST}:${devServerPort}\n`)
+      );
       if (openBrowser) {
-        await open(`http://localhost:${devServerPort}/modules/${moduleInfo.moduleName}`);
+        await open(`http://${DEV_SERVER_HOST}:${devServerPort}/modules/${moduleInfo.moduleName}`);
       }
       return;
     }
@@ -238,5 +241,7 @@ export const createServer = async (devServerPort: number, devArgs: DevArgs) => {
 
   app.use(errorMiddleware(vite));
 
-  app.listen(devServerPort, () => process.stdout.write(`listening on :${devServerPort}\n`));
+  app.listen(devServerPort, DEV_SERVER_HOST, () =>
+    process.stdout.write(`listening on http://${DEV_SERVER_HOST}:${devServerPort}\n`)
+  );
 };


### PR DESCRIPTION
This [vuln](https://yext.atlassian.net/browse/VULN-45051?atlOrigin=eyJpIjoiN2FiMDZlZjVkNjZjNDE0NzllYjAyMjk3MDM2OGYzNjciLCJwIjoiaiJ9) requires either a vite upgrade or that the vulnerability isn't reachable. 

This PR ensures our dev server is loopback bound and therefore the vulnerability isn't reachable