### PR TITLE
chore: restrict secrets in playwright github action

### DIFF
--- a/.github/workflows/build_and_test_pages.yml
+++ b/.github/workflows/build_and_test_pages.yml
@@ -11,7 +11,8 @@ jobs:
   call_playwright:
     needs: call_build
     uses: ./.github/workflows/playwright.yml
-    secrets: inherit
+    secrets:
+      BOT_REPO_SCOPED_TOKEN: ${{ secrets.BOT_REPO_SCOPED_TOKEN }}
     
   call_jstest:
     needs: call_build


### PR DESCRIPTION
Only passes the needed secret instead of all secrets to the playwright step