### PR TITLE
fix: allow empty reverse proxy prefix to be passed

### DIFF
--- a/packages/pages/src/util/applyReverseProxy.test.ts
+++ b/packages/pages/src/util/applyReverseProxy.test.ts
@@ -20,8 +20,21 @@ const writeEsmPackageJson = (directory: string) => {
 };
 
 describe("parseReverseProxyPrefix", () => {
-  it("returns undefined when no prefix is provided", () => {
-    expect(parseReverseProxyPrefix(undefined)).toBeUndefined();
+  it.each([
+    {
+      name: "undefined",
+      reverseProxyPrefix: undefined,
+    },
+    {
+      name: "empty",
+      reverseProxyPrefix: "",
+    },
+    {
+      name: "whitespace-only",
+      reverseProxyPrefix: "   ",
+    },
+  ])("returns undefined when the prefix is $name", ({ reverseProxyPrefix }) => {
+    expect(parseReverseProxyPrefix(reverseProxyPrefix)).toBeUndefined();
   });
 
   it("trims the prefix and normalizes the subpath", () => {
@@ -52,11 +65,6 @@ describe("parseReverseProxyPrefix", () => {
     {
       name: "no host",
       reverseProxyPrefix: "/locations",
-      expectedError: /Expected a host and subpath/,
-    },
-    {
-      name: "an empty value",
-      reverseProxyPrefix: "",
       expectedError: /Expected a host and subpath/,
     },
     {

--- a/packages/pages/src/util/applyReverseProxy.ts
+++ b/packages/pages/src/util/applyReverseProxy.ts
@@ -34,6 +34,10 @@ export const parseReverseProxyPrefix = (
   }
 
   const trimmedReverseProxyPrefix = reverseProxyPrefix.trim();
+  if (!trimmedReverseProxyPrefix) {
+    return undefined;
+  }
+
   if (trimmedReverseProxyPrefix.includes("://")) {
     throw new Error(
       `Invalid reverseProxyPrefix "${reverseProxyPrefix}". Do not include a protocol. Expected a host and subpath like "www.brand.com/locations".`


### PR DESCRIPTION
Update the `parseReverseProxyPrefix` function to allow for an empty string to be passed, in which case it will no-op. Already made a fix on the starter to not pass an empty string if the RPP env var is not set, but do this as well for safety.

TEST=auto

Ran unit tests