### PR TITLE
fix: use createHash instead of globalThis webcrypto

### DIFF
--- a/packages/pages/src/util/fileContentHash.ts
+++ b/packages/pages/src/util/fileContentHash.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 
 /**
@@ -5,6 +6,5 @@ import fs from "node:fs";
  */
 export const getFileContentHash = async (filepath: string): Promise<string> => {
   const contents = fs.readFileSync(filepath);
-  const digest = await globalThis.crypto.subtle.digest("SHA-256", contents);
-  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return createHash("sha256").update(contents).digest("hex");
 };


### PR DESCRIPTION
The previous `globalThis` implementation isn't available in node 18, which is a supported node version on the `1.3.x` branch. Update to import the `createHash` function from `node:crypto` instead of using the `globalThis.webcrypto` property