### PR TITLE
chore: adjust @types/node

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -201,7 +201,7 @@ The following npm packages may be included in this product:
  - @types/markdown-it@14.1.2
  - @types/mdast@4.0.4
  - @types/mdurl@2.0.0
- - @types/node@25.9.3
+ - @types/node@20.19.43
  - @types/prop-types@15.7.15
  - @types/react@18.3.28
  - @types/unist@3.0.3
@@ -8317,7 +8317,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 The following npm package may be included in this product:
 
- - undici-types@7.24.6
+ - undici-types@6.21.0
 
 This package contains the following license:
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.14.202",
     "@types/minimist": "^1.2.5",
-    "@types/node": "^24.0.0",
+    "@types/node": "^20.0.0",
     "@types/prompts": "^2.4.9",
     "@types/semver": "^7.5.6",
     "execa": "^8.0.1",

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -92,7 +92,7 @@
     "@types/glob": "^8.1.0",
     "@types/lodash": "^4.17.0",
     "@types/mime-types": "^2.1.4",
-    "@types/node": "^25.9.3",
+    "@types/node": "^20.0.0",
     "@types/prompts": "^2.4.9",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.2.5
         version: 1.2.5
       '@types/node':
-        specifier: ^24.0.0
-        version: 24.13.2
+        specifier: ^20.0.0
+        version: 20.19.43
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
@@ -151,23 +151,23 @@ importers:
         version: 22.0.0
       vite:
         specifier: ^4.3.0 || ^5.0.2
-        version: 5.4.11(@types/node@25.9.3)
+        version: 5.4.11(@types/node@20.19.43)
       vite-plugin-node-polyfills:
         specifier: 0.17.0
-        version: 0.17.0(rollup@4.59.0)(vite@5.4.11(@types/node@25.9.3))
+        version: 0.17.0(rollup@4.59.0)(vite@5.4.11(@types/node@20.19.43))
       vitepress:
         specifier: 1.5.0
-        version: 1.5.0(@algolia/client-search@5.15.0)(@types/node@25.9.3)(@types/react@18.3.28)(postcss@8.4.35)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 1.5.0(@algolia/client-search@5.15.0)(@types/node@20.19.43)(@types/react@18.3.28)(postcss@8.4.35)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)
       yaml:
         specifier: ^2.4.1
         version: 2.4.1
     devDependencies:
       '@microsoft/api-documenter':
         specifier: ^7.25.21
-        version: 7.25.21(@types/node@25.9.3)
+        version: 7.25.21(@types/node@20.19.43)
       '@microsoft/api-extractor':
         specifier: ^7.57.7
-        version: 7.58.7(@types/node@25.9.3)
+        version: 7.58.7(@types/node@20.19.43)
       '@types/escape-html':
         specifier: ^1.0.4
         version: 1.0.4
@@ -190,8 +190,8 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4
       '@types/node':
-        specifier: ^25.9.3
-        version: 25.9.3
+        specifier: ^20.0.0
+        version: 20.19.43
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
@@ -221,7 +221,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.0.6(@types/node@25.9.3)(jsdom@24.0.0)
+        version: 3.0.6(@types/node@20.19.43)(jsdom@24.0.0)
 
   packages/plugins: {}
 
@@ -1261,8 +1261,8 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
-  '@types/node@24.13.2':
-    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
@@ -3908,8 +3908,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -4674,43 +4674,43 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@microsoft/api-documenter@7.25.21(@types/node@25.9.3)':
+  '@microsoft/api-documenter@7.25.21(@types/node@20.19.43)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.8(@types/node@25.9.3)
+      '@microsoft/api-extractor-model': 7.29.8(@types/node@20.19.43)
       '@microsoft/tsdoc': 0.15.0
-      '@rushstack/node-core-library': 5.9.0(@types/node@25.9.3)
-      '@rushstack/terminal': 0.14.2(@types/node@25.9.3)
-      '@rushstack/ts-command-line': 4.23.0(@types/node@25.9.3)
+      '@rushstack/node-core-library': 5.9.0(@types/node@20.19.43)
+      '@rushstack/terminal': 0.14.2(@types/node@20.19.43)
+      '@rushstack/ts-command-line': 4.23.0(@types/node@20.19.43)
       js-yaml: 3.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.29.8(@types/node@25.9.3)':
