### PR TITLE
fix: make getFileContentHash sync

### DIFF
--- a/packages/pages/src/common/src/assets/getAssetsFilepath.test.ts
+++ b/packages/pages/src/common/src/assets/getAssetsFilepath.test.ts
@@ -19,7 +19,7 @@ describe("getAssetsFilepath - determineAssetsFilepath", () => {
       },
     };
 
-    vi.spyOn(importHelper, "versionedFileUrl").mockResolvedValue("versioned file path");
+    vi.spyOn(importHelper, "versionedFileUrl").mockReturnValue("versioned file path");
     const importSpy = vi.spyOn(importHelper, "import_");
     importSpy.mockImplementation(async () => viteConfig);
 

--- a/packages/pages/src/common/src/assets/getAssetsFilepath.ts
+++ b/packages/pages/src/common/src/assets/getAssetsFilepath.ts
@@ -15,7 +15,7 @@ export const determineAssetsFilepath = async (
     return defaultAssetsDir;
   }
 
-  const viteConfig = await import_(await versionedFileUrl(viteConfigPath));
+  const viteConfig = await import_(versionedFileUrl(viteConfigPath));
   const userConfig = viteConfig.default as UserConfig;
 
   return userConfig.build?.assetsDir ?? defaultAssetsDir;

--- a/packages/pages/src/common/src/assets/getPublicFilepath.test.ts
+++ b/packages/pages/src/common/src/assets/getPublicFilepath.test.ts
@@ -17,7 +17,7 @@ describe("getPublicFilepath - determinePublicFilepath", () => {
       },
     };
 
-    vi.spyOn(importHelper, "versionedFileUrl").mockResolvedValue("versioned file path");
+    vi.spyOn(importHelper, "versionedFileUrl").mockReturnValue("versioned file path");
     const importSpy = vi.spyOn(importHelper, "import_");
     importSpy.mockImplementation(async () => viteConfig);
 

--- a/packages/pages/src/common/src/assets/getPublicFilepath.ts
+++ b/packages/pages/src/common/src/assets/getPublicFilepath.ts
@@ -14,7 +14,7 @@ export const determinePublicFilepath = async (
     return defaultPublicDir;
   }
 
-  const viteConfig = await import_(await versionedFileUrl(viteConfigPath));
+  const viteConfig = await import_(versionedFileUrl(viteConfigPath));
   const userConfig = viteConfig.default as UserConfig;
 
   return userConfig.publicDir || defaultPublicDir;

--- a/packages/pages/src/common/src/assets/import.test.ts
+++ b/packages/pages/src/common/src/assets/import.test.ts
@@ -11,11 +11,11 @@ describe("versionedFileUrl", () => {
 
     try {
       fs.writeFileSync(modulePath, 'export default { value: "first" };\n');
-      const firstUrl = await versionedFileUrl(modulePath);
+      const firstUrl = versionedFileUrl(modulePath);
       expect((await import_(firstUrl)).default.value).toBe("first");
 
       fs.writeFileSync(modulePath, 'export default { value: "second" };\n');
-      const secondUrl = await versionedFileUrl(modulePath);
+      const secondUrl = versionedFileUrl(modulePath);
       expect(secondUrl).not.toBe(firstUrl);
       expect((await import_(secondUrl)).default.value).toBe("second");
     } finally {

--- a/packages/pages/src/common/src/assets/import.ts
+++ b/packages/pages/src/common/src/assets/import.ts
@@ -4,9 +4,9 @@ import { getFileContentHash } from "../../../util/fileContentHash.js";
 /**
  * Returns a file URL versioned with a stable hash of its contents.
  */
-export const versionedFileUrl = async (filepath: string): Promise<string> => {
+export const versionedFileUrl = (filepath: string): string => {
   const moduleUrl = pathToFileURL(filepath);
-  moduleUrl.searchParams.set("contentHash", await getFileContentHash(filepath));
+  moduleUrl.searchParams.set("contentHash", getFileContentHash(filepath));
   return moduleUrl.href;
 };
 

--- a/packages/pages/src/dev/server/ssr/moduleImports.ts
+++ b/packages/pages/src/dev/server/ssr/moduleImports.ts
@@ -10,7 +10,7 @@ import { getFileContentHash } from "../../../util/fileContentHash.js";
  * @returns the loaded module
  */
 export async function importFresh<T>(devserver: ViteDevServer, modulePath: string): Promise<T> {
-  const contentHash = await getFileContentHash(modulePath);
+  const contentHash = getFileContentHash(modulePath);
   const cacheBustingModulePath = `${modulePath}?update=${contentHash}`;
   return (await devserver.ssrLoadModule(cacheBustingModulePath)) as T;
 }

--- a/packages/pages/src/util/fileContentHash.test.ts
+++ b/packages/pages/src/util/fileContentHash.test.ts
@@ -16,14 +16,14 @@ describe("getFileContentHash", () => {
       contents: Buffer.from([0x66, 0x80, 0x6f]),
       expectedHash: "edb3d848684a3437ea1944dd1361b87aa07f7dbefbf5498b83d85875f50f0444",
     },
-  ])("hashes the raw bytes for $name contents", async ({ contents, expectedHash }) => {
+  ])("hashes the raw bytes for $name contents", ({ contents, expectedHash }) => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pages-file-content-hash-"));
     const filepath = path.join(tempDir, "contents");
 
     try {
       fs.writeFileSync(filepath, contents);
 
-      await expect(getFileContentHash(filepath)).resolves.toBe(expectedHash);
+      expect(getFileContentHash(filepath)).toBe(expectedHash);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/packages/pages/src/util/fileContentHash.ts
+++ b/packages/pages/src/util/fileContentHash.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 /**
  * Returns a stable hash of a file's contents for use in module cache keys.
  */
-export const getFileContentHash = async (filepath: string): Promise<string> => {
+export const getFileContentHash = (filepath: string): string => {
   const contents = fs.readFileSync(filepath);
   return createHash("sha256").update(contents).digest("hex");
 };


### PR DESCRIPTION
Brian pointed out that this function no longer needed to be async after updating to use `createHash`. Change to be sync

TEST=auto

Ran unit tests