### PR TITLE
feat: use template from _pageset.config (#608)

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -202,8 +202,8 @@ The following npm packages may be included in this product:
  - @types/mdast@4.0.4
  - @types/mdurl@2.0.0
  - @types/node@20.19.41
- - @types/prop-types@15.7.15
- - @types/react@18.3.28
+ - @types/prop-types@15.7.11
+ - @types/react@18.3.12
  - @types/unist@3.0.3
  - @types/web-bluetooth@0.0.20
 
@@ -8281,8 +8281,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-<<<<<<< HEAD
-=======
 The following npm package may be included in this product:
 
  - undici-types@6.21.0
@@ -8313,39 +8311,6 @@ SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
-
- - react-dom@19.2.4
- - react@19.2.4
- - scheduler@0.27.0
-
-These packages each contain the following license:
-
-MIT License
-
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------------
-
->>>>>>> 8ba6b60 (chore: update minimatch (#614))
 The following npm package may be included in this product:
 
  - perfect-debounce@1.0.0
@@ -8742,11 +8707,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 The following npm package may be included in this product:
 
-<<<<<<< HEAD
- - minimatch@9.0.3
-=======
  - minimatch@9.0.9
->>>>>>> 8ba6b60 (chore: update minimatch (#614))
 
 This package contains the following license:
 

--- a/packages/pages/docs/api/pages.getlang.md
+++ b/packages/pages/docs/api/pages.getlang.md
@@ -9,14 +9,10 @@ Function that takes in a [HeadConfig](./pages.headconfig.md) interface and a pro
 **Signature:**
 
 ```typescript
-<<<<<<< HEAD
-getLang: <T extends TemplateRenderProps<any>>(
+getLang: <T extends TemplateRenderProps>(
   headConfig: HeadConfig | undefined,
   props: T
 ) => string;
-=======
-getLang: <T extends TemplateRenderProps>(headConfig: HeadConfig | undefined, props: T) => string;
->>>>>>> 8ba6b60 (chore: update minimatch (#614))
 ```
 
 ## Parameters

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDocumentTemplateName,
+  getVisualEditorTemplateId,
+} from "./resolveTemplateName.js";
+
+const baseDocument = {
+  __: {
+    codeTemplate: "legacy-template",
+    name: "page-set-name",
+  },
+};
+
+describe("getDocumentTemplateName", () => {
+  it("prefers _pageset.config.template over codeTemplate", () => {
+    expect(
+      getDocumentTemplateName({
+        ...baseDocument,
+        _pageset: JSON.stringify({
+          config: {
+            template: "accounts/123/visualEditorTemplates/main",
+          },
+        }),
+      })
+    ).toBe("main");
+  });
+
+  it("supports _pageset when it is already an object", () => {
+    expect(
+      getDocumentTemplateName({
+        ...baseDocument,
+        _pageset: {
+          config: {
+            template: "accounts/123/visualEditorTemplates/main",
+          },
+        },
+      })
+    ).toBe("main");
+  });
+
+  it("falls back when _pageset cannot be parsed", () => {
+    expect(
+      getDocumentTemplateName({
+        ...baseDocument,
+        _pageset: "{not-json",
+      })
+    ).toBe("legacy-template");
+  });
+
+  it("falls back to document.__.codeTemplate", () => {
+    expect(getDocumentTemplateName(baseDocument)).toBe("legacy-template");
+  });
+
+  it("falls back to codeTemplate when _pageset.config.template is blank", () => {
+    expect(
+      getDocumentTemplateName({
+        ...baseDocument,
+        _pageset: JSON.stringify({
+          config: {
+            template: "   ",
+          },
+        }),
+      })
+    ).toBe("legacy-template");
+  });
+
+  it("falls back to document.__.name when codeTemplate is blank", () => {
+    expect(
+      getDocumentTemplateName({
+        ...baseDocument,
+        __: {
+          ...baseDocument.__,
+          codeTemplate: "   ",
+        },
+      })
+    ).toBe("page-set-name");
+  });
+
+  it("falls back to document.__.name", () => {
+    expect(
+      getDocumentTemplateName({
+        ...baseDocument,
+        __: {
+          ...baseDocument.__,
+          codeTemplate: undefined,
+        },
+      })
+    ).toBe("page-set-name");
+  });
+});
+
+describe("getVisualEditorTemplateId", () => {
+  it("extracts the trailing template id from a resource name", () => {
+    expect(
+      getVisualEditorTemplateId("accounts/123/visualEditorTemplates/main")
+    ).toBe("main");
+  });
+
+  it("returns plain template ids unchanged", () => {
+    expect(getVisualEditorTemplateId("main")).toBe("main");
+  });
+});

--- a/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
+++ b/packages/pages/src/common/src/template/internal/resolveTemplateName.ts
@@ -1,0 +1,49 @@
+export const normalizeTemplateName = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return value.trim() || undefined;
+};
+
+export const getDocumentTemplateName = (
+  document: Record<string, any>
+): string | undefined => {
+  const pageSet = document._pageset;
+  const parsedPageSet =
+    typeof pageSet === "string"
+      ? (() => {
+          try {
+            return JSON.parse(pageSet);
+          } catch {
+            return undefined;
+          }
+        })()
+      : pageSet;
+
+  return (
+    getVisualEditorTemplateId(parsedPageSet?.config?.template) ??
+    normalizeTemplateName(document.__?.codeTemplate) ??
+    normalizeTemplateName(document.__?.name)
+  );
+};
+
+// getVisualEditorTemplateId extracts the template ID from the visualEditorTemplate
+// which comes in the format of "accounts/{accountId}/visualEditorTemplates/{templateId}"
+export const getVisualEditorTemplateId = (
+  value: unknown
+): string | undefined => {
+  const normalizedTemplateName = normalizeTemplateName(value);
+  if (!normalizedTemplateName) {
+    return undefined;
+  }
+
+  const prefix = "visualEditorTemplates/";
+  const prefixIndex = normalizedTemplateName.lastIndexOf(prefix);
+  if (prefixIndex === -1) {
+    return normalizedTemplateName;
+  }
+
+  return normalizeTemplateName(
+    normalizedTemplateName.slice(prefixIndex + prefix.length)
+  );
+};

--- a/packages/pages/src/dev/server/middleware/indexPage.ts
+++ b/packages/pages/src/dev/server/middleware/indexPage.ts
@@ -26,6 +26,7 @@ import path from "node:path";
 import { logWarning } from "../../../util/logError.js";
 import {
   getInPlatformPageSetDocuments,
+  getPageSetTemplateName,
   PageSetConfig,
 } from "../ssr/inPlatformPageSets.js";
 
@@ -53,10 +54,7 @@ export const indexPage =
       const { accountId, universe } = parseYextrcContents();
       if (accountId !== undefined && universe !== undefined) {
         const partition = getPartition(Number(accountId));
-        const accountUrl = `https://${getYextUrlForPartition(
-          universe,
-          partition
-        )}/s/${accountId}/`;
+        const accountUrl = `https://${getYextUrlForPartition(universe, partition)}/s/${accountId}/`;
         accountLink = `
           <span class="link-container">
             <a target="_blank" rel="noopener noreferrer" href="${accountUrl}">
@@ -142,11 +140,7 @@ export const indexPage =
                     </tr>
                   </thead>
                   <tbody>
-                    ${createEntityPageListItems(
-                      localDataManifest,
-                      templateName,
-                      useProdURLs
-                    )}
+                    ${createEntityPageListItems(localDataManifest, templateName, useProdURLs)}
                   </tbody>
                 </table>`,
             ""
@@ -182,7 +176,7 @@ export const indexPage =
                 (await pageSetAccumulator) +
                 `<h4>
                 ${pageSetConfig.display_name}
-                pages [template: ${pageSetConfig.code_template}] (${
+                pages [template: ${getPageSetTemplateName(pageSetConfig) ?? "unknown"}] (${
                   (documents?.filter((d) => !useProdURLs || d.slug) || [])
                     .length
                 }):
@@ -195,11 +189,7 @@ export const indexPage =
                     </tr>
                   </thead>
                   <tbody>
-                    ${createInPlatformPageSetsItems(
-                      documents,
-                      pageSetConfig.id,
-                      useProdURLs
-                    )}
+                    ${createInPlatformPageSetsItems(documents, pageSetConfig.id, useProdURLs)}
                   </tbody>
                 </table>`
               );
@@ -413,11 +403,7 @@ const createInPlatformPageSetsItems = (
            </a>
         </td>
         <td>
-          ${
-            accountId && universe
-              ? `<a href="${formatKnowledgeGraphLink(uid)}">${id}</a>`
-              : id
-          }
+          ${accountId && universe ? `<a href="${formatKnowledgeGraphLink(uid)}">${id}</a>` : id}
         </td>
     </tr>`
     );

--- a/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderRoute.ts
@@ -19,6 +19,7 @@ import send404 from "./send404.js";
 import { findStaticTemplateModuleAndDocBySlug } from "../ssr/findMatchingStaticTemplate.js";
 import {
   getInPlatformPageSetDocuments,
+  getPageSetTemplateName,
   PageSetConfig,
 } from "../ssr/inPlatformPageSets.js";
 
@@ -86,26 +87,34 @@ export const serverRenderRoute =
         return;
       }
 
-      // Look up the template by code_template if in-platform or feature if in-repo
-      const templateModuleInternal =
-        siteId && pageSet
-          ? await findTemplateModuleInternalByName(
-              vite,
-              pageSet.code_template,
-              templateFilepaths,
-              true
-            )
-          : await findTemplateModuleInternalByName(
-              vite,
-              feature,
-              templateFilepaths,
-              false
-            );
+      // Look up the template by the in-platform configured template if present, otherwise
+      // fall back to the legacy code_template value.
+      const isInPlatformPageSet = Boolean(siteId && pageSet);
+      let templateName = feature;
+      if (isInPlatformPageSet && pageSet) {
+        const pageSetTemplateName = getPageSetTemplateName(pageSet);
+        if (!pageSetTemplateName) {
+          send404(
+            res,
+            `Cannot find template for in-platform page set: ${pageSet.id}`
+          );
+          return;
+        }
+        templateName = pageSetTemplateName;
+      }
+
+      const templateModuleInternal = await findTemplateModuleInternalByName(
+        vite,
+        templateName,
+        templateFilepaths,
+        isInPlatformPageSet
+      );
+
       if (!templateModuleInternal) {
         send404(
           res,
-          pageSet
-            ? `Cannot find template: ${pageSet.code_template}`
+          isInPlatformPageSet
+            ? `Cannot find template: ${templateName}`
             : `Cannot find template corresponding to feature: ${feature}`
         );
         return;

--- a/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
+++ b/packages/pages/src/dev/server/middleware/serverRenderSlugRoute.ts
@@ -5,6 +5,7 @@ import { findTemplateModuleInternalByName } from "../ssr/findTemplateModuleInter
 import { ProjectStructure } from "../../../common/src/project/structure.js";
 import { getTemplateFilepathsFromProjectStructure } from "../../../common/src/template/internal/getTemplateFilepaths.js";
 import { TemplateRenderProps } from "../../../common/src/template/types.js";
+import { getDocumentTemplateName } from "../../../common/src/template/internal/resolveTemplateName.js";
 import sendAppHTML from "./sendAppHTML.js";
 import { generateTestDataForSlug } from "../ssr/generateTestData.js";
 import { getLocalEntityPageDataForSlug } from "../ssr/getLocalData.js";
@@ -61,6 +62,7 @@ export const serverRenderSlugRoute =
 
       // If in-platform page sets exist, try to match the slug to a page set
       let document;
+      let isInPlatformDocument = false;
       if (siteId && inPlatformPageSets.length) {
         for (const ps of inPlatformPageSets) {
           document = (
@@ -69,6 +71,7 @@ export const serverRenderSlugRoute =
             })
           )?.[0];
           if (document) {
+            isInPlatformDocument = true;
             break;
           }
         }
@@ -89,17 +92,21 @@ export const serverRenderSlugRoute =
         return;
       }
 
-      const feature = document.__.codeTemplate || document.__.name;
+      const templateName = getDocumentTemplateName(document);
+      if (!templateName) {
+        send404(res, `Cannot find template corresponding to slug: ${slug}`);
+        return;
+      }
       const templateModuleInternal = await findTemplateModuleInternalByName(
         vite,
-        feature,
+        templateName,
         templateFilepaths,
-        Boolean(document.__.codeTemplate)
+        isInPlatformDocument
       );
       if (!templateModuleInternal) {
         send404(
           res,
-          `Cannot find template corresponding to feature: ${feature}`
+          `Cannot find template corresponding to feature: ${templateName}`
         );
         return;
       }

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { getPageSetTemplateName, PageSetConfig } from "./inPlatformPageSets.js";
+
+const pageSet = {
+  id: "locations",
+  name: "sites/test/pagesets/locations",
+  display_name: "Locations",
+  code_template: "legacy-template",
+  config: {
+    template: "accounts/123/visualEditorTemplates/new-template",
+  },
+  scope: {
+    locales: ["en"],
+    saved_filters: [],
+    entity_types: ["location"],
+  },
+} satisfies PageSetConfig;
+
+describe("getPageSetTemplateName", () => {
+  it("prefers config.template over code_template", () => {
+    expect(getPageSetTemplateName(pageSet)).toBe("new-template");
+  });
+
+  it("supports plain template ids in config.template", () => {
+    expect(
+      getPageSetTemplateName({
+        ...pageSet,
+        config: {
+          template: "new-template",
+        },
+      })
+    ).toBe("new-template");
+  });
+
+  it("falls back to code_template when config.template is blank", () => {
+    expect(
+      getPageSetTemplateName({
+        ...pageSet,
+        config: {
+          template: "   ",
+        },
+      })
+    ).toBe("legacy-template");
+  });
+
+  it("falls back to code_template", () => {
+    expect(
+      getPageSetTemplateName({
+        ...pageSet,
+        config: undefined,
+      })
+    ).toBe("legacy-template");
+  });
+
+  it("returns undefined when no template metadata exists", () => {
+    expect(
+      getPageSetTemplateName({
+        ...pageSet,
+        code_template: undefined,
+        config: undefined,
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
+++ b/packages/pages/src/dev/server/ssr/inPlatformPageSets.ts
@@ -1,15 +1,34 @@
 import { spawn } from "child_process";
+import {
+  getVisualEditorTemplateId,
+  normalizeTemplateName,
+} from "../../../common/src/template/internal/resolveTemplateName.js";
 
 export type PageSetConfig = {
   name: string;
   id: string;
-  code_template: string;
+  code_template?: string;
+  config?: {
+    template?: string;
+  };
   scope: {
     locales: string[];
     saved_filters: string[];
     entity_types: string[];
   };
   display_name: string;
+};
+
+/*
+ * getPageSetTemplateName gets the template name for a fetched pageset, as opposed to the pageset on the document.
+ */
+export const getPageSetTemplateName = (
+  pageSet: PageSetConfig
+): string | undefined => {
+  return (
+    getVisualEditorTemplateId(pageSet.config?.template) ??
+    normalizeTemplateName(pageSet.code_template)
+  );
 };
 
 export const getInPlatformPageSets = async (
@@ -103,17 +122,13 @@ async function spawnPageSetCommands(
           parsedData = JSON.parse(testData.trim());
         } catch {
           stdout.write(
-            `\nUnable to parse test data from command: \`${command} ${args.join(
-              " "
-            )}\``
+            `\nUnable to parse test data from command: \`${command} ${args.join(" ")}\``
           );
           resolve(null);
         }
       } else {
         stdout.write(
-          `\nUnable to generate test data from command: \`${command} ${args.join(
-            " "
-          )}\``
+          `\nUnable to generate test data from command: \`${command} ${args.join(" ")}\``
         );
       }
 

--- a/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
+++ b/packages/pages/src/vite-plugin/build/buildStart/rendering/renderer.ts
@@ -1,4 +1,5 @@
 import { ProjectStructure } from "../../../../common/src/project/structure.js";
+import { getDocumentTemplateName } from "../../../../common/src/template/internal/resolveTemplateName.js";
 import {
   Manifest,
   TemplateProps,
@@ -30,7 +31,11 @@ export default async (
   manifest: Manifest
 ): Promise<GeneratedPage | GeneratedRedirect> => {
   const projectStructure = new ProjectStructure(manifest.projectStructure);
-  const feature = props.document.__.codeTemplate ?? props.document.__.name;
+  const feature = getDocumentTemplateName(props.document);
+
+  if (!feature) {
+    throw new Error("Could not determine template name from document metadata");
+  }
 
   const template = await readTemplateModules(
     feature,


### PR DESCRIPTION
Updates to use the template found in _pageset.config.template

Implements fallback logic to use the old behavior if _pageset.config.template is missing

_pageset.config.template comes through in a resource_name format, so we extract the template_id to match the current patterns