+  '@microsoft/api-extractor-model@7.29.8(@types/node@20.19.43)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.9.0(@types/node@25.9.3)
+      '@rushstack/node-core-library': 5.9.0(@types/node@20.19.43)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.33.8(@types/node@25.9.3)':
+  '@microsoft/api-extractor-model@7.33.8(@types/node@20.19.43)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.3)
+      '@rushstack/node-core-library': 5.23.1(@types/node@20.19.43)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.58.7(@types/node@25.9.3)':
+  '@microsoft/api-extractor@7.58.7(@types/node@20.19.43)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.8(@types/node@25.9.3)
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@20.19.43)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.3)
+      '@rushstack/node-core-library': 5.23.1(@types/node@20.19.43)
       '@rushstack/rig-package': 0.7.3
-      '@rushstack/terminal': 0.24.0(@types/node@25.9.3)
-      '@rushstack/ts-command-line': 5.3.9(@types/node@25.9.3)
+      '@rushstack/terminal': 0.24.0(@types/node@20.19.43)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@20.19.43)
       diff: 8.0.4
       minimatch: 10.2.3
       resolve: 1.22.8
@@ -5054,7 +5054,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@rushstack/node-core-library@5.23.1(@types/node@25.9.3)':
+  '@rushstack/node-core-library@5.23.1(@types/node@20.19.43)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -5065,9 +5065,9 @@ snapshots:
       resolve: 1.22.8
       semver: 7.7.4
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
-  '@rushstack/node-core-library@5.9.0(@types/node@25.9.3)':
+  '@rushstack/node-core-library@5.9.0(@types/node@20.19.43)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -5078,44 +5078,44 @@ snapshots:
       resolve: 1.22.8
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@25.9.3)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@20.19.43)':
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
   '@rushstack/rig-package@0.7.3':
     dependencies:
       jju: 1.4.0
       resolve: 1.22.8
 
-  '@rushstack/terminal@0.14.2(@types/node@25.9.3)':
+  '@rushstack/terminal@0.14.2(@types/node@20.19.43)':
     dependencies:
-      '@rushstack/node-core-library': 5.9.0(@types/node@25.9.3)
+      '@rushstack/node-core-library': 5.9.0(@types/node@20.19.43)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
-  '@rushstack/terminal@0.24.0(@types/node@25.9.3)':
+  '@rushstack/terminal@0.24.0(@types/node@20.19.43)':
     dependencies:
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.3)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@25.9.3)
+      '@rushstack/node-core-library': 5.23.1(@types/node@20.19.43)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@20.19.43)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
-  '@rushstack/ts-command-line@4.23.0(@types/node@25.9.3)':
+  '@rushstack/ts-command-line@4.23.0(@types/node@20.19.43)':
     dependencies:
-      '@rushstack/terminal': 0.14.2(@types/node@25.9.3)
+      '@rushstack/terminal': 0.14.2(@types/node@20.19.43)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/ts-command-line@5.3.9(@types/node@25.9.3)':
+  '@rushstack/ts-command-line@5.3.9(@types/node@20.19.43)':
     dependencies:
-      '@rushstack/terminal': 0.24.0(@types/node@25.9.3)
+      '@rushstack/terminal': 0.24.0(@types/node@20.19.43)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -5225,11 +5225,11 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
   '@types/escape-html@1.0.4': {}
 
@@ -5239,7 +5239,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.17.43':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
       '@types/qs': 6.9.12
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -5254,12 +5254,12 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
   '@types/hast@3.0.4':
     dependencies:
@@ -5269,7 +5269,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
   '@types/linkify-it@5.0.0': {}
 
@@ -5298,17 +5298,18 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
-  '@types/node@24.13.2':
+  '@types/node@20.19.43':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 6.21.0
 
   '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
+    optional: true
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
       kleur: 3.0.3
 
   '@types/prop-types@15.7.15': {}
@@ -5339,13 +5340,13 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
   '@types/serve-static@1.15.5':
     dependencies:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.4
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
 
   '@types/unist@3.0.3': {}
 
