### PR TITLE
chore: pin npm version to 11.18.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Update npm
         # npm version npm 11.5.1 or later needed for Trusted Publishing
-        run: npm install -g npm@11.18.0
+        run: npm install -g npm@11
 
       - name: Verify package version and get npm tag
         id: get_npm_tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Update npm
         # npm version npm 11.5.1 or later needed for Trusted Publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Verify package version and get npm tag
         id: get_npm_tag


### PR DESCRIPTION
The latest version of npm is now 12, which is incompatible with node 20. Pin to npm 11