### PR TITLE
chore: update postcss to ^8.5.18

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -33,12 +33,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following npm package may be included in this product:
 
- - source-map-js@1.0.2
  - source-map-js@1.2.1
 
-These packages each contain the following license:
+This package contains the following license:
 
 Copyright (c) 2009-2011, Mozilla Foundation and contributors
 All rights reserved.
@@ -10977,16 +10976,15 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following npm package may be included in this product:
 
- - postcss@8.4.35
- - postcss@8.4.49
+ - postcss@8.5.25
 
-These packages each contain the following license:
+This package contains the following license:
 
 The MIT License (MIT)
 
-Copyright 2013 Andrey Sitnik <andrey@sitnik.ru>
+Copyright 2013 Andrey Sitnik <andrey@sitnik.es>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -11068,7 +11066,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - nanoid@3.3.7
+ - nanoid@3.3.17
 
 This package contains the following license:
 

--- a/packages/pages/THIRD-PARTY-NOTICES
+++ b/packages/pages/THIRD-PARTY-NOTICES
@@ -1149,13 +1149,13 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - postcss@8.4.35
+ - postcss@8.5.25
 
 This package contains the following license:
 
 The MIT License (MIT)
 
-Copyright 2013 Andrey Sitnik <andrey@sitnik.ru>
+Copyright 2013 Andrey Sitnik <andrey@sitnik.es>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -72,7 +72,7 @@
     "open": "^10.1.0",
     "ora": "^8.0.1",
     "picocolors": "^1.0.0",
-    "postcss": "^8.4.35",
+    "postcss": "^8.5.18",
     "postcss-nested": "^6.0.1",
     "pretty-ms": "^9.0.0",
     "prompts": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,11 +127,11 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       postcss:
-        specifier: ^8.4.35
-        version: 8.4.35
+        specifier: ^8.5.18
+        version: 8.5.25
       postcss-nested:
         specifier: ^6.0.1
-        version: 6.0.1(postcss@8.4.35)
+        version: 6.0.1(postcss@8.5.25)
       pretty-ms:
         specifier: ^9.0.0
         version: 9.0.0
@@ -158,7 +158,7 @@ importers:
         version: 0.17.0(rollup@4.59.0)(vite@5.4.11(@types/node@20.19.43))
       vitepress:
         specifier: 1.5.0
-        version: 1.5.0(@algolia/client-search@5.15.0)(@types/node@20.19.43)(@types/react@18.3.28)(postcss@8.4.35)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 1.5.0(@algolia/client-search@5.15.0)(@types/node@20.19.43)(@types/react@18.3.28)(postcss@8.5.25)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)
       yaml:
         specifier: ^2.4.1
         version: 2.4.1
@@ -2899,6 +2899,11 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3245,8 +3250,8 @@ packages:
     resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.4.49:
-    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.25.0:
@@ -5388,7 +5393,7 @@ snapshots:
       '@vue/shared': 3.5.13
       estree-walker: 2.0.2
       magic-string: 0.30.13
-      postcss: 8.4.49
+      postcss: 8.5.25
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.13':
@@ -7076,6 +7081,8 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.17: {}
+
   nanoid@3.3.7: {}
 
   negotiator@0.6.3: {}
@@ -7458,28 +7465,28 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.4.35):
+  postcss-import@15.1.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.5.25
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
 
-  postcss-js@4.0.1(postcss@8.4.35):
+  postcss-js@4.0.1(postcss@8.5.25):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.35
+      postcss: 8.5.25
 
-  postcss-load-config@4.0.2(postcss@8.4.35):
+  postcss-load-config@4.0.2(postcss@8.5.25):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.1
     optionalDependencies:
-      postcss: 8.4.35
+      postcss: 8.5.25
 
-  postcss-nested@6.0.1(postcss@8.4.35):
+  postcss-nested@6.0.1(postcss@8.5.25):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.5.25
       postcss-selector-parser: 6.0.15
 
   postcss-selector-parser@6.0.15:
@@ -7500,9 +7507,9 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  postcss@8.4.49:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.7
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8084,11 +8091,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.35
-      postcss-import: 15.1.0(postcss@8.4.35)
-      postcss-js: 4.0.1(postcss@8.4.35)
-      postcss-load-config: 4.0.2(postcss@8.4.35)
-      postcss-nested: 6.0.1(postcss@8.4.35)
+      postcss: 8.5.25
+      postcss-import: 15.1.0(postcss@8.5.25)
+      postcss-js: 4.0.1(postcss@8.5.25)
+      postcss-load-config: 4.0.2(postcss@8.5.25)
+      postcss-nested: 6.0.1(postcss@8.5.25)
       postcss-selector-parser: 6.0.15
       resolve: 1.22.8
       sucrase: 3.35.0
@@ -8264,7 +8271,7 @@ snapshots:
     dependencies:
       browserslist: 4.23.0
       escalade: 3.1.2
-      picocolors: 1.0.0
+      picocolors: 1.1.1
 
   url-parse@1.5.10:
     dependencies:
@@ -8338,7 +8345,7 @@ snapshots:
   vite@5.1.4(@types/node@25.9.3):
     dependencies:
       esbuild: 0.28.1
-      postcss: 8.4.35
+      postcss: 8.5.25
       rollup: 4.59.0
     optionalDependencies:
       '@types/node': 25.9.3
@@ -8347,13 +8354,13 @@ snapshots:
   vite@5.4.11(@types/node@20.19.43):
     dependencies:
       esbuild: 0.28.1
-      postcss: 8.4.49
+      postcss: 8.5.25
       rollup: 4.59.0
     optionalDependencies:
       '@types/node': 20.19.43
       fsevents: 2.3.3
 
-  vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@20.19.43)(@types/react@18.3.28)(postcss@8.4.35)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@1.5.0(@algolia/client-search@5.15.0)(@types/node@20.19.43)(@types/react@18.3.28)(postcss@8.5.25)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3):
     dependencies:
       '@docsearch/css': 3.8.0
       '@docsearch/js': 3.8.0(@algolia/client-search@5.15.0)(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)
@@ -8374,7 +8381,7 @@ snapshots:
       vite: 5.4.11(@types/node@20.19.43)
       vue: 3.5.13(typescript@5.9.3)
     optionalDependencies:
-      postcss: 8.4.35
+      postcss: 8.5.25
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'


### PR DESCRIPTION
https://github.com/advisories/GHSA-r28c-9q8g-f849

Vulnerable Package:
postcss 8.4.35

Safe Dependencies:
postcss 8.5.18