@@ -5364,9 +5365,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.0(vite@5.4.11(@types/node@25.9.3))(vue@3.5.13(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.0(vite@5.4.11(@types/node@20.19.43))(vue@3.5.13(typescript@5.9.3))':
     dependencies:
-      vite: 5.4.11(@types/node@25.9.3)
+      vite: 5.4.11(@types/node@20.19.43)
       vue: 3.5.13(typescript@5.9.3)
 
   '@vitest/expect@3.0.6':
@@ -5376,13 +5377,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.6(vite@5.4.11(@types/node@25.9.3))':
+  '@vitest/mocker@3.0.6(vite@5.4.11(@types/node@20.19.43))':
     dependencies:
       '@vitest/spy': 3.0.6
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.11(@types/node@25.9.3)
+      vite: 5.4.11(@types/node@20.19.43)
 
   '@vitest/pretty-format@3.0.6':
     dependencies:
@@ -8281,9 +8282,10 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.18.2: {}
+  undici-types@6.21.0: {}
 
-  undici-types@7.24.6: {}
+  undici-types@7.24.6:
+    optional: true
 
   unique-filename@3.0.0:
     dependencies:
@@ -8383,13 +8385,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.0.6(@types/node@25.9.3):
+  vite-node@3.0.6(@types/node@20.19.43):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 5.4.11(@types/node@25.9.3)
+      vite: 5.4.11(@types/node@20.19.43)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8401,13 +8403,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-node-polyfills@0.17.0(rollup@4.59.0)(vite@5.4.11(@types/node@25.9.3)):
+  vite-plugin-node-polyfills@0.17.0(rollup@4.59.0)(vite@5.4.11(@types/node@20.19.43)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.59.0)
       buffer-polyfill: buffer@6.0.3
       node-stdlib-browser: 1.3.1
       process: 0.11.10
-      vite: 5.4.11(@types/node@25.9.3)
+      vite: 5.4.11(@types/node@20.19.43)
     transitivePeerDependencies:
       - rollup
 
@@ -8420,16 +8422,16 @@ snapshots:
       '@types/node': 25.9.3
       fsevents: 2.3.3
 
-  vite@5.4.11(@types/node@25.9.3):
+  vite@5.4.11(@types/node@20.19.43):
     dependencies:
       esbuild: 0.28.1
       postcss: 8.4.49
       rollup: 4.59.0
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
       fsevents: 2.3.3
 
-  vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@25.9.3)(@types/react@18.3.28)(postcss@8.4.35)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@20.19.43)(@types/react@18.3.28)(postcss@8.4.35)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3):
     dependencies:
       '@docsearch/css': 3.8.0
       '@docsearch/js': 3.8.0(@algolia/client-search@5.15.0)(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)
@@ -8438,7 +8440,7 @@ snapshots:
       '@shikijs/transformers': 1.23.1
       '@shikijs/types': 1.23.1
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.0(vite@5.4.11(@types/node@25.9.3))(vue@3.5.13(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.0(vite@5.4.11(@types/node@20.19.43))(vue@3.5.13(typescript@5.9.3))
       '@vue/devtools-api': 7.6.4
       '@vue/shared': 3.5.13
       '@vueuse/core': 11.3.0(vue@3.5.13(typescript@5.9.3))
@@ -8447,7 +8449,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.1
       shiki: 1.23.1
-      vite: 5.4.11(@types/node@25.9.3)
+      vite: 5.4.11(@types/node@20.19.43)
       vue: 3.5.13(typescript@5.9.3)
     optionalDependencies:
       postcss: 8.4.35
@@ -8479,10 +8481,10 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.0.6(@types/node@25.9.3)(jsdom@24.0.0):
+  vitest@3.0.6(@types/node@20.19.43)(jsdom@24.0.0):
     dependencies:
       '@vitest/expect': 3.0.6
-      '@vitest/mocker': 3.0.6(vite@5.4.11(@types/node@25.9.3))
+      '@vitest/mocker': 3.0.6(vite@5.4.11(@types/node@20.19.43))
       '@vitest/pretty-format': 3.0.6
       '@vitest/runner': 3.0.6
       '@vitest/snapshot': 3.0.6
@@ -8498,11 +8500,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.11(@types/node@25.9.3)
-      vite-node: 3.0.6(@types/node@25.9.3)
+      vite: 5.4.11(@types/node@20.19.43)
+      vite-node: 3.0.6(@types/node@20.19.43)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.43
       jsdom: 24.0.0
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Upgraded `@types/node` too high in my last PR when it should align with lowest node version